### PR TITLE
Add premade bouquet editing + fix orders page layout

### DIFF
--- a/apps/florist/src/components/PremadeBouquetCard.jsx
+++ b/apps/florist/src/components/PremadeBouquetCard.jsx
@@ -1,14 +1,11 @@
 // PremadeBouquetCard — a premade-bouquet row on the inventory view.
 //
-// Shows composition, price, age, and three primary actions:
-//   • "Sold" — opens the order wizard with the premade pre-selected (Step 1
-//     for the customer, then Step 3 for delivery/payment — Step 2 is skipped
-//     because the composition is already locked in).
-//   • "Return to stock" — restores all flowers to inventory and deletes the
-//     premade record. Nothing to cancel, because no order was ever created.
-//   • Tap header to expand — shows the full flower list and notes.
+// Shows composition, price, age, and primary actions:
+//   • "Sold" — opens the order wizard with the premade pre-selected
+//   • "Return to stock" — restores all flowers to inventory
+//   • "Edit" — inline editing of name, notes, price override, and flower lines
 
-import { useState } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import client from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import t from '../translations.js';
@@ -25,10 +22,25 @@ function timeAgo(iso) {
   return `${days}d`;
 }
 
-export default function PremadeBouquetCard({ bouquet, isOwner, onRemoved, onMatchClicked }) {
+export default function PremadeBouquetCard({ bouquet, isOwner, onRemoved, onUpdated, onMatchClicked }) {
   const { showToast } = useToast();
   const [expanded, setExpanded] = useState(false);
   const [busy, setBusy] = useState(false);
+  const [editing, setEditing] = useState(false);
+
+  // Editable field state
+  const [editName, setEditName] = useState(bouquet.Name || '');
+  const [editNotes, setEditNotes] = useState(bouquet.Notes || '');
+  const [editPriceOverride, setEditPriceOverride] = useState(bouquet['Price Override'] || '');
+
+  // Line editing state
+  const [editLines, setEditLines] = useState([]);
+  const [removedLines, setRemovedLines] = useState([]);
+
+  // Stock catalog for adding flowers
+  const [stock, setStock] = useState([]);
+  const [flowerSearch, setFlowerSearch] = useState('');
+  const [showAddFlower, setShowAddFlower] = useState(false);
 
   const sellTotal = Number(bouquet['Computed Sell Total'] || 0);
   const costTotal = Number(bouquet['Computed Cost Total'] || 0);
@@ -38,6 +50,135 @@ export default function PremadeBouquetCard({ bouquet, isOwner, onRemoved, onMatc
     || (bouquet.lines || [])
       .map(l => `${Number(l.Quantity || 0)}× ${l['Flower Name'] || '?'}`)
       .join(', ');
+
+  // Computed totals for edit mode
+  const editSellTotal = useMemo(() =>
+    editLines.reduce((s, l) => s + Number(l.sellPricePerUnit || 0) * Number(l.quantity || 0), 0),
+    [editLines],
+  );
+  const editCostTotal = useMemo(() =>
+    editLines.reduce((s, l) => s + Number(l.costPricePerUnit || 0) * Number(l.quantity || 0), 0),
+    [editLines],
+  );
+
+  function startEditing() {
+    setEditing(true);
+    setEditName(bouquet.Name || '');
+    setEditNotes(bouquet.Notes || '');
+    setEditPriceOverride(bouquet['Price Override'] || '');
+    setEditLines((bouquet.lines || []).map(l => ({
+      id: l.id,
+      stockItemId: l['Stock Item']?.[0] || null,
+      flowerName: l['Flower Name'] || '',
+      quantity: Number(l.Quantity || 0),
+      _originalQty: Number(l.Quantity || 0),
+      costPricePerUnit: Number(l['Cost Price Per Unit'] || 0),
+      sellPricePerUnit: Number(l['Sell Price Per Unit'] || 0),
+    })));
+    setRemovedLines([]);
+    setShowAddFlower(false);
+    setFlowerSearch('');
+  }
+
+  function cancelEditing() {
+    setEditing(false);
+    setRemovedLines([]);
+    setShowAddFlower(false);
+  }
+
+  function removeLine(idx) {
+    const line = editLines[idx];
+    if (line.id) {
+      setRemovedLines(prev => [...prev, {
+        lineId: line.id,
+        stockItemId: line.stockItemId,
+        quantity: line._originalQty,
+      }]);
+    }
+    setEditLines(prev => prev.filter((_, i) => i !== idx));
+  }
+
+  function updateQty(idx, delta) {
+    setEditLines(prev => prev.map((l, i) => {
+      if (i !== idx) return l;
+      const newQty = Math.max(1, l.quantity + delta);
+      return { ...l, quantity: newQty };
+    }));
+  }
+
+  function addFlowerFromStock(item) {
+    const existing = editLines.findIndex(l => l.stockItemId === item.id);
+    if (existing >= 0) {
+      setEditLines(prev => prev.map((l, i) =>
+        i === existing ? { ...l, quantity: l.quantity + 1 } : l,
+      ));
+    } else {
+      setEditLines(prev => [...prev, {
+        id: null,
+        stockItemId: item.id,
+        flowerName: item['Display Name'] || '',
+        quantity: 1,
+        _originalQty: 0,
+        costPricePerUnit: Number(item['Current Cost Price'] || 0),
+        sellPricePerUnit: Number(item['Current Sell Price'] || 0),
+      }]);
+    }
+    setShowAddFlower(false);
+    setFlowerSearch('');
+  }
+
+  // Fetch stock when opening add-flower
+  useEffect(() => {
+    if (!showAddFlower || stock.length > 0) return;
+    client.get('/stock').then(r => setStock(r.data)).catch(() => {});
+  }, [showAddFlower]);
+
+  const filteredStock = useMemo(() => {
+    if (!flowerSearch.trim()) return stock.slice(0, 20);
+    const q = flowerSearch.toLowerCase().trim();
+    return stock.filter(s =>
+      (s['Display Name'] || '').toLowerCase().includes(q),
+    ).slice(0, 20);
+  }, [stock, flowerSearch]);
+
+  async function handleSave() {
+    setBusy(true);
+    try {
+      // 1. Patch top-level fields if changed
+      const patch = {};
+      if (editName.trim() !== (bouquet.Name || '')) patch.name = editName.trim();
+      if ((editNotes || '') !== (bouquet.Notes || '')) patch.notes = editNotes;
+      const overrideNum = editPriceOverride ? Number(editPriceOverride) : null;
+      if (overrideNum !== (bouquet['Price Override'] || null)) patch.priceOverride = overrideNum;
+
+      if (Object.keys(patch).length > 0) {
+        await client.patch(`/premade-bouquets/${bouquet.id}`, patch);
+      }
+
+      // 2. Save line changes if any
+      const hasLineChanges = removedLines.length > 0
+        || editLines.some(l => !l.id)
+        || editLines.some(l => l.id && l.quantity !== l._originalQty);
+
+      if (hasLineChanges) {
+        await client.put(`/premade-bouquets/${bouquet.id}/lines`, {
+          lines: editLines,
+          removedLines,
+        });
+      }
+
+      // 3. Refresh the bouquet data
+      const res = await client.get(`/premade-bouquets/${bouquet.id}`);
+      onUpdated?.(res.data);
+      setEditing(false);
+      showToast(t.bouquetUpdated, 'success');
+    } catch (err) {
+      console.error('Failed to save premade bouquet:', err);
+      showToast(err.response?.data?.error || t.error, 'error');
+    } finally {
+      setBusy(false);
+    }
+  }
 
   async function handleReturnToStock() {
     if (!window.confirm(t.confirmReturnToStock)) return;
@@ -59,7 +200,7 @@ export default function PremadeBouquetCard({ bouquet, isOwner, onRemoved, onMatc
       {/* Header — tap to expand */}
       <button
         type="button"
-        onClick={() => setExpanded(v => !v)}
+        onClick={() => { if (!editing) setExpanded(v => !v); }}
         className="w-full px-4 py-3 flex items-center gap-3 text-left active-scale"
       >
         <div className="w-10 h-10 rounded-full bg-pink-100 text-pink-600 text-lg flex items-center justify-center shrink-0">
@@ -86,7 +227,7 @@ export default function PremadeBouquetCard({ bouquet, isOwner, onRemoved, onMatc
       </button>
 
       {/* Expanded body */}
-      {expanded && (
+      {expanded && !editing && (
         <div className="px-4 pb-4 pt-1 border-t border-gray-100">
           {(bouquet.lines || []).length > 0 && (
             <div className="mb-3">
@@ -127,10 +268,162 @@ export default function PremadeBouquetCard({ bouquet, isOwner, onRemoved, onMatc
             <button
               type="button"
               disabled={busy}
+              onClick={startEditing}
+              className="h-11 px-4 rounded-xl bg-gray-100 text-ios-label text-sm font-semibold disabled:opacity-30 active:bg-gray-200 active-scale"
+            >
+              {t.editBouquet}
+            </button>
+            <button
+              type="button"
+              disabled={busy}
               onClick={handleReturnToStock}
-              className="flex-1 h-11 rounded-xl bg-amber-100 text-amber-700 text-sm font-semibold disabled:opacity-30 active:bg-amber-200 active-scale"
+              className="h-11 px-4 rounded-xl bg-amber-100 text-amber-700 text-sm font-semibold disabled:opacity-30 active:bg-amber-200 active-scale"
             >
               {t.returnToStock}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Editing mode */}
+      {expanded && editing && (
+        <div className="px-4 pb-4 pt-1 border-t border-gray-100">
+          {/* Name */}
+          <div className="mb-3">
+            <label className="text-[11px] text-ios-tertiary uppercase tracking-wide">{t.premadeBouquetName}</label>
+            <input
+              type="text"
+              value={editName}
+              onChange={e => setEditName(e.target.value)}
+              className="w-full mt-1 px-3 py-2.5 rounded-xl bg-ios-fill text-base text-ios-label outline-none"
+            />
+          </div>
+
+          {/* Lines editor */}
+          <div className="mb-3">
+            <div className="flex items-center justify-between mb-1">
+              <span className="text-[11px] text-ios-tertiary uppercase tracking-wide">{t.labelBouquet}</span>
+              <button
+                type="button"
+                onClick={() => setShowAddFlower(v => !v)}
+                className="text-xs font-semibold text-brand-600 active-scale"
+              >
+                + {t.addFlower}
+              </button>
+            </div>
+
+            {/* Add flower search */}
+            {showAddFlower && (
+              <div className="mb-2 bg-gray-50 rounded-xl p-3">
+                <input
+                  type="text"
+                  value={flowerSearch}
+                  onChange={e => setFlowerSearch(e.target.value)}
+                  placeholder={t.flowerSearch}
+                  className="w-full px-3 py-2 rounded-lg bg-white border border-ios-separator text-sm outline-none mb-2"
+                  autoFocus
+                />
+                <div className="max-h-40 overflow-y-auto space-y-1">
+                  {filteredStock.map(item => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => addFlowerFromStock(item)}
+                      className="w-full text-left px-3 py-2 rounded-lg bg-white text-sm active:bg-gray-100 flex justify-between items-center"
+                    >
+                      <span className="text-ios-label">{item['Display Name'] || '?'}</span>
+                      <span className="text-ios-tertiary text-xs">
+                        {Number(item['Current Quantity'] || 0)} · {Number(item['Current Sell Price'] || 0)} zł
+                      </span>
+                    </button>
+                  ))}
+                  {filteredStock.length === 0 && (
+                    <p className="text-xs text-ios-tertiary text-center py-2">{t.noStockFound || 'No items found'}</p>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Current lines */}
+            <div className="space-y-1">
+              {editLines.map((line, idx) => (
+                <div key={line.id || `new-${idx}`} className="flex items-center gap-2 bg-gray-50 rounded-xl px-3 py-2">
+                  <span className="flex-1 text-sm text-ios-label truncate">{line.flowerName}</span>
+                  <div className="flex items-center gap-1.5">
+                    <button
+                      type="button"
+                      onClick={() => updateQty(idx, -1)}
+                      className="w-7 h-7 rounded-full bg-white border border-ios-separator text-sm text-ios-label flex items-center justify-center active-scale"
+                    >−</button>
+                    <span className="w-6 text-center text-sm font-semibold text-ios-label">{line.quantity}</span>
+                    <button
+                      type="button"
+                      onClick={() => updateQty(idx, 1)}
+                      className="w-7 h-7 rounded-full bg-white border border-ios-separator text-sm text-ios-label flex items-center justify-center active-scale"
+                    >+</button>
+                  </div>
+                  <span className="text-xs text-ios-tertiary w-12 text-right">{Math.round(line.sellPricePerUnit * line.quantity)} zł</span>
+                  <button
+                    type="button"
+                    onClick={() => removeLine(idx)}
+                    className="text-red-400 text-sm active-scale ml-1"
+                  >✕</button>
+                </div>
+              ))}
+            </div>
+
+            {/* Edit totals */}
+            {editLines.length > 0 && (
+              <div className="flex justify-between mt-2 px-1 text-xs">
+                <span className="text-ios-tertiary">{t.sellTotal}: <strong className="text-ios-label">{Math.round(editSellTotal)} zł</strong></span>
+                {isOwner && (
+                  <span className="text-ios-tertiary">{t.costTotal}: <strong className="text-ios-label">{Math.round(editCostTotal)} zł</strong></span>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Price override */}
+          <div className="mb-3">
+            <label className="text-[11px] text-ios-tertiary uppercase tracking-wide">{t.priceOverrideOptional}</label>
+            <input
+              type="number"
+              value={editPriceOverride}
+              onChange={e => setEditPriceOverride(e.target.value)}
+              placeholder={`${Math.round(editSellTotal)} zł`}
+              className="w-full mt-1 px-3 py-2.5 rounded-xl bg-ios-fill text-base text-ios-label outline-none"
+            />
+          </div>
+
+          {/* Notes */}
+          <div className="mb-4">
+            <label className="text-[11px] text-ios-tertiary uppercase tracking-wide">{t.premadeBouquetNotes}</label>
+            <textarea
+              value={editNotes}
+              onChange={e => setEditNotes(e.target.value)}
+              placeholder={t.premadeBouquetNotesHint}
+              rows={2}
+              className="w-full mt-1 px-3 py-2.5 rounded-xl bg-ios-fill text-sm text-ios-label outline-none resize-none"
+            />
+          </div>
+
+          {/* Save / Cancel */}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={busy || !editName.trim() || editLines.length === 0}
+              onClick={handleSave}
+              className="flex-1 h-11 rounded-xl bg-brand-600 text-white text-sm font-semibold disabled:opacity-30 active:bg-brand-700 active-scale"
+            >
+              {t.saveBouquet}
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={cancelEditing}
+              className="h-11 px-6 rounded-xl bg-gray-100 text-ios-secondary text-sm font-semibold active:bg-gray-200 active-scale"
+            >
+              {t.cancel}
             </button>
           </div>
         </div>

--- a/apps/florist/src/pages/OrderListPage.jsx
+++ b/apps/florist/src/pages/OrderListPage.jsx
@@ -240,6 +240,9 @@ export default function OrderListPage() {
         <div className="flex items-center justify-between max-w-2xl mx-auto">
           <img src="/logo.png" alt="Blossom" className="h-7" />
           <div className="flex items-center gap-2">
+            <button onClick={fetchOrders} className="h-8 w-8 rounded-full bg-white/80 border border-ios-separator flex items-center justify-center text-ios-tertiary active:bg-ios-fill">
+              ↻
+            </button>
             <LangToggle />
           </div>
         </div>
@@ -297,48 +300,43 @@ export default function OrderListPage() {
       {/* Filters */}
       <div className="px-4 py-3 max-w-2xl mx-auto flex flex-col gap-2">
         {/* View mode toggle: Active / Completed / Premade */}
-        <div className="flex gap-2 items-center">
-          <div className="flex gap-1.5 bg-white rounded-full border border-ios-separator shadow-sm p-1 min-w-0 overflow-x-auto">
-            <button
-              onClick={() => { setViewMode(VIEW_MODES.ACTIVE); setStatus(''); }}
-              className={`px-3 h-7 rounded-full text-xs font-semibold whitespace-nowrap transition-colors ${
-                viewMode === VIEW_MODES.ACTIVE
-                  ? 'bg-brand-600 text-white'
-                  : 'text-ios-secondary active:bg-ios-fill'
-              }`}
-            >
-              {t.activeOrders}
-            </button>
-            <button
-              onClick={() => { setViewMode(VIEW_MODES.COMPLETED); setStatus(''); setDate(''); }}
-              className={`px-3 h-7 rounded-full text-xs font-semibold whitespace-nowrap transition-colors ${
-                viewMode === VIEW_MODES.COMPLETED
-                  ? 'bg-brand-600 text-white'
-                  : 'text-ios-secondary active:bg-ios-fill'
-              }`}
-            >
-              {t.completedOrders}
-            </button>
-            <button
-              onClick={() => { setViewMode(VIEW_MODES.PREMADE); setStatus(''); setDate(''); }}
-              className={`px-3 h-7 rounded-full text-xs font-semibold whitespace-nowrap transition-colors flex items-center gap-1.5 ${
-                viewMode === VIEW_MODES.PREMADE
-                  ? 'bg-brand-600 text-white'
-                  : 'text-ios-secondary active:bg-ios-fill'
-              }`}
-            >
-              {t.premadeBouquets}
-              {premadeCount > 0 && (
-                <span className={`min-w-[18px] h-[18px] px-1 rounded-full text-[10px] font-bold flex items-center justify-center ${
-                  viewMode === VIEW_MODES.PREMADE ? 'bg-white text-brand-600' : 'bg-brand-600 text-white'
-                }`}>
-                  {premadeCount}
-                </span>
-              )}
-            </button>
-          </div>
-          <button onClick={fetchOrders} className="shrink-0 h-9 w-9 rounded-full bg-white border border-ios-separator shadow-sm flex items-center justify-center text-ios-tertiary active:bg-ios-fill">
-            ↻
+        <div className="flex gap-1.5 bg-white rounded-full border border-ios-separator shadow-sm p-1">
+          <button
+            onClick={() => { setViewMode(VIEW_MODES.ACTIVE); setStatus(''); }}
+            className={`px-4 h-7 rounded-full text-xs font-semibold whitespace-nowrap transition-colors ${
+              viewMode === VIEW_MODES.ACTIVE
+                ? 'bg-brand-600 text-white'
+                : 'text-ios-secondary active:bg-ios-fill'
+            }`}
+          >
+            {t.activeOrders}
+          </button>
+          <button
+            onClick={() => { setViewMode(VIEW_MODES.COMPLETED); setStatus(''); setDate(''); }}
+            className={`px-4 h-7 rounded-full text-xs font-semibold whitespace-nowrap transition-colors ${
+              viewMode === VIEW_MODES.COMPLETED
+                ? 'bg-brand-600 text-white'
+                : 'text-ios-secondary active:bg-ios-fill'
+            }`}
+          >
+            {t.completedOrders}
+          </button>
+          <button
+            onClick={() => { setViewMode(VIEW_MODES.PREMADE); setStatus(''); setDate(''); }}
+            className={`px-4 h-7 rounded-full text-xs font-semibold whitespace-nowrap transition-colors flex items-center gap-1.5 ${
+              viewMode === VIEW_MODES.PREMADE
+                ? 'bg-brand-600 text-white'
+                : 'text-ios-secondary active:bg-ios-fill'
+            }`}
+          >
+            {t.premadeBouquets}
+            {premadeCount > 0 && (
+              <span className={`min-w-[18px] h-[18px] px-1 rounded-full text-[10px] font-bold flex items-center justify-center ${
+                viewMode === VIEW_MODES.PREMADE ? 'bg-white text-brand-600' : 'bg-brand-600 text-white'
+              }`}>
+                {premadeCount}
+              </span>
+            )}
           </button>
         </div>
 
@@ -427,6 +425,7 @@ export default function OrderListPage() {
                   bouquet={bouquet}
                   isOwner={isOwner}
                   onRemoved={(id) => setPremadeBouquets(prev => prev.filter(b => b.id !== id))}
+                  onUpdated={(updated) => setPremadeBouquets(prev => prev.map(b => b.id === updated.id ? updated : b))}
                   onMatchClicked={(id) => navigate('/orders/new', { state: { matchPremadeId: id } })}
                 />
               ))}

--- a/apps/florist/src/pages/OrderListPage.jsx
+++ b/apps/florist/src/pages/OrderListPage.jsx
@@ -10,9 +10,6 @@ import TextImportModal from '../components/TextImportModal.jsx';
 import { OrderListSkeleton } from '../components/Skeleton.jsx';
 import t from '../translations.js';
 
-// Key for dismissing stock alerts per session
-const ALERTS_DISMISSED_KEY = 'blossom-alerts-dismissed';
-
 // View modes:
 //   active — non-terminal orders (florist's default view)
 //   completed — past/terminal orders
@@ -103,9 +100,6 @@ export default function OrderListPage() {
 
   // Owner-only: dashboard summary data
   const [dashData, setDashData]       = useState(null);
-  const [alertsDismissed, setAlertsDismissed] = useState(
-    () => sessionStorage.getItem(ALERTS_DISMISSED_KEY) === 'true'
-  );
   // Track whether we've done the initial load (show spinner only on first load)
   const initialLoaded = useRef(false);
 
@@ -238,11 +232,6 @@ export default function OrderListPage() {
     }
   }, [isOwner]);
 
-  function dismissAlerts() {
-    setAlertsDismissed(true);
-    sessionStorage.setItem(ALERTS_DISMISSED_KEY, 'true');
-  }
-
   return (
     <div className="min-h-screen dark:bg-dark-bg dark:text-dark-label">
 
@@ -309,10 +298,10 @@ export default function OrderListPage() {
       <div className="px-4 py-3 max-w-2xl mx-auto flex flex-col gap-2">
         {/* View mode toggle: Active / Completed / Premade */}
         <div className="flex gap-2 items-center">
-          <div className="flex gap-1.5 bg-white rounded-full border border-ios-separator shadow-sm p-1">
+          <div className="flex gap-1.5 bg-white rounded-full border border-ios-separator shadow-sm p-1 min-w-0 overflow-x-auto">
             <button
               onClick={() => { setViewMode(VIEW_MODES.ACTIVE); setStatus(''); }}
-              className={`px-4 h-7 rounded-full text-xs font-semibold whitespace-nowrap transition-colors ${
+              className={`px-3 h-7 rounded-full text-xs font-semibold whitespace-nowrap transition-colors ${
                 viewMode === VIEW_MODES.ACTIVE
                   ? 'bg-brand-600 text-white'
                   : 'text-ios-secondary active:bg-ios-fill'
@@ -322,7 +311,7 @@ export default function OrderListPage() {
             </button>
             <button
               onClick={() => { setViewMode(VIEW_MODES.COMPLETED); setStatus(''); setDate(''); }}
-              className={`px-4 h-7 rounded-full text-xs font-semibold whitespace-nowrap transition-colors ${
+              className={`px-3 h-7 rounded-full text-xs font-semibold whitespace-nowrap transition-colors ${
                 viewMode === VIEW_MODES.COMPLETED
                   ? 'bg-brand-600 text-white'
                   : 'text-ios-secondary active:bg-ios-fill'
@@ -332,7 +321,7 @@ export default function OrderListPage() {
             </button>
             <button
               onClick={() => { setViewMode(VIEW_MODES.PREMADE); setStatus(''); setDate(''); }}
-              className={`px-4 h-7 rounded-full text-xs font-semibold whitespace-nowrap transition-colors flex items-center gap-1.5 ${
+              className={`px-3 h-7 rounded-full text-xs font-semibold whitespace-nowrap transition-colors flex items-center gap-1.5 ${
                 viewMode === VIEW_MODES.PREMADE
                   ? 'bg-brand-600 text-white'
                   : 'text-ios-secondary active:bg-ios-fill'
@@ -348,7 +337,7 @@ export default function OrderListPage() {
               )}
             </button>
           </div>
-          <button onClick={fetchOrders} className="h-9 w-9 rounded-full bg-white border border-ios-separator shadow-sm flex items-center justify-center text-ios-tertiary active:bg-ios-fill">
+          <button onClick={fetchOrders} className="shrink-0 h-9 w-9 rounded-full bg-white border border-ios-separator shadow-sm flex items-center justify-center text-ios-tertiary active:bg-ios-fill">
             ↻
           </button>
         </div>
@@ -389,37 +378,6 @@ export default function OrderListPage() {
           </div>
         </div>
       </div>
-
-      {/* Owner: Stock alerts banner */}
-      {isOwner && dashData?.lowStockAlerts?.length > 0 && !alertsDismissed && (
-        <div className="px-4 max-w-2xl mx-auto">
-          <div className="bg-amber-50 border border-amber-200 rounded-2xl px-4 py-3">
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-xs font-semibold text-amber-800 uppercase tracking-wide">{t.owner.stockAlerts}</span>
-              <button onClick={dismissAlerts} className="text-xs text-amber-600 active-scale">{t.owner.dismissAlerts}</button>
-            </div>
-            <div className="flex flex-col gap-1">
-              {dashData.lowStockAlerts
-                .sort((a, b) => (a['Current Quantity'] || 0) - (b['Current Quantity'] || 0))
-                .map((item, i) => {
-                  const qty = item['Current Quantity'] || 0;
-                  const isOut = qty === 0;
-                  return (
-                    <button
-                      key={i}
-                      onClick={() => navigate('/stock')}
-                      className="text-left text-xs py-0.5 active-scale"
-                    >
-                      <span className={isOut ? 'text-red-600' : 'text-orange-600'}>
-                        {isOut ? '🔴' : '🟠'} {item['Display Name']} — {isOut ? t.owner.outOfStock : `${qty} ${t.owner.left} (${t.owner.threshold}: ${item['Reorder Threshold']})`}
-                      </span>
-                    </button>
-                  );
-                })}
-            </div>
-          </div>
-        </div>
-      )}
 
       {/* Stock shortfall warning banner */}
       {(() => {

--- a/backend/src/routes/premadeBouquets.js
+++ b/backend/src/routes/premadeBouquets.js
@@ -10,6 +10,7 @@ import {
   getPremadeBouquet,
   createPremadeBouquet,
   updatePremadeBouquet,
+  editPremadeBouquetLines,
   returnPremadeBouquetToStock,
   matchPremadeBouquetToOrder,
 } from '../services/premadeBouquetService.js';
@@ -91,6 +92,25 @@ router.patch('/:id', async (req, res, next) => {
     if (notes !== undefined) patch.notes = notes;
     const bouquet = await updatePremadeBouquet(req.params.id, patch);
     res.json(bouquet);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PUT /api/premade-bouquets/:id/lines — edit bouquet lines (add/remove/qty).
+router.put('/:id/lines', async (req, res, next) => {
+  try {
+    const { lines = [], removedLines = [] } = req.body;
+    try {
+      const result = await editPremadeBouquetLines(req.params.id, { lines, removedLines });
+      const bouquet = await getPremadeBouquet(req.params.id);
+      res.json({ ...result, bouquet });
+    } catch (editErr) {
+      if (editErr.statusCode === 400) {
+        return res.status(400).json({ error: editErr.message });
+      }
+      return res.status(500).json({ error: 'Failed to edit premade bouquet lines.', detail: editErr.message });
+    }
   } catch (err) {
     next(err);
   }

--- a/backend/src/services/premadeBouquetService.js
+++ b/backend/src/services/premadeBouquetService.js
@@ -210,6 +210,79 @@ export async function updatePremadeBouquet(id, patch) {
 }
 
 /**
+ * Edit bouquet lines — handle removals (return to stock), new lines, qty changes.
+ * Mirrors editBouquetLines() in orderService.js but for premade bouquets.
+ * @param {string} id - premade bouquet record ID
+ * @param {Object} params
+ * @param {Array}  params.lines - [{ id?, stockItemId, flowerName, quantity, _originalQty?, costPricePerUnit, sellPricePerUnit }]
+ * @param {Array}  params.removedLines - [{ lineId?, stockItemId, quantity }]
+ * @returns {{ updated: true, createdLines }}
+ */
+export async function editPremadeBouquetLines(id, { lines = [], removedLines = [] }) {
+  // Verify bouquet exists
+  await db.getById(TABLES.PREMADE_BOUQUETS, id);
+
+  // 1. Handle removed lines — always return to stock (no writeoff for premade)
+  for (const rem of removedLines) {
+    if (rem.stockItemId && rem.quantity > 0) {
+      await db.atomicStockAdjust(rem.stockItemId, rem.quantity);
+    }
+    if (rem.lineId) {
+      await db.deleteRecord(TABLES.PREMADE_BOUQUET_LINES, rem.lineId).catch(() => {});
+    }
+  }
+
+  // 2a. Auto-match new unlinked lines
+  const newUnmatched = lines.filter(l => !l.id && !l.stockItemId && l.flowerName);
+  if (newUnmatched.length > 0) {
+    await autoMatchStock(newUnmatched);
+  }
+
+  // 2a-bis. Reject orphan new lines
+  const orphans = lines.filter(l => !l.id && !l.stockItemId);
+  if (orphans.length > 0) {
+    const names = orphans.map(o => o.flowerName || '(unnamed)').join(', ');
+    const err = new Error(
+      `Bouquet line(s) without a Stock Item are not allowed: ${names}. ` +
+      `Create the flower in Stock first.`,
+    );
+    err.statusCode = 400;
+    throw err;
+  }
+
+  // 2b. Process new/updated lines
+  const createdLines = [];
+  for (const line of lines) {
+    if (line.id) {
+      // Existing line — update quantity, adjust stock for delta
+      if (line._originalQty != null && line.quantity !== line._originalQty) {
+        const delta = line._originalQty - line.quantity;
+        if (line.stockItemId && delta !== 0) {
+          await db.atomicStockAdjust(line.stockItemId, delta);
+        }
+        await db.update(TABLES.PREMADE_BOUQUET_LINES, line.id, { Quantity: line.quantity });
+      }
+    } else {
+      // New line — create + deduct stock
+      const created = await db.create(TABLES.PREMADE_BOUQUET_LINES, {
+        'Premade Bouquets': [id],
+        ...(line.stockItemId ? { 'Stock Item': [line.stockItemId] } : {}),
+        'Flower Name': line.flowerName,
+        Quantity: line.quantity,
+        'Cost Price Per Unit': line.costPricePerUnit || 0,
+        'Sell Price Per Unit': line.sellPricePerUnit || 0,
+      });
+      createdLines.push(created);
+      if (line.stockItemId) {
+        await db.atomicStockAdjust(line.stockItemId, -line.quantity);
+      }
+    }
+  }
+
+  return { updated: true, createdLines };
+}
+
+/**
  * Return all flowers in a premade bouquet to stock, then delete the records.
  * Mirrors cancelWithStockReturn() in orderService.js.
  * @returns {{ message, returnedItems }}


### PR DESCRIPTION
## Summary

- **Refresh button moved to header bar** — no longer squeezed next to filter pills. Pills get full width.
- **Stock alerts removed from orders view** — already covered by Low/Negative/Shortfall filters on the Stock page.
- **Premade bouquet editing** — tap a premade card → expand → "Edit" button for inline editing of name, notes, price override, and flower lines (add/remove/qty with stock adjustments).
- **Backend**: new `editPremadeBouquetLines()` service + `PUT /api/premade-bouquets/:id/lines` route.

## Test plan

- [ ] Verify refresh button appears in header bar next to RU toggle, not next to filter pills
- [ ] Verify stock alerts banner no longer appears on orders page
- [ ] Open a premade bouquet → expand → tap "Edit"
- [ ] Change name, add/remove flowers, adjust qty, set price override, add notes → Save
- [ ] Verify stock adjusts correctly (removed flowers return to stock, added flowers deduct)
- [ ] Verify bouquet card updates after save

https://claude.ai/code/session_015ZikGB7FJSwBWj3aveBBhz