### PR TITLE
fix: three separate aligned tables + deferred-only committed endpoint

### DIFF
--- a/apps/dashboard/src/components/StockTab.jsx
+++ b/apps/dashboard/src/components/StockTab.jsx
@@ -244,12 +244,12 @@ export default function StockTab({ initialFilter, onNavigate }) {
   // Planned rows — flowers arriving from pending POs, cross-referenced with committed orders
   const plannedRows = useMemo(() => {
     const nameMap = {};
-    for (const s of stock) nameMap[s.id] = s['Display Name'] || s['Purchase Name'] || '';
+    for (const s of stock) nameMap[s.id] = stockBaseName(s['Display Name']) || s['Purchase Name'] || '';
     let rows = Object.keys(pendingPO).map(stockId => {
       const po = pendingPO[stockId] || { ordered: 0, pos: [], flowerName: '' };
       const com = committedMap[stockId] || { committed: 0, orders: [] };
       const stockName = nameMap[stockId] || '';
-      const poName = po.flowerName || '';
+      const poName = stockBaseName(po.flowerName) || '';
       return {
         stockId,
         name: (poName.length >= stockName.length ? poName : stockName) || '—',
@@ -268,7 +268,7 @@ export default function StockTab({ initialFilter, onNavigate }) {
   // Needed rows — flowers committed to future orders (shows demand)
   const neededRows = useMemo(() => {
     const nameMap = {};
-    for (const s of stock) nameMap[s.id] = s['Display Name'] || s['Purchase Name'] || '';
+    for (const s of stock) nameMap[s.id] = stockBaseName(s['Display Name']) || s['Purchase Name'] || '';
     let rows = Object.keys(committedMap).map(stockId => {
       const com = committedMap[stockId];
       const hasPO = !!pendingPO[stockId];
@@ -650,157 +650,161 @@ export default function StockTab({ initialFilter, onNavigate }) {
         );
       })()}
 
-      {/* ── Unified stock table — Planned + Needed + Available in one aligned table ── */}
+      {/* ── Three aligned stock tables: Planned → Needed → Available ── */}
       {view !== 'waste' && !loading && (
         <div className="glass-card overflow-x-auto">
-          <table className="w-full text-sm whitespace-nowrap" style={{ tableLayout: 'fixed' }}>
-            <colgroup>
-              <col style={{ width: '24%' }} />
-              <col style={{ width: '7%' }} />
-              <col style={{ width: '6%' }} />
-              <col style={{ width: '7%' }} />
-              <col style={{ width: '7%' }} />
-              <col style={{ width: '5%' }} />
-              <col style={{ width: '8%' }} />
-              <col style={{ width: '7%' }} />
-              <col style={{ width: '6%' }} />
-              <col style={{ width: '6%' }} />
-              <col style={{ width: '17%' }} />
-            </colgroup>
-
-            {/* ── Section A: PLANNED — flowers arriving from pending POs ── */}
-            {plannedRows.length > 0 && (
-              <tbody>
+          {/* ── PLANNED — flowers arriving from pending POs ── */}
+          {plannedRows.length > 0 && (
+            <table className="w-full text-sm whitespace-nowrap" style={{ tableLayout: 'fixed' }}>
+              <colgroup>
+                <col style={{ width: '24%' }} /><col style={{ width: '7%' }} /><col style={{ width: '6%' }} />
+                <col style={{ width: '7%' }} /><col style={{ width: '7%' }} /><col style={{ width: '5%' }} />
+                <col style={{ width: '8%' }} /><col style={{ width: '7%' }} /><col style={{ width: '6%' }} />
+                <col style={{ width: '6%' }} /><col style={{ width: '17%' }} />
+              </colgroup>
+              <thead>
                 <tr className="bg-indigo-50/60">
-                  <td colSpan={11} className="px-3 py-2 border-b border-indigo-100">
+                  <th colSpan={11} className="px-3 py-2 border-b border-indigo-100 text-left font-normal">
                     <button onClick={() => setPlannedCollapsed(v => !v)} className="w-full flex items-center justify-between">
                       <span className="text-xs font-semibold text-indigo-700 uppercase tracking-wide">
                         {t.pendingArrivals} ({plannedRows.length})
                       </span>
                       <span className="text-xs text-indigo-400">{plannedCollapsed ? '▼' : '▲'}</span>
                     </button>
-                  </td>
+                  </th>
                 </tr>
                 {!plannedCollapsed && (
-                  <>
-                    <tr className="text-xs text-ios-tertiary border-b border-indigo-100 bg-indigo-50/20">
-                      <th className="text-left px-2 py-1.5 font-medium">{t.stockName}</th>
-                      <th className="text-left px-2 py-1.5 font-medium">{t.planned}</th>
-                      <th className="text-right px-2 py-1.5 font-medium">{t.ordered}</th>
-                      <th className="text-right px-2 py-1.5 font-medium">{t.committedToOrders}</th>
-                      <th className="text-right px-2 py-1.5 font-medium">{t.netQty}</th>
-                      <th colSpan={6}></th>
-                    </tr>
-                    {plannedRows.map(row => (
-                      <Fragment key={row.stockId}>
-                        <tr
-                          className="border-b border-gray-100 hover:bg-indigo-50/20 cursor-pointer"
-                          onClick={() => setExpandedPlanned(expandedPlanned === row.stockId ? null : row.stockId)}
-                        >
-                          <td className="px-2 py-1.5 text-ios-label font-medium text-sm truncate">{row.name}</td>
-                          <td className="px-2 py-1.5">{formatDateTag(row.plannedDate, 'indigo')}</td>
-                          <td className="px-2 py-1.5 text-right tabular-nums text-base font-bold text-indigo-600">{row.ordered}</td>
-                          <td className="px-2 py-1.5 text-right tabular-nums text-amber-600 font-medium">
-                            {row.committed > 0 ? row.committed : '—'}
-                          </td>
-                          <td className={`px-2 py-1.5 text-right tabular-nums font-semibold ${
-                            row.net > 0 ? 'text-green-600' : row.net < 0 ? 'text-red-600' : 'text-ios-label'
-                          }`}>
-                            {row.net > 0 ? '+' : ''}{row.net}
-                          </td>
-                          <td colSpan={6}></td>
-                        </tr>
-                        {expandedPlanned === row.stockId && row.orders.length > 0 && (
-                          <tr className="bg-amber-50/50">
-                            <td colSpan={11} className="px-6 py-1.5">
-                              <div className="space-y-0.5">
-                                {row.orders.map((o, i) => (
-                                  <div
-                                    key={i}
-                                    className="flex items-center justify-between text-xs cursor-pointer hover:underline text-amber-700"
-                                    onClick={e => { e.stopPropagation(); onNavigate?.({ tab: 'orders', filter: { orderId: o.orderId } }); }}
-                                  >
-                                    <span>#{o.appOrderId} — {o.customerName} ({o.requiredBy || '—'})</span>
-                                    <span className="tabular-nums font-medium">{o.qty} {t.stems}</span>
-                                  </div>
-                                ))}
-                              </div>
-                            </td>
-                          </tr>
-                        )}
-                      </Fragment>
-                    ))}
-                  </>
+                  <tr className="text-xs text-ios-tertiary border-b border-indigo-100 bg-indigo-50/20">
+                    <th className="text-left px-2 py-1.5 font-medium">{t.stockName}</th>
+                    <th className="text-left px-2 py-1.5 font-medium">{t.planned}</th>
+                    <th className="text-right px-2 py-1.5 font-medium">{t.ordered}</th>
+                    <th className="text-right px-2 py-1.5 font-medium">{t.committedToOrders}</th>
+                    <th className="text-right px-2 py-1.5 font-medium">{t.netQty}</th>
+                    <th colSpan={6}></th>
+                  </tr>
                 )}
-              </tbody>
-            )}
+              </thead>
+              {!plannedCollapsed && (
+                <tbody>
+                  {plannedRows.map(row => (
+                    <Fragment key={row.stockId}>
+                      <tr
+                        className="border-b border-gray-100 hover:bg-indigo-50/20 cursor-pointer"
+                        onClick={() => setExpandedPlanned(expandedPlanned === row.stockId ? null : row.stockId)}
+                      >
+                        <td className="px-2 py-1.5 text-ios-label font-medium text-sm truncate">{row.name}</td>
+                        <td className="px-2 py-1.5">{formatDateTag(row.plannedDate, 'indigo')}</td>
+                        <td className="px-2 py-1.5 text-right tabular-nums text-base font-bold text-indigo-600">{row.ordered}</td>
+                        <td className="px-2 py-1.5 text-right tabular-nums text-amber-600 font-medium">
+                          {row.committed > 0 ? row.committed : '—'}
+                        </td>
+                        <td className={`px-2 py-1.5 text-right tabular-nums font-semibold ${
+                          row.net > 0 ? 'text-green-600' : row.net < 0 ? 'text-red-600' : 'text-ios-label'
+                        }`}>
+                          {row.net > 0 ? '+' : ''}{row.net}
+                        </td>
+                        <td colSpan={6}></td>
+                      </tr>
+                      {expandedPlanned === row.stockId && row.orders.length > 0 && (
+                        <tr className="bg-amber-50/50">
+                          <td colSpan={11} className="px-6 py-1.5">
+                            <div className="space-y-0.5">
+                              {row.orders.map((o, i) => (
+                                <div key={i} className="flex items-center justify-between text-xs cursor-pointer hover:underline text-amber-700"
+                                     onClick={e => { e.stopPropagation(); onNavigate?.({ tab: 'orders', filter: { orderId: o.orderId } }); }}>
+                                  <span>#{o.appOrderId} — {o.customerName} ({o.requiredBy || '—'})</span>
+                                  <span className="tabular-nums font-medium">{o.qty} {t.stems}</span>
+                                </div>
+                              ))}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  ))}
+                </tbody>
+              )}
+            </table>
+          )}
 
-            {/* ── Section B: NEEDED — flowers committed to future orders ── */}
-            {neededRows.length > 0 && (
-              <tbody>
+          {/* ── NEEDED — flowers committed to future orders (deferred stock only) ── */}
+          {neededRows.length > 0 && (
+            <table className="w-full text-sm whitespace-nowrap" style={{ tableLayout: 'fixed' }}>
+              <colgroup>
+                <col style={{ width: '24%' }} /><col style={{ width: '7%' }} /><col style={{ width: '6%' }} />
+                <col style={{ width: '7%' }} /><col style={{ width: '7%' }} /><col style={{ width: '5%' }} />
+                <col style={{ width: '8%' }} /><col style={{ width: '7%' }} /><col style={{ width: '6%' }} />
+                <col style={{ width: '6%' }} /><col style={{ width: '17%' }} />
+              </colgroup>
+              <thead>
                 <tr className="bg-amber-50/60">
-                  <td colSpan={11} className="px-3 py-2 border-b border-amber-100">
+                  <th colSpan={11} className="px-3 py-2 border-b border-amber-100 text-left font-normal">
                     <button onClick={() => setNeededCollapsed(v => !v)} className="w-full flex items-center justify-between">
                       <span className="text-xs font-semibold text-amber-700 uppercase tracking-wide">
                         {t.neededForOrders} ({neededRows.length})
                       </span>
                       <span className="text-xs text-amber-400">{neededCollapsed ? '▼' : '▲'}</span>
                     </button>
-                  </td>
+                  </th>
                 </tr>
                 {!neededCollapsed && (
-                  <>
-                    <tr className="text-xs text-ios-tertiary border-b border-amber-100 bg-amber-50/20">
-                      <th className="text-left px-2 py-1.5 font-medium">{t.stockName}</th>
-                      <th className="text-left px-2 py-1.5 font-medium">{t.neededBy}</th>
-                      <th className="text-right px-2 py-1.5 font-medium">{t.needed}</th>
-                      <th className="text-left px-2 py-1.5 font-medium">{t.orders}</th>
-                      <th className="px-2 py-1.5"></th>
-                      <th colSpan={6}></th>
-                    </tr>
-                    {neededRows.map(row => (
-                      <Fragment key={row.stockId}>
-                        <tr
-                          className="border-b border-gray-100 hover:bg-amber-50/20 cursor-pointer"
-                          onClick={() => setExpandedNeeded(expandedNeeded === row.stockId ? null : row.stockId)}
-                        >
-                          <td className="px-2 py-1.5 text-ios-label font-medium text-sm truncate">{row.name}</td>
-                          <td className="px-2 py-1.5">{formatDateTag(row.earliestDate, 'amber')}</td>
-                          <td className="px-2 py-1.5 text-right tabular-nums text-base font-bold text-red-600">-{row.needed}</td>
-                          <td className="px-2 py-1.5 text-xs text-ios-secondary">
-                            {row.orders.length}
-                          </td>
-                          <td className="px-2 py-1.5">
-                            {!row.hasPO && <span className="text-[10px] text-red-500 font-medium whitespace-nowrap">⚠ {t.noPO}</span>}
-                          </td>
-                          <td colSpan={6}></td>
-                        </tr>
-                        {expandedNeeded === row.stockId && row.orders.length > 0 && (
-                          <tr className="bg-amber-50/50">
-                            <td colSpan={11} className="px-6 py-1.5">
-                              <div className="space-y-0.5">
-                                {row.orders.map((o, i) => (
-                                  <div
-                                    key={i}
-                                    className="flex items-center justify-between text-xs cursor-pointer hover:underline text-amber-700"
-                                    onClick={e => { e.stopPropagation(); onNavigate?.({ tab: 'orders', filter: { orderId: o.orderId } }); }}
-                                  >
-                                    <span>#{o.appOrderId} — {o.customerName} ({o.requiredBy || '—'})</span>
-                                    <span className="tabular-nums font-medium">{o.qty} {t.stems}</span>
-                                  </div>
-                                ))}
-                              </div>
-                            </td>
-                          </tr>
-                        )}
-                      </Fragment>
-                    ))}
-                  </>
+                  <tr className="text-xs text-ios-tertiary border-b border-amber-100 bg-amber-50/20">
+                    <th className="text-left px-2 py-1.5 font-medium">{t.stockName}</th>
+                    <th className="text-left px-2 py-1.5 font-medium">{t.neededBy}</th>
+                    <th className="text-right px-2 py-1.5 font-medium">{t.needed}</th>
+                    <th className="text-left px-2 py-1.5 font-medium">{t.orders}</th>
+                    <th className="px-2 py-1.5"></th>
+                    <th colSpan={6}></th>
+                  </tr>
                 )}
-              </tbody>
-            )}
+              </thead>
+              {!neededCollapsed && (
+                <tbody>
+                  {neededRows.map(row => (
+                    <Fragment key={row.stockId}>
+                      <tr
+                        className="border-b border-gray-100 hover:bg-amber-50/20 cursor-pointer"
+                        onClick={() => setExpandedNeeded(expandedNeeded === row.stockId ? null : row.stockId)}
+                      >
+                        <td className="px-2 py-1.5 text-ios-label font-medium text-sm truncate">{row.name}</td>
+                        <td className="px-2 py-1.5">{formatDateTag(row.earliestDate, 'amber')}</td>
+                        <td className="px-2 py-1.5 text-right tabular-nums text-base font-bold text-red-600">-{row.needed}</td>
+                        <td className="px-2 py-1.5 text-xs text-ios-secondary">{row.orders.length}</td>
+                        <td className="px-2 py-1.5">
+                          {!row.hasPO && <span className="text-[10px] text-red-500 font-medium whitespace-nowrap">⚠ {t.noPO}</span>}
+                        </td>
+                        <td colSpan={6}></td>
+                      </tr>
+                      {expandedNeeded === row.stockId && row.orders.length > 0 && (
+                        <tr className="bg-amber-50/50">
+                          <td colSpan={11} className="px-6 py-1.5">
+                            <div className="space-y-0.5">
+                              {row.orders.map((o, i) => (
+                                <div key={i} className="flex items-center justify-between text-xs cursor-pointer hover:underline text-amber-700"
+                                     onClick={e => { e.stopPropagation(); onNavigate?.({ tab: 'orders', filter: { orderId: o.orderId } }); }}>
+                                  <span>#{o.appOrderId} — {o.customerName} ({o.requiredBy || '—'})</span>
+                                  <span className="tabular-nums font-medium">{o.qty} {t.stems}</span>
+                                </div>
+                              ))}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  ))}
+                </tbody>
+              )}
+            </table>
+          )}
 
-            {/* ── Section C: AVAILABLE — current stock inventory ── */}
+          {/* ── AVAILABLE — current stock inventory ── */}
+          <table className="w-full text-sm whitespace-nowrap" style={{ tableLayout: 'fixed' }}>
+            <colgroup>
+              <col style={{ width: '24%' }} /><col style={{ width: '7%' }} /><col style={{ width: '6%' }} />
+              <col style={{ width: '7%' }} /><col style={{ width: '7%' }} /><col style={{ width: '5%' }} />
+              <col style={{ width: '8%' }} /><col style={{ width: '7%' }} /><col style={{ width: '6%' }} />
+              <col style={{ width: '6%' }} /><col style={{ width: '17%' }} />
+            </colgroup>
             <thead>
               <tr className="text-xs text-ios-tertiary border-b border-gray-200 bg-gray-50/60">
                 {[

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -114,7 +114,7 @@ router.get('/committed', async (req, res, next) => {
     // Bulk-fetch all order lines
     const allLineIds = orders.flatMap(o => o['Order Lines'] || []);
     const allLines = await listByIds(TABLES.ORDER_LINES, allLineIds, {
-      fields: ['Order', 'Stock Item', 'Quantity', 'Flower Name'],
+      fields: ['Order', 'Stock Item', 'Quantity', 'Flower Name', 'Stock Deferred'],
       maxRecords: 2000,
     });
 
@@ -138,9 +138,12 @@ router.get('/committed', async (req, res, next) => {
       };
     }
 
-    // Aggregate committed quantities per stock item
+    // Aggregate committed quantities per stock item — only deferred lines
+    // (non-deferred lines already had stock deducted at creation, so they're reflected in current qty)
     const committed = {};
     for (const line of allLines) {
+      const isDeferred = line['Stock Deferred'] === true || line['Stock Deferred'] === 'true';
+      if (!isDeferred) continue;
       const stockId = line['Stock Item']?.[0];
       if (!stockId) continue;
       const qty = Number(line.Quantity || 0);


### PR DESCRIPTION
Frontend: Split single <table> into three separate <table> elements (each with identical colgroup + table-layout:fixed) to fix <thead> floating to top. Headers now render in correct section order. Applied stockBaseName() to Planned/Needed names to strip batch suffixes.

Backend: GET /stock/committed now only returns deferred order lines. Non-deferred lines already had stock deducted at creation, so showing them as "needed" was double-counting (e.g. Oxypetalum -6 and Hydrangea -5 were already Ready and deducted from stock).

https://claude.ai/code/session_015ZikGB7FJSwBWj3aveBBhz