### PR TITLE
Stock improvements: PO visibility, tracing, lot sizes, parity fixes

### DIFF
--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -210,7 +210,9 @@ router.get('/pending-po', async (req, res, next) => {
       }
     }
 
-    // Resolve unlinked lines by matching Flower Name → Stock Item Display Name
+    // Resolve unlinked lines by matching Flower Name → Stock Item Display Name.
+    // If no match found, auto-create a stock item with qty=0 so the flower
+    // appears in the bouquet picker. Also link the PO line for future consistency.
     if (unlinked.length > 0) {
       const uniqueNames = [...new Set(unlinked.map(u => u.name))];
       const nameToId = {};
@@ -222,12 +224,30 @@ router.get('/pending-po', async (req, res, next) => {
             fields: ['Display Name'],
             maxRecords: 1,
           });
-          if (matches.length > 0) nameToId[name] = matches[0].id;
+          if (matches.length > 0) {
+            nameToId[name] = matches[0].id;
+          } else {
+            // Auto-create stock item so the flower shows up in pickers
+            const created = await db.create(TABLES.STOCK, {
+              'Display Name': name,
+              'Purchase Name': name,
+              'Current Quantity': 0,
+              Category: 'Other',
+              Active: true,
+            });
+            nameToId[name] = created.id;
+            console.log(`[STOCK] Auto-created "${name}" (${created.id}) from pending PO line`);
+          }
         } catch { /* skip */ }
       }
+      // Link resolved/created stock items back to PO lines (fire-and-forget)
       for (const u of unlinked) {
         if (nameToId[u.name]) {
           allLines[u.idx]._resolvedStockId = nameToId[u.name];
+          const lineId = allLines[u.idx].id;
+          if (lineId) {
+            db.update(TABLES.STOCK_ORDER_LINES, lineId, { 'Stock Item': [nameToId[u.name]] }).catch(() => {});
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Batch of stock management improvements, PO workflow fixes, and florist ↔ dashboard parity alignment.

### Pending PO visibility in bouquet pickers
- New `GET /api/stock/pending-po` endpoint shows flowers from Draft/Sent/Shopping POs
- Bouquet pickers show "+25 → 15.Apr." (quantity + planned arrival date) in blue
- Items with pending POs stay visible even at qty=0 with "In stock" filter on
- PO lines without Stock Item links are auto-resolved or auto-created

### PO quantity = lots (not stems)
- Quantity field now represents number of lots (e.g. 3 × 25 = 75 stems)
- Display shows: `= 3 × 25 = 75`
- PO summary shows total stems + cost/sell totals
- Stored in Airtable as actual stem count for downstream compatibility

### PO evaluation auto-resolve
- Lines without Stock Item links are auto-resolved by Flower Name match
- If no match found, stock item is auto-created (fixes the "no linked Stock Item" error)
- New flowers added to POs also auto-create stock items immediately

### Stock tracing ("Trace" button)
- Each stock item has a "Trace" button showing chronological audit trail
- Shows orders (purple), write-offs (red), purchases (green) with quantities
- Available in both dashboard and florist apps

### Dashboard fixes
- **Tab persistence**: active tab saved to localStorage, survives reload
- **Cancel + return stock**: delivered/picked-up orders can be cancelled with stock return
- **Date column**: passes Display Name to renderDateTag for batch date extraction
- **Delete Draft PO**: red "Delete PO" button on draft purchase orders

### Florist ↔ Dashboard parity
- Editable lot size field in DraftLineEditor (both apps)
- Delete Draft PO button (both apps)
- Hide-zero toggle for stock panel (both apps)
- Trace/usage button on stock items (both apps)

### Date tag fixes
- English month format (Jan, Feb, Mar...) instead of Russian locale
- Stale dates hidden on zero-stock items in bouquet picker
- Batch names in Display Name always show regardless of qty

## Test plan
- [ ] Create a Draft PO with a new flower → verify it appears in bouquet picker with "+X → date"
- [ ] Set lot size to 25, qty to 2 → verify display shows "= 2 × 25 = 50" and stock shows "+50"
- [ ] Delete a Draft PO → verify it's removed
- [ ] Cancel a delivered order with "Cancel + return stock" → verify stock quantities restored
- [ ] Click "Trace" on a stock item → verify audit trail shows orders/write-offs/purchases
- [ ] Reload dashboard → verify it stays on the same tab
- [ ] Retry PO evaluation for lines without Stock Item → verify auto-resolve works

https://claude.ai/code/session_01KuVvmPgcZyUrxhGa9mejWX