### PR TITLE
Fix stock trace showing wrong data for batches

### DIFF
--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -377,24 +377,21 @@ router.get('/:id/usage', async (req, res, next) => {
   try {
     const stockItem = await db.getById(TABLES.STOCK, req.params.id);
     const displayName = stockItem['Display Name'] || '';
-    const purchaseName = stockItem['Purchase Name'] || displayName;
     const stockId = req.params.id;
 
     // 1. Order lines — filter by Flower Name (linked record IDs aren't searchable
-    //    in Airtable formulas). Match both exact Display Name and Purchase Name.
+    //    in Airtable formulas). Use exact Display Name only — not Purchase Name,
+    //    which would match all batches of the same flower type.
     const safeName = sanitizeFormulaValue(displayName);
-    const safePurchase = purchaseName !== displayName ? sanitizeFormulaValue(purchaseName) : null;
-    const nameFilter = safePurchase
-      ? `OR({Flower Name} = '${safeName}', {Flower Name} = '${safePurchase}')`
-      : `{Flower Name} = '${safeName}'`;
     const orderLines = await db.list(TABLES.ORDER_LINES, {
-      filterByFormula: nameFilter,
+      filterByFormula: `{Flower Name} = '${safeName}'`,
       fields: ['Order', 'Flower Name', 'Quantity', 'Sell Price Per Unit', 'Cost Price Per Unit', 'Stock Item'],
     });
-    // Verify Stock Item link matches (avoids false positives from same-name flowers)
+    // Keep only lines linked to THIS specific stock item — excludes unlinked lines
+    // and lines from other batches that happen to share the same base name.
     const matchedLines = orderLines.filter(l => {
       const linkedId = l['Stock Item']?.[0];
-      return linkedId === stockId || !linkedId; // include unlinked lines by name match
+      return linkedId === stockId;
     });
 
     // Fetch parent orders for context


### PR DESCRIPTION
Two bugs in GET /api/stock/:id/usage:

1. Query used both Display Name AND Purchase Name in filterByFormula. For a batch like "Rosa garden salvia pink (1.Apr.)", Purchase Name is the base name "Rosa garden salvia pink" — so it fetched order lines for ALL batches of that flower, not just this one.

2. JS filter included unlinked order lines (linkedId === stockId || !linkedId) which let through lines matched only by name, defeating the batch-specific filtering.

Fix: query by exact Display Name only, and require Stock Item link to match this specific stock item ID. Write-offs and purchases were already correctly filtered by Stock Item ID.

https://claude.ai/code/session_015ZikGB7FJSwBWj3aveBBhz