### PR TITLE
Fix 14 bugs found in codebase audit: cascades, stale state, hardcoded values

### DIFF
--- a/apps/florist/src/components/OrderCard.jsx
+++ b/apps/florist/src/components/OrderCard.jsx
@@ -204,7 +204,7 @@ export default function OrderCard({ order, onOrderUpdated, isOwner }) {
   // Effective price: Price Override || (sell total + delivery fee)
   const detailLineTotal = (detail?.orderLines || []).reduce((sum, l) =>
     sum + (l['Sell Price Per Unit'] || 0) * (l.Quantity || 0), 0);
-  const detailDeliveryFee = Number(d['Delivery Fee'] || detail?.delivery?.['Delivery Fee'] || 0);
+  const detailDeliveryFee = Number(detail?.delivery?.['Delivery Fee'] || d['Delivery Fee'] || 0);
   const currentPrice = d['Price Override'] || (detailLineTotal > 0 ? detailLineTotal + detailDeliveryFee : (d['Sell Total'] || price) ) || 0;
 
   function statusLabel(s) {
@@ -219,7 +219,7 @@ export default function OrderCard({ order, onOrderUpdated, isOwner }) {
       }`}
     >
       {/* Unpaid warning — prominent banner for pickup orders */}
-      {!currentPaid && !isDelivery && currentStatus !== 'Cancelled' && (
+      {!currentPaid && currentStatus !== 'Cancelled' && (
         <div className="bg-red-50 border border-red-200 rounded-xl px-3 py-2 mb-3 flex items-center gap-2">
           <span className="text-red-500 text-sm">⚠</span>
           <span className="text-xs font-semibold text-red-700">{t.collectPayment || 'Collect payment before handing over'}</span>
@@ -339,7 +339,9 @@ export default function OrderCard({ order, onOrderUpdated, isOwner }) {
                         setEditingBouquet(true);
                         // Lazy-load stock for the flower picker
                         if (stockItems.length === 0) {
-                          client.get('/stock').then(r => setStockItems(r.data)).catch(() => {});
+                          client.get('/stock').then(r => setStockItems(r.data)).catch(() => {
+                            showToast(t.loadError || 'Failed to load stock', 'error');
+                          });
                         }
                       }} className="text-xs text-brand-600 font-medium">{t.edit || 'Edit'}</button>
                     )}
@@ -617,7 +619,23 @@ export default function OrderCard({ order, onOrderUpdated, isOwner }) {
                         className="w-full text-sm text-ios-label bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg px-2.5 py-1.5 outline-none disabled:opacity-40"
                       />
                     </div>
-                    <Row label={t.labelFee} value={detail.delivery['Delivery Fee'] ? `${detail.delivery['Delivery Fee']} zł` : null} />
+                    <div className="py-1">
+                      <span className="text-xs text-ios-tertiary block mb-1">{t.labelFee}</span>
+                      <div className="flex items-center gap-1">
+                        <input
+                          type="number"
+                          defaultValue={detail.delivery['Delivery Fee'] || ''}
+                          onBlur={e => {
+                            const val = e.target.value === '' ? 0 : Number(e.target.value);
+                            if (val !== Number(detail.delivery['Delivery Fee'] || 0)) patchDelivery({ 'Delivery Fee': val });
+                          }}
+                          placeholder="0"
+                          disabled={saving}
+                          className="w-20 text-sm text-ios-label bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg px-2.5 py-1.5 outline-none disabled:opacity-40"
+                        />
+                        <span className="text-xs text-ios-tertiary">zł</span>
+                      </div>
+                    </div>
                   </div>
                 </div>
               )}
@@ -668,7 +686,7 @@ export default function OrderCard({ order, onOrderUpdated, isOwner }) {
                   || (detail.orderLines || []).reduce(
                     (sum, l) => sum + Number(l['Sell Price Per Unit'] || 0) * Number(l['Quantity'] || 0), 0
                   );
-                const effectivePrice = sellTotal + Number(detail['Delivery Fee'] || 0);
+                const effectivePrice = sellTotal + Number(detail?.delivery?.['Delivery Fee'] || detail['Delivery Fee'] || 0);
                 if (!costTotal && !effectivePrice) return null;
                 const marginAmt = effectivePrice - costTotal;
                 const marginPct = effectivePrice > 0 ? Math.round((marginAmt / effectivePrice) * 100) : 0;

--- a/apps/florist/src/pages/StockPanelPage.jsx
+++ b/apps/florist/src/pages/StockPanelPage.jsx
@@ -59,7 +59,7 @@ export default function StockPanelPage() {
       ]);
       setStock(stockRes.data);
       setCommittedMap(committedRes.data);
-    } catch { showToast(t.adjustError, 'error'); }
+    } catch (err) { showToast(err.response?.data?.error || t.adjustError, 'error'); }
     finally   { setLoading(false); }
   }
 
@@ -69,7 +69,7 @@ export default function StockPanelPage() {
     try {
       const res = await client.post(`/stock/${id}/adjust`, { delta });
       setStock(prev => prev.map(s => s.id === id ? { ...s, ...res.data } : s));
-    } catch { showToast(t.adjustError, 'error'); }
+    } catch (err) { showToast(err.response?.data?.error || t.adjustError, 'error'); }
   }
 
   async function handleWriteOff(id, quantity, reason) {
@@ -77,7 +77,7 @@ export default function StockPanelPage() {
       const res = await client.post(`/stock/${id}/write-off`, { quantity, reason: reason || undefined });
       setStock(prev => prev.map(s => s.id === id ? { ...s, ...res.data } : s));
       showToast(`${quantity} stems written off`, 'success');
-    } catch { showToast(t.writeOffError, 'error'); }
+    } catch (err) { showToast(err.response?.data?.error || t.writeOffError, 'error'); }
   }
 
   async function handleReceive(data) {
@@ -86,14 +86,14 @@ export default function StockPanelPage() {
       showToast(t.success, 'success');
       setShowReceive(false);
       fetchStock();
-    } catch { showToast(t.receiveError, 'error'); }
+    } catch (err) { showToast(err.response?.data?.error || t.receiveError, 'error'); }
   }
 
   async function handlePatch(id, fields) {
     try {
       const res = await client.patch(`/stock/${id}`, fields);
       setStock(prev => prev.map(s => s.id === id ? { ...s, ...res.data } : s));
-    } catch { showToast(t.adjustError, 'error'); }
+    } catch (err) { showToast(err.response?.data?.error || t.adjustError, 'error'); }
   }
 
   function toggleSort(key) {

--- a/backend/src/constants/statuses.js
+++ b/backend/src/constants/statuses.js
@@ -28,6 +28,7 @@ export const DELIVERY_STATUS = {
   PENDING:          'Pending',
   OUT_FOR_DELIVERY: 'Out for Delivery',
   DELIVERED:        'Delivered',
+  CANCELLED:        'Cancelled',
 };
 
 // ── Payment statuses ──

--- a/backend/src/routes/deliveries.js
+++ b/backend/src/routes/deliveries.js
@@ -121,7 +121,8 @@ router.patch('/:id', async (req, res, next) => {
     // the Delivery — a permanent desync. Doing the delivery first means a
     // failure leaves both records untouched.
     let linkedOrderId = null;
-    if (fields.Status === DELIVERY_STATUS.OUT_FOR_DELIVERY || fields.Status === DELIVERY_STATUS.DELIVERED) {
+    const cascadeStatuses = [DELIVERY_STATUS.OUT_FOR_DELIVERY, DELIVERY_STATUS.DELIVERED, DELIVERY_STATUS.CANCELLED];
+    if (cascadeStatuses.includes(fields.Status)) {
       if (fields.Status === DELIVERY_STATUS.DELIVERED) {
         fields['Delivered At'] = new Date().toISOString();
       }
@@ -134,7 +135,11 @@ router.patch('/:id', async (req, res, next) => {
     const updated = await db.update(TABLES.DELIVERIES, req.params.id, fields);
 
     if (linkedOrderId) {
-      await db.update(TABLES.ORDERS, linkedOrderId, { Status: fields.Status });
+      // Map delivery status to order status for the cascade
+      const orderStatus = fields.Status === DELIVERY_STATUS.CANCELLED
+        ? 'Cancelled'  // ORDER_STATUS.CANCELLED — orders use same string
+        : fields.Status;
+      await db.update(TABLES.ORDERS, linkedOrderId, { Status: orderStatus });
     }
     res.json(updated);
   } catch (err) {

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -343,7 +343,7 @@ router.patch('/:id', async (req, res, next) => {
     }
 
     // Broadcast all other status changes so delivery app stays in sync
-    if (newStatus && newStatus !== 'Ready') {
+    if (newStatus && newStatus !== ORDER_STATUS.READY) {
       broadcast({
         type: 'order_status_changed',
         orderId: order.id,
@@ -352,11 +352,11 @@ router.patch('/:id', async (req, res, next) => {
     }
 
     // Cascade Order → Delivery status (mirrors the Delivery → Order cascade in deliveries.js)
-    if (newStatus === 'Out for Delivery' || newStatus === 'Delivered' || newStatus === 'Cancelled') {
+    if (newStatus === ORDER_STATUS.OUT_FOR_DELIVERY || newStatus === ORDER_STATUS.DELIVERED || newStatus === ORDER_STATUS.CANCELLED) {
       const deliveryIds = order['Deliveries'] || [];
       if (deliveryIds.length > 0) {
-        const deliveryFields = { Status: newStatus === 'Cancelled' ? 'Cancelled' : newStatus };
-        if (newStatus === 'Delivered') deliveryFields['Delivered At'] = new Date().toISOString();
+        const deliveryFields = { Status: newStatus === ORDER_STATUS.CANCELLED ? DELIVERY_STATUS.CANCELLED : newStatus };
+        if (newStatus === ORDER_STATUS.DELIVERED) deliveryFields['Delivered At'] = new Date().toISOString();
         await db.update(TABLES.DELIVERIES, deliveryIds[0], deliveryFields);
       }
     }

--- a/backend/src/routes/stockOrders.js
+++ b/backend/src/routes/stockOrders.js
@@ -12,7 +12,7 @@ import { TABLES } from '../config/airtable.js';
 import { broadcast } from '../services/notifications.js';
 import { sanitizeFormulaValue } from '../utils/sanitize.js';
 import { PO_STATUS, VALID_PO_STATUSES, PO_LINE_STATUS, LOSS_REASON } from '../constants/statuses.js';
-import { getConfig } from './settings.js';
+import { getConfig, getDriverOfDay } from './settings.js';
 
 const VALID_STATUSES = VALID_PO_STATUSES;
 
@@ -342,6 +342,9 @@ router.post('/:id/lines', authorize('stock-orders', ['owner']), async (req, res,
       return res.status(400).json({ error: `Cannot add lines to a "${po.Status}" PO.` });
     }
     const { stockItemId: rawStockItemId, flowerName, quantity, supplier, costPrice, sellPrice, lotSize } = req.body;
+    if (!rawStockItemId && !flowerName?.trim()) {
+      return res.status(400).json({ error: 'PO line must have a stock item or flower name.' });
+    }
     // Auto-link or auto-create stock item
     let resolvedStockItemId = rawStockItemId || null;
     if (!resolvedStockItemId && flowerName) {
@@ -427,13 +430,14 @@ router.delete('/:id/lines/:lineId', authorize('stock-orders', ['owner']), async 
 router.post('/:id/send', authorize('stock-orders', ['owner']), async (req, res, next) => {
   try {
     const { driverName } = req.body;
+    const resolvedDriver = driverName || getDriverOfDay() || 'Driver';
     const updated = await db.update(TABLES.STOCK_ORDERS, req.params.id, {
       Status: PO_STATUS.SENT,
-      'Assigned Driver': driverName || 'Nikita',
+      'Assigned Driver': resolvedDriver,
     });
 
     // SSE notification to driver
-    broadcast({ type: 'stock_pickup_assigned', stockOrderId: req.params.id, driverName: driverName || 'Nikita' });
+    broadcast({ type: 'stock_pickup_assigned', stockOrderId: req.params.id, driverName: resolvedDriver });
 
     res.json(updated);
   } catch (err) {

--- a/backend/src/services/wix.js
+++ b/backend/src/services/wix.js
@@ -10,6 +10,7 @@ import { notifyNewOrder } from './telegram.js';
 import { logWebhookEvent } from './webhookLog.js';
 import { generateOrderId } from '../routes/settings.js';
 import { checkOversell } from './oversellCheck.js';
+import { DELIVERY_STATUS } from '../constants/statuses.js';
 
 
 /**
@@ -194,6 +195,7 @@ export async function processWixOrder(payload) {
       return null;
     }
 
+    const createdLines = [];
     for (const li of lineItems) {
       const productName = li.name || li.productName || li.catalogReference?.catalogItemName || 'Wix Item';
       const qty = li.quantity || 1;
@@ -213,7 +215,8 @@ export async function processWixOrder(payload) {
         lineFields['Stock Item'] = [matched.id];
       }
 
-      await db.create(TABLES.ORDER_LINES, lineFields);
+      const createdLine = await db.create(TABLES.ORDER_LINES, lineFields);
+      createdLines.push(createdLine);
 
       // No stock deduction for Wix orders — Wix "bouquets" don't map to
       // individual flower stock items. The florist opens the order later and
@@ -227,13 +230,9 @@ export async function processWixOrder(payload) {
 
     // 9b. Oversell check — compare ordered quantities against stock.
     // Doesn't block the order; just sends a Telegram alert if stock is short.
-    // Like a post-shipment quality gate: the order ships, but if we're short
-    // on materials, the production manager gets a heads-up to call the customer.
+    // Uses the lines we just created above instead of re-querying Airtable
+    // (ARRAYJOIN on linked fields returns display names, not record IDs).
     try {
-      const createdLines = await db.list(TABLES.ORDER_LINES, {
-        filterByFormula: `SEARCH('${sanitizeFormulaValue(order.id)}', ARRAYJOIN({Order}))`,
-        fields: ['Stock Item', 'Quantity', 'Flower Name'],
-      });
       await checkOversell(order.id, createdLines, customerName, customerPhone);
     } catch (oversellErr) {
       console.error('[WIX] Oversell check failed (non-blocking):', oversellErr.message);
@@ -253,7 +252,7 @@ export async function processWixOrder(payload) {
           || new Date().toISOString().split('T')[0],
         'Delivery Time': '',
         'Delivery Fee': 0, // studio adjusts later
-        Status: 'Pending',
+        Status: DELIVERY_STATUS.PENDING,
       });
       log('8-DELIVERY', `Delivery created → ${deliveryAddress}`);
     }


### PR DESCRIPTION
Critical:
- Fix ARRAYJOIN query on linked field in wix.js that silently broke oversell
  checks (ARRAYJOIN returns display names, not record IDs). Now collects
  created lines during the loop and passes them directly to checkOversell.
- Add DELIVERY_STATUS.CANCELLED to statuses.js and extend delivery→order
  cascade in deliveries.js to include cancellation. Previously cancelling
  a delivery directly left the linked order permanently desynchronized.

High:
- Replace hardcoded status strings ('Out for Delivery', 'Delivered', etc.)
  with ORDER_STATUS/DELIVERY_STATUS constants in orders.js cascade logic.
- Replace hardcoded 'Nikita' default driver in stockOrders.js send endpoint
  with getDriverOfDay() config-based lookup.
- Replace hardcoded 'Pending' status string in wix.js delivery creation
  with DELIVERY_STATUS.PENDING constant.
- Add validation to PO line creation: reject lines with neither stock item
  nor flower name (previously caused cryptic errors during evaluation).

Medium:
- Fix delivery fee calculation in OrderCard.jsx to prefer delivery sub-record
  over stale order-level field (lines 207, 689).
- Remove !isDelivery gate from unpaid warning banner so delivery orders also
  show payment collection reminder.
- Make delivery fee editable (was read-only Row) in OrderCard delivery section,
  matching the pattern used by address/name/phone fields.

Low:
- Add error toast when stock fetch fails in bouquet editor (was silent catch).
- Extract backend error messages in StockPanelPage catch blocks instead of
  showing generic translations.

All 3 frontend apps build clean, 46 backend tests pass.

https://claude.ai/code/session_01D3mCpzWCiEDrKNn7frwVoh