### PR TITLE
Fix editor price lookup: seed sellPrice/costPrice from saved order lines

### DIFF
--- a/apps/florist/src/components/OrderCard.jsx
+++ b/apps/florist/src/components/OrderCard.jsx
@@ -343,6 +343,8 @@ export default function OrderCard({ order, onOrderUpdated, isOwner }) {
                           id: l.id, stockItemId: l['Stock Item']?.[0] || null,
                           flowerName: l['Flower Name'], quantity: l.Quantity,
                           _originalQty: l.Quantity,
+                          costPricePerUnit: Number(l['Cost Price Per Unit']) || 0,
+                          sellPricePerUnit: Number(l['Sell Price Per Unit']) || 0,
                         })));
                         setRemovedLines([]);
                         setAddingFlower(false);
@@ -378,7 +380,7 @@ export default function OrderCard({ order, onOrderUpdated, isOwner }) {
                             </div>
                             <div className="flex justify-between items-baseline pr-12">
                               <span className="text-xs text-ios-tertiary">
-                                {liveSell > 0 ? `${liveSell.toFixed(0)} zł × ${qtyNum}` : (t.noPriceSet || '—')}
+                                {liveSell > 0 ? `${liveSell.toFixed(0)} zł × ${qtyNum}` : '—'}
                               </span>
                               {liveSell > 0 && (
                                 <span className="text-xs font-semibold text-brand-700">{lineTotal.toFixed(0)} zł</span>


### PR DESCRIPTION
Follow-up to the previous bouquet-editor commit. When opening Edit on an existing bouquet, the editLines were seeded from detail.orderLines but without copying sellPricePerUnit / costPricePerUnit. The live-total lookup falls back to stockItems[id]['Current Sell Price'], which is fine for items whose linked stock row currently has a sell price, but in practice several lines ended up with no visible price (the editor rendered a raw 't.noPriceSet' token, and the Flowers footer summed only the one freshly-added line).

- Seed costPricePerUnit and sellPricePerUnit from the saved order line, mirroring how the picker-add path already does it. This is the snapshotted price at order-creation time, which is the correct source of truth when stock data is stale or missing.
- Drop the stray t.noPriceSet reference — that key doesn't exist in translations.js, so it was rendering the literal 'noPriceSet'. Fall back to an em dash.

https://claude.ai/code/session_01X4P4FLCfV3P4yutht4Sf9Q