### PR TITLE
Fix bouquet editor UX: live totals + single return-to-stock prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,58 @@ AIRTABLE_PREMADE_BOUQUET_LINES_TABLE=tbl...  # Premade Bouquet Lines table ID
 
 ---
 
+## 2026-04-16 — Bouquet Editor UX (florist app): live totals + single return-to-stock prompt
+
+Two annoyances in the florist bouquet editor surfaced while editing an
+existing order:
+
+1. **Double "return to stock" prompt when removing a line.** Tapping ✕ on
+   a flower already opens a per-line dialog (Return / Write-off). After
+   picking an action, pressing **Save** would show the same question again
+   as a second confirmation — the user had to re-choose for a decision
+   they'd already made.
+2. **Totals didn't refresh while editing.** The "Flowers" subtotal and
+   "TOTAL" in the price-summary card kept showing the saved value. To see
+   the effect of adding or removing stems, the owner had to save, see the
+   new total, and decide if they needed to add more — a multi-round trip.
+   Per-line sell price × qty was also not visible while editing.
+
+### Frontend — `apps/florist/src/components/OrderCard.jsx`
+
+- Save handler now only opens the spare-flowers dialog when a line
+  quantity was **reduced inline** (e.g. 10 → 7). Lines fully removed via
+  ✕ already carry `action: 'return' | 'writeoff'` from their per-line
+  dialog, so the second prompt was redundant and has been dropped.
+- Bouquet edit rows now render `{price} zł × {qty}` and `{line total}` under
+  each flower, using the current stock sell price so the owner sees
+  exactly what each line contributes.
+- New live "Flowers" footer inside the editor — sums all lines as
+  quantities change and shows the delta vs. the original order total in
+  red (over) / green (under).
+- Flower picker results now show sell price + quantity (e.g. `65 zł · 12 pcs`)
+  so the owner can pick the right flower by price before adding.
+- `flowerTotal` in the outer Price Summary card now reflects in-memory
+  edits while `editingBouquet` is true (falls back to the saved total
+  otherwise). This propagates to the grand total displayed at the top of
+  the card and below the bouquet.
+
+### Frontend — `packages/shared/hooks/useOrderEditing.js`
+
+- Same single-prompt fix applied to the shared hook used by the dashboard
+  flow and tests, for consistency.
+
+### What to watch for
+
+- The top-of-card price badge now moves while editing — that's intentional
+  so the owner can gauge the new total at a glance, but it means the badge
+  is no longer "what the customer owes right now" during edits.
+- `sellPricePerUnit` on a line is a snapshot at add-time; the editor
+  prefers the live `Current Sell Price` from stock so if an owner
+  mid-editing changes a stock price elsewhere, the editor reflects that
+  immediately. The committed line still snapshots the price at save.
+
+---
+
 ## 2026-04-16 — PO Visibility Fix (partial qty + owner-added lines)
 
 Three related symptoms in the PO flow collapsed onto the same root cause:

