### PR TITLE
Harden stock workflow: reject orphan order lines server-side

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -165,6 +165,9 @@ Features and improvements tracked against original build phases.
 - [ ] **Card text + notes lost after submit** — Greeting Card Text and important notes disappear after order submission (order 202603-038)
 - [ ] **Postcard text not visible after accepting** — even when text entered while accepting order, not visible once submitted
 - [ ] **Finished order stale after submit** — order stays on screen after submission, doesn't refresh
+- [x] **Florist "Add new flower" fails** — Airtable rejected `Lot Size` because the column on Stock had a trailing space (`appM8rLfcE9cbxduZ`). Renamed in Airtable, no code change. (2026-04-07)
+- [x] **Dashboard silently created orphan order lines** — `apps/dashboard/.../Step2Bouquet.jsx` had a `catch {}` that pushed lines with `stockItemId: null` whenever stock create failed. Now shows the real error toast and `orderService.createOrder` / `editBouquetLines` reject orphan lines server-side. (2026-04-07)
+- [x] **PO evaluate silently dropped lines without Stock Item** — `routes/stockOrders.js` `/evaluate` skipped the receive-into-stock block when a line had no Stock link, marking it `Processed` while the flowers vanished. Now throws per-line so the PO flips to `Eval Error` and the owner can fix the link. (2026-04-07)
 - [ ] **Purchase orders can't be saved** — PO save fails, blocks entire PO workflow
 - [ ] **New order doesn't create negative stock** — submitting order does not generate negative stock entries
 - [ ] **New flowers for future order not in negative stock** — flowers added to future order don't appear in negative stock view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,26 @@ Changes made to the **dev base** that must be replicated in **production** befor
 
 ---
 
+## 2026-04-07 — Stock Workflow Hardening (orphan order/PO lines)
+
+### Airtable (production base `appM8rLfcE9cbxduZ`)
+- **Stock.Lot Size** — renamed to remove a trailing space. Symptom: `POST /api/stock` returned `UNKNOWN_FIELD_NAME: "Lot Size"`, breaking the florist "Add new flower" flow on iPad. Verified Airtable column was literally `Lot Size ` (one trailing space). No code change needed; just rename the column.
+- **Stock.Farmer** — verified, no trailing space, no rename needed.
+
+### Backend
+- `services/orderService.js` — `createOrder` and `editBouquetLines` now hard-reject any new order line that ends up with `stockItemId === null` after `autoMatchStock` runs. Throws a 400 with the offending flower names. Rationale: orphan lines silently broke stock deduction, demand calc and PO generation.
+- `routes/orders.js` — `POST /api/orders` now surfaces `statusCode === 400` errors verbatim instead of wrapping them as 500, so the dashboard/florist toast shows the real reason ("Create the flower in Stock first.").
+- `routes/stockOrders.js` — `POST /:id/evaluate` now throws per-line if a PO line has any received/written-off quantity but no linked Stock Item. The existing partial-failure machinery flips the PO to `Eval Error` so the owner can fix the link and retry. Previously these lines were silently marked `Processed` and the flowers vanished from inventory.
+
+### Dashboard (`apps/dashboard`)
+- `components/steps/Step2Bouquet.jsx` — removed the silent `catch {}` fallback that pushed an inline order line with `stockItemId: null` whenever `POST /api/stock` failed. Now mirrors the florist app: shows the real error in a toast via `useToast`. This was the main producer of orphan order lines.
+
+### Watch for
+- Any historical Order Lines created via the dashboard "Add new" path between ~2026-03-16 and 2026-04-07 may already be orphans (no `Stock Item` link). They will not block new orders, but they are invisible to demand/stock calc. To find them in Airtable: filter Order Lines where `Stock Item` is empty.
+- The new validation will reject orders that previously slipped through. If a florist hits "Order line(s) without a Stock Item are not allowed", the fix is to first add the flower in Stock (the same form they were already using), not to bypass the check.
+
+---
+
 ## 2026-03-21 — Phase 4: Testing Foundation
 
 ### Backend

--- a/apps/dashboard/src/components/steps/Step2Bouquet.jsx
+++ b/apps/dashboard/src/components/steps/Step2Bouquet.jsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from 'react';
 import client from '../../api/client.js';
 import t from '../../translations.js';
+import { useToast } from '../../context/ToastContext.jsx';
 import useConfigLists from '../../hooks/useConfigLists.js';
 import { renderStockName } from '@flower-studio/shared';
 
@@ -17,6 +18,7 @@ export default function Step2Bouquet({
     return requiredBy > today;
   })();
   const { targetMarkup } = useConfigLists();
+  const { showToast } = useToast();
   const [flowerQuery, setFlowerQuery] = useState('');
   const [showCost, setShowCost]       = useState(false);
   const [showCustomFlower, setShowCustomFlower] = useState(false);
