### PR TITLE
fix(wix): pull re-activation + lead time edit disappearing

### DIFF
--- a/apps/dashboard/src/components/products/ProductCard.jsx
+++ b/apps/dashboard/src/components/products/ProductCard.jsx
@@ -144,6 +144,23 @@ function VariantRow({ variant, productType, stockMap, onUpdate }) {
   const active = variant['Active'] || false;
   const minStems = Number(variant['Min Stems'] || 0);
 
+  // Local draft state — only commits on blur/Enter to prevent
+  // mid-edit filtering (e.g. typing "1" on the way to "2")
+  const [draftPrice, setDraftPrice] = useState(price);
+  const [draftLt, setDraftLt] = useState(lt);
+  useEffect(() => { setDraftPrice(price); }, [price]);
+  useEffect(() => { setDraftLt(lt); }, [lt]);
+
+  function commitPrice() {
+    if (draftPrice !== price) onUpdate(variant.id, 'Price', draftPrice);
+  }
+  function commitLt() {
+    if (draftLt !== lt) onUpdate(variant.id, 'Lead Time Days', draftLt);
+  }
+  function handleKeyDown(e, commitFn) {
+    if (e.key === 'Enter') { e.target.blur(); commitFn(); }
+  }
+
   let suggested = null;
   if (productType === 'mono' && minStems > 0) {
     const keyFlower = variant['Key Flower'];
@@ -162,7 +179,8 @@ function VariantRow({ variant, productType, stockMap, onUpdate }) {
         {minStems > 0 && <span className="text-xs text-gray-400 ml-1">({minStems} {t.prodStems})</span>}
       </td>
       <td className="py-2 px-2 text-right">
-        <input type="number" value={price} onChange={e => onUpdate(variant.id, 'Price', Number(e.target.value))}
+        <input type="number" value={draftPrice} onChange={e => setDraftPrice(Number(e.target.value))}
+          onBlur={commitPrice} onKeyDown={e => handleKeyDown(e, commitPrice)}
           className="w-20 text-right border border-gray-200 rounded-lg px-2 py-1 text-sm" min="0" />
       </td>
       {productType === 'mono' && (
@@ -183,7 +201,8 @@ function VariantRow({ variant, productType, stockMap, onUpdate }) {
         </td>
       )}
       <td className="py-2 px-2 text-center">
-        <input type="number" value={lt} onChange={e => onUpdate(variant.id, 'Lead Time Days', Number(e.target.value))}
+        <input type="number" value={draftLt} onChange={e => setDraftLt(Number(e.target.value))}
+          onBlur={commitLt} onKeyDown={e => handleKeyDown(e, commitLt)}
           className="w-14 text-center border border-gray-200 rounded-lg px-1 py-1 text-sm" min="0" />
       </td>
       <td className="py-2 px-2 text-center">

--- a/backend/src/services/wixProductSync.js
+++ b/backend/src/services/wixProductSync.js
@@ -420,7 +420,8 @@ export async function runPull() {
           const updates = {};
           if (existing['Product Name'] !== productName) updates['Product Name'] = productName;
           if (existing['Image URL'] !== imageUrl) updates['Image URL'] = imageUrl;
-          if (existing['Active'] !== wixVisible) updates['Active'] = wixVisible;
+          // Active is Airtable-owned — never overwrite from Wix pull.
+          // Only sync Visible in Wix (what Wix reports) for informational purposes.
           if (existing['Visible in Wix'] !== wixVisible) updates['Visible in Wix'] = wixVisible;
           const existingCats = parseCategoryField(existing['Category']);
           if (existingCats.length === 0 && importedCategories.length > 0) {


### PR DESCRIPTION
## Summary
- **Pull re-activation bug**: `runPull()` was overwriting `Active` with Wix's `product.visible` flag on existing rows. Since push uses the inventory API (`inStock`) — not product visibility — Wix always reported `visible: true`, undoing manual deactivations. Removed the `Active` overwrite; it is now Airtable-owned. `Visible in Wix` still syncs for reference.
- **Lead time edit disappearing bug**: Number inputs (price, lead time) fired `onChange` per keystroke, triggering optimistic state updates. Typing "1" (on the way to "2") in lead time caused the product to fail `isAvailableToday` (requires `=== 0`) and vanish from the filtered view. Replaced with local draft state that commits only on blur/Enter.

## Test plan
- [ ] Set a product inactive in dashboard → Push to Wix → Pull from Wix → verify it stays inactive
- [ ] On "Available today" filter, edit lead time from 0 to 2 — product should stay visible until blur/Enter
- [ ] Edit price on a variant — verify it commits on blur/Enter, not per keystroke
- [ ] Pull from Wix with a genuinely new product — verify it still gets `Active: true` on first import
- [ ] Verify deactivation of deleted Wix products still works (products removed from Wix → pull marks them inactive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)