--- a/apps/florist/src/components/OrderCard.jsx
+++ b/apps/florist/src/components/OrderCard.jsx
@@ -201,9 +201,19 @@ export default function OrderCard({ order, onOrderUpdated, isOwner }) {
   const d = detail || order;
   const currentStatus = d['Status'] || 'New';
   const currentPaid   = d['Payment Status'] === 'Paid';
-  // Price Override replaces flower total only; delivery fee always added on top
-  const detailLineTotal = (detail?.orderLines || []).reduce((sum, l) =>
+  // Price Override replaces flower total only; delivery fee always added on top.
+  // While editing the bouquet, compute the line total from the in-memory editLines
+  // (using live stock sell prices) so Flowers / Total update as quantities change.
+  const savedLineTotal = (detail?.orderLines || []).reduce((sum, l) =>
     sum + (l['Sell Price Per Unit'] || 0) * (l.Quantity || 0), 0);
+  const editingLineTotal = editingBouquet
+    ? editLines.reduce((sum, l) => {
+        const si = l.stockItemId ? stockItems.find(s => s.id === l.stockItemId) : null;
+        const price = Number(si?.['Current Sell Price'] ?? l.sellPricePerUnit ?? 0);
+        return sum + price * Number(l.quantity || 0);
+      }, 0)
+    : null;
+  const detailLineTotal = editingLineTotal != null ? editingLineTotal : savedLineTotal;
   const detailDeliveryFee = Number(detail?.delivery?.['Delivery Fee'] || d['Delivery Fee'] || 0);
   const flowerTotal = detailLineTotal > 0 ? detailLineTotal : (Number(d['Sell Total']) || 0);
   const currentPrice = (d['Price Override'] || flowerTotal) + detailDeliveryFee;
@@ -350,17 +360,59 @@ export default function OrderCard({ order, onOrderUpdated, isOwner }) {
 
                   {editingBouquet ? (
                     <div className="bg-gray-50 rounded-xl px-3 py-3 space-y-2">
-                      {editLines.map((line, idx) => (
-                        <div key={line.id || idx} className="flex items-center gap-2">
-                          <span className="flex-1 text-sm text-ios-label truncate">{line.flowerName}</span>
-                          <input type="number" min="1" value={line.quantity}
-                            onChange={e => setEditLines(p => p.map((l, i) => i === idx ? { ...l, quantity: e.target.value === '' ? '' : (Number(e.target.value) || 0) } : l))}
-                            onBlur={e => { if (!e.target.value || Number(e.target.value) < 1) setEditLines(p => p.map((l, i) => i === idx ? { ...l, quantity: 1 } : l)); }}
-                            onFocus={e => e.target.select()}
-                            className="w-14 text-center text-sm border border-gray-200 rounded-lg py-1.5" />
-                          <button onClick={() => setRemoveIdx(idx)} className="text-red-400 text-sm px-1">✕</button>
-                        </div>
-                      ))}
+                      {editLines.map((line, idx) => {
+                        const si = line.stockItemId ? stockItems.find(s => s.id === line.stockItemId) : null;
+                        const liveSell = Number(si?.['Current Sell Price'] ?? line.sellPricePerUnit ?? 0);
+                        const qtyNum = Number(line.quantity || 0);
+                        const lineTotal = liveSell * qtyNum;
+                        return (
+                          <div key={line.id || idx} className="flex flex-col gap-0.5">
+                            <div className="flex items-center gap-2">
+                              <span className="flex-1 text-sm text-ios-label truncate">{line.flowerName}</span>
+                              <input type="number" min="1" value={line.quantity}
+                                onChange={e => setEditLines(p => p.map((l, i) => i === idx ? { ...l, quantity: e.target.value === '' ? '' : (Number(e.target.value) || 0) } : l))}
+                                onBlur={e => { if (!e.target.value || Number(e.target.value) < 1) setEditLines(p => p.map((l, i) => i === idx ? { ...l, quantity: 1 } : l)); }}
+                                onFocus={e => e.target.select()}
+                                className="w-14 text-center text-sm border border-gray-200 rounded-lg py-1.5" />
+                              <button onClick={() => setRemoveIdx(idx)} className="text-red-400 text-sm px-1">✕</button>
+                            </div>
+                            <div className="flex justify-between items-baseline pr-12">
+                              <span className="text-xs text-ios-tertiary">
+                                {liveSell > 0 ? `${liveSell.toFixed(0)} zł × ${qtyNum}` : (t.noPriceSet || '—')}
+                              </span>
+                              {liveSell > 0 && (
+                                <span className="text-xs font-semibold text-brand-700">{lineTotal.toFixed(0)} zł</span>
+                              )}
+                            </div>
+                          </div>
+                        );
+                      })}
+
+                      {/* Live flower total — updates as quantities change */}
+                      {editLines.length > 0 && (() => {
+                        const liveSellTotal = editLines.reduce((sum, l) => {
+                          const si = l.stockItemId ? stockItems.find(s => s.id === l.stockItemId) : null;
+                          const price = Number(si?.['Current Sell Price'] ?? l.sellPricePerUnit ?? 0);
+                          return sum + price * Number(l.quantity || 0);
+                        }, 0);
+                        const originalTotal = Number(detail?.['Sell Total'] || 0);
+                        const delta = originalTotal > 0 ? liveSellTotal - originalTotal : 0;
+                        return (
+                          <div className="flex justify-between items-baseline pt-1 border-t border-gray-200">
+                            <span className="text-xs font-semibold text-ios-secondary uppercase tracking-wide">
+                              {t.flowerTotal || 'Flowers'}
+                            </span>
+                            <div className="flex items-center gap-2">
+                              {originalTotal > 0 && delta !== 0 && (
+                                <span className={`text-xs font-bold ${delta > 0 ? 'text-red-500' : 'text-green-600'}`}>
+                                  ({delta > 0 ? '+' : ''}{delta.toFixed(0)})
+                                </span>
+                              )}
+                              <span className="text-sm font-bold text-brand-600">{liveSellTotal.toFixed(0)} zł</span>
+                            </div>
+                          </div>
+                        );
+                      })()}
 
                       {/* Add flower picker */}
                       {!addingFlower ? (
@@ -386,29 +438,34 @@ export default function OrderCard({ order, onOrderUpdated, isOwner }) {
                                 return name.includes(q) && !editLines.some(l => l.stockItemId === s.id);
                               })
                               .slice(0, 6)
-                              .map(s => (
-                                <div key={s.id}
-                                  onPointerDown={e => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    setEditLines(p => [...p, {
-                                      id: null, stockItemId: s.id,
-                                      flowerName: s['Display Name'],
-                                      quantity: 1, _originalQty: 0,
-                                      costPricePerUnit: Number(s['Current Cost Price']) || 0,
-                                      sellPricePerUnit: Number(s['Current Sell Price']) || 0,
-                                    }]);
-                                    setFlowerSearch('');
-                                    setAddingFlower(false);
-                                  }}
-                                  className="w-full text-left px-2 py-2.5 text-sm active:bg-gray-100 dark:active:bg-gray-700 rounded cursor-pointer"
-                                >
-                                  <span className="font-medium">{s['Display Name']}</span>
-                                  <span className="text-xs text-ios-tertiary ml-1">
-                                    ({Number(s['Current Quantity']) || 0} pcs)
-                                  </span>
-                                </div>
-                              ))}
+                              .map(s => {
+                                const stockQty = Number(s['Current Quantity']) || 0;
+                                const stockSell = Number(s['Current Sell Price']) || 0;
+                                return (
+                                  <div key={s.id}
+                                    onPointerDown={e => {
+                                      e.preventDefault();
+                                      e.stopPropagation();
+                                      setEditLines(p => [...p, {
+                                        id: null, stockItemId: s.id,
+                                        flowerName: s['Display Name'],
+                                        quantity: 1, _originalQty: 0,
+                                        costPricePerUnit: Number(s['Current Cost Price']) || 0,
+                                        sellPricePerUnit: stockSell,
+                                      }]);
+                                      setFlowerSearch('');
+                                      setAddingFlower(false);
+                                    }}
+                                    className="w-full text-left px-2 py-2.5 text-sm active:bg-gray-100 dark:active:bg-gray-700 rounded cursor-pointer flex items-center justify-between gap-2"
+                                  >
+                                    <span className="font-medium truncate">{s['Display Name']}</span>
+                                    <span className="text-xs text-ios-tertiary shrink-0">
+                                      {stockSell > 0 && <span className="font-bold text-brand-700">{stockSell.toFixed(0)} zł</span>}
+                                      {' · '}{stockQty} pcs
+                                    </span>
+                                  </div>
+                                );
+                              })}
                             {/* Add unlisted flower */}
                             {flowerSearch.length >= 2 && !stockItems.some(s =>
                               (s['Display Name'] || '').toLowerCase() === flowerSearch.toLowerCase()
@@ -472,11 +529,13 @@ export default function OrderCard({ order, onOrderUpdated, isOwner }) {
                         </div>
                       )}
 
-                      {/* Stock action dialog — shown when Save is tapped and quantities decreased */}
+                      {/* Stock action dialog — shown when Save is tapped and quantities
+                          were reduced inline (e.g. 10→7). Fully-removed lines already
+                          carry their own action from the per-line ✕ dialog. */}
                       {stockAction === 'pending' && (() => {
                         const reduced = editLines.filter(l => l._originalQty > 0 && l.quantity < l._originalQty);
                         const totalReduced = reduced.reduce((s, l) => s + (l._originalQty - l.quantity), 0);
-                        return totalReduced > 0 || removedLines.length > 0 ? (
+                        return totalReduced > 0 ? (
                           <div className="bg-amber-50 rounded-xl px-3 py-3 space-y-2">
                             <p className="text-sm font-medium text-amber-800">
                               {t.spareFlowersQuestion || 'What would you like to do with the spare flowers?'}
@@ -498,14 +557,14 @@ export default function OrderCard({ order, onOrderUpdated, isOwner }) {
 
                       <div className="flex gap-2 pt-1">
                         <button onClick={() => {
-                          // Check if any quantities decreased or lines removed
+                          // Only ask about spare flowers for INLINE quantity reductions.
+                          // Lines removed via ✕ already chose return/writeoff per-line,
+                          // so a second confirmation would be redundant.
                           const hasReductions = editLines.some(l => l._originalQty > 0 && l.quantity < l._originalQty);
-                          const hasRemovals = removedLines.length > 0;
-                          if ((hasReductions || hasRemovals) && stockAction !== 'pending') {
+                          if (hasReductions && stockAction !== 'pending') {
                             setStockAction('pending');
                             return;
                           }
-                          // No reductions — save directly (additions or no changes)
                           doSave(null);
                         }} disabled={saving}
                           className="flex-1 py-2.5 rounded-xl bg-brand-600 text-white text-sm font-semibold"

--- a/packages/shared/hooks/useOrderEditing.js
+++ b/packages/shared/hooks/useOrderEditing.js
@@ -184,13 +184,13 @@ export default function useOrderEditing({ orderId, apiClient, showToast, t }) {
     }
   }
 
-  // Called when the user clicks Save. If quantities were reduced, shows stock
-  // action dialog first. Otherwise saves directly.
-  // Returns a promise that resolves to the refreshed data or null.
+  // Called when the user clicks Save. Only asks about spare flowers when a line
+  // quantity was reduced inline (e.g. 10 → 7) — those stems need a return/writeoff
+  // decision. Fully-removed lines already carry their own action from the per-line
+  // remove dialog, so re-asking would be a redundant second confirmation.
   function handleSaveClick() {
     const hasReductions = editLines.some(l => l._originalQty > 0 && l.quantity < l._originalQty);
-    const hasRemovals = removedLines.length > 0;
-    if ((hasReductions || hasRemovals) && stockAction !== 'pending') {
+    if (hasReductions && stockAction !== 'pending') {
       setStockAction('pending');
       return Promise.resolve(null); // dialog will appear, user picks action, then doSave runs
     }


### PR DESCRIPTION
Two annoyances when editing an existing bouquet on the florist app:

1. Removing a line via the ✕ button asked the user twice whether to return the stems to stock — once in the per-line dialog, then again as a spare-flowers confirmation on Save. The per-line choice already sets action: 'return'|'writeoff' on the removedLines entry, so the second prompt was redundant. Save now only opens the spare-flowers dialog when a line quantity was reduced inline (e.g. 10 → 7), where no action has been recorded yet.

2. While editing, the "Flowers" subtotal and grand "Total" stayed frozen on the saved value. The owner had to save, see the new number, and decide if more stems were needed — a multi-round trip. Per-flower sell price × qty was also hidden until after save.

   - Each edit row now shows "{price} zł × {qty} = {line total}" using the current stock sell price.
   - A live Flowers footer inside the editor sums all lines as quantities change, with delta vs. original shown in red (over) or green (under).
   - The outer Price Summary's flowerTotal now reflects in-memory edits while editingBouquet is true, which propagates to the grand total and the top-of-card price badge.
   - Flower picker rows show sell price next to stock quantity so the owner can pick by price, not guess.

Same single-prompt fix applied to useOrderEditing.handleSaveClick for consistency across the shared hook.

https://claude.ai/code/session_01X4P4FLCfV3P4yutht4Sf9Q