@@ -250,15 +252,12 @@ export default function Step2Bouquet({
                   setShowCustomFlower(false);
                   setFlowerQuery('');
                   onStockRefresh();
-                } catch {
-                  onLinesChange(lines => [...lines, {
-                    stockItemId: null, flowerName: customFlower.name.trim(), quantity: 1,
-                    costPricePerUnit: Number(customFlower.costPrice) || 0,
-                    sellPricePerUnit: Number(customFlower.sellPrice) || 0,
-                    stockDeferred: isFutureOrder,
-                  }]);
-                  setShowCustomFlower(false);
-                  setFlowerQuery('');
+                } catch (err) {
+                  // Show error — do NOT fall back to a stockItemId-less line.
+                  // Every flower in an order must have a stock record so demand,
+                  // PO generation, and stock deduction stay consistent.
+                  const msg = err.response?.data?.error || t.error;
+                  showToast(msg, 'error');
                 }
               }}
               className="flex-1 py-2.5 rounded-xl bg-brand-600 text-white text-sm font-semibold active-scale"

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -266,6 +266,10 @@ router.post('/', async (req, res, next) => {
 
       res.status(201).json(result);
     } catch (creationErr) {
+      // Validation errors (e.g. orphan lines) — surface message verbatim
+      if (creationErr.statusCode === 400) {
+        return res.status(400).json({ error: creationErr.message });
+      }
       return res.status(500).json({
         error: 'Order creation failed. Partial records have been cleaned up.',
         detail: creationErr.message,

--- a/backend/src/routes/stockOrders.js
+++ b/backend/src/routes/stockOrders.js
@@ -396,6 +396,20 @@ router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), as
 
         const accepted = Number(evalLine.quantityAccepted) || 0;
         const writeOff = Number(evalLine.writeOffQty) || 0;
+        const altAcceptedPre = Number(evalLine.altQuantityAccepted) || 0;
+        const altWriteOffPre = Number(evalLine.altWriteOffQty) || 0;
+
+        // Hard fail: a PO line with received qty but no Stock Item link cannot
+        // be received into inventory. Previously this was silently skipped,
+        // marking the line PROCESSED while the flowers vanished from tracking.
+        // The per-line catch below will record this and flip the PO to EVAL_ERROR
+        // so the owner can fix the line (link a Stock Item, then retry evaluate).
+        if (!stockItemId && (accepted > 0 || altAcceptedPre > 0 || writeOff > 0 || altWriteOffPre > 0)) {
+          throw new Error(
+            `Line "${line['Flower Name'] || evalLine.lineId}" has no linked Stock Item — ` +
+            `link it on the PO and retry. Stock cannot be received without a Stock Item.`
+          );
+        }
 
         // Primary supplier: receive into stock with batch logic
         if (stockItemId && accepted > 0) {

--- a/backend/src/services/orderService.js
+++ b/backend/src/services/orderService.js
@@ -92,6 +92,21 @@ export async function createOrder(params, config) {
     // 2a. Auto-match unlinked lines to stock
     await autoMatchStock(orderLines);
 
+    // 2a-bis. Reject the whole order if any line is still orphaned.
+    // Orphan lines (stockItemId=null) silently break stock deduction, demand
+    // signals, and PO generation. Better to fail loudly here so the caller
+    // creates the missing Stock record first (POST /api/stock).
+    const orphans = orderLines.filter(l => !l.stockItemId);
+    if (orphans.length > 0) {
+      const names = orphans.map(o => o.flowerName || '(unnamed)').join(', ');
+      const err = new Error(
+        `Order line(s) without a Stock Item are not allowed: ${names}. ` +
+        `Create the flower in Stock first.`
+      );
+      err.statusCode = 400;
+      throw err;
+    }
+
     // 2b. Create order line records (price snapshotting)
     const createdLines = [];
     for (const line of orderLines) {
@@ -323,6 +338,19 @@ export async function editBouquetLines(orderId, { lines = [], removedLines = [] 
   const newUnmatched = lines.filter(l => !l.id && !l.stockItemId && l.flowerName);
   if (newUnmatched.length > 0) {
     await autoMatchStock(newUnmatched);
+  }
+
+  // 2a-bis. Reject orphan new lines (see createOrder for rationale).
+  // Existing lines (line.id) are exempt — they were created before this guard.
+  const orphans = lines.filter(l => !l.id && !l.stockItemId);
+  if (orphans.length > 0) {
+    const names = orphans.map(o => o.flowerName || '(unnamed)').join(', ');
+    const err = new Error(
+      `Order line(s) without a Stock Item are not allowed: ${names}. ` +
+      `Create the flower in Stock first.`
+    );
+    err.statusCode = 400;
+    throw err;
   }
 
   // 2b. Process new/updated lines


### PR DESCRIPTION
## Summary
This PR adds server-side validation to prevent order lines from being created without a linked Stock Item. Orphan lines (where `stockItemId === null`) silently broke stock deduction, demand signals, and PO generation. The fix includes hard rejections in order creation/editing, improved error surfacing, and removal of a silent fallback in the dashboard that was creating orphans.

## Key Changes

**Backend (`services/orderService.js`)**
- `createOrder()` now rejects the entire order if any line remains orphaned after `autoMatchStock()` runs, throwing a 400 error with the offending flower names
- `editBouquetLines()` applies the same validation to new lines (existing lines are exempt since they were created before this guard)

**Backend (`routes/orders.js`)**
- `POST /api/orders` now surfaces 400 validation errors verbatim instead of wrapping them as 500, so the caller sees the real reason ("Create the flower in Stock first.")

**Backend (`routes/stockOrders.js`)**
- `POST /:id/evaluate` now throws a per-line error if a PO line has received/written-off quantity but no linked Stock Item
- The existing partial-failure machinery flips the PO to `Eval Error` so the owner can fix the link and retry
- Previously these lines were silently marked `Processed` and flowers vanished from inventory

**Dashboard (`apps/dashboard/src/components/steps/Step2Bouquet.jsx`)**
- Removed the silent `catch {}` fallback that pushed inline order lines with `stockItemId: null` when `POST /api/stock` failed
- Now shows the real error in a toast via `useToast()`, mirroring the florist app behavior
- This was the primary source of orphan order lines in production

## Notable Details
- The validation in `createOrder` and `editBouquetLines` includes user-friendly error messages listing the flower names that lack Stock Items
- PO evaluation errors are per-line, allowing partial success while flagging problematic lines for manual correction
- Historical orphan lines (created between ~2026-03-16 and 2026-04-07) remain in the database but won't block new orders; they are invisible to demand/stock calculations

https://claude.ai/code/session_01HUnZKDMmzdwR5w3AUTtw5C