### PR TITLE
fix: revert Stock Deferred field (doesn't exist in Airtable), filter …

### DIFF
--- a/apps/dashboard/src/components/StockTab.jsx
+++ b/apps/dashboard/src/components/StockTab.jsx
@@ -248,16 +248,19 @@ export default function StockTab({ initialFilter, onNavigate }) {
     let rows = Object.keys(pendingPO).map(stockId => {
       const po = pendingPO[stockId] || { ordered: 0, pos: [], flowerName: '' };
       const com = committedMap[stockId] || { committed: 0, orders: [] };
+      // Only count "New" orders as committed — Ready orders already have flowers composed
+      const newOrders = (com.orders || []).filter(o => o.status === 'New');
+      const committedQty = newOrders.reduce((sum, o) => sum + (o.qty || 0), 0);
       const stockName = nameMap[stockId] || '';
       const poName = stockBaseName(po.flowerName) || '';
       return {
         stockId,
         name: (poName.length >= stockName.length ? poName : stockName) || '—',
         ordered: po.ordered,
-        committed: com.committed,
-        net: po.ordered - com.committed,
+        committed: committedQty,
+        net: po.ordered - committedQty,
         pos: po.pos || [],
-        orders: com.orders || [],
+        orders: newOrders,
         plannedDate: po.plannedDate || null,
       };
     }).filter(r => r.ordered > 0).sort((a, b) => a.name.localeCompare(b.name));
@@ -265,22 +268,26 @@ export default function StockTab({ initialFilter, onNavigate }) {
     return rows;
   }, [pendingPO, committedMap, stock, search]);
 
-  // Needed rows — flowers committed to future orders (shows demand)
+  // Needed rows — flowers committed to future orders that haven't been composed yet.
+  // Only "New" status orders: once a bouquet is "Ready", the flowers are physically committed.
   const neededRows = useMemo(() => {
     const nameMap = {};
     for (const s of stock) nameMap[s.id] = stockBaseName(s['Display Name']) || s['Purchase Name'] || '';
     let rows = Object.keys(committedMap).map(stockId => {
       const com = committedMap[stockId];
+      // Filter to only New orders — Ready/later orders have already been composed
+      const newOrders = (com.orders || []).filter(o => o.status === 'New');
+      const needed = newOrders.reduce((sum, o) => sum + (o.qty || 0), 0);
       const hasPO = !!pendingPO[stockId];
-      const earliestDate = com.orders.reduce((earliest, o) => {
+      const earliestDate = newOrders.reduce((earliest, o) => {
         if (!o.requiredBy) return earliest;
         return !earliest || o.requiredBy < earliest ? o.requiredBy : earliest;
       }, null);
       return {
         stockId,
         name: nameMap[stockId] || '—',
-        needed: com.committed,
-        orders: com.orders || [],
+        needed,
+        orders: newOrders,
         earliestDate,
         hasPO,
       };

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -114,7 +114,7 @@ router.get('/committed', async (req, res, next) => {
     // Bulk-fetch all order lines
     const allLineIds = orders.flatMap(o => o['Order Lines'] || []);
     const allLines = await listByIds(TABLES.ORDER_LINES, allLineIds, {
-      fields: ['Order', 'Stock Item', 'Quantity', 'Flower Name', 'Stock Deferred'],
+      fields: ['Order', 'Stock Item', 'Quantity', 'Flower Name'],
       maxRecords: 2000,
     });
 
@@ -138,12 +138,9 @@ router.get('/committed', async (req, res, next) => {
       };
     }
 
-    // Aggregate committed quantities per stock item — only deferred lines
-    // (non-deferred lines already had stock deducted at creation, so they're reflected in current qty)
+    // Aggregate committed quantities per stock item
     const committed = {};
     for (const line of allLines) {
-      const isDeferred = line['Stock Deferred'] === true || line['Stock Deferred'] === 'true';
-      if (!isDeferred) continue;
       const stockId = line['Stock Item']?.[0];
       if (!stockId) continue;
       const qty = Number(line.Quantity || 0);
@@ -160,6 +157,7 @@ router.get('/committed', async (req, res, next) => {
           appOrderId: orderInfo.appOrderId,
           customerName: orderInfo.customerName,
           requiredBy: orderInfo.requiredBy,
+          status: orderInfo.status,
           qty,
         });
       }


### PR DESCRIPTION
…by order status

Stock Deferred is an in-memory flag during order creation, never persisted to Airtable. Instead, add order status to committed endpoint response and filter on the frontend: only "New" orders appear in the Needed section and count as Committed in Planned. Ready/later orders have already been physically composed, so they're not "needed."

https://claude.ai/code/session_015ZikGB7FJSwBWj3aveBBhz