### PR TITLE
fix: shortfall uses negative-stock signal + trace aggregates siblings

### DIFF
--- a/apps/dashboard/src/components/StockTab.jsx
+++ b/apps/dashboard/src/components/StockTab.jsx
@@ -318,7 +318,24 @@ export default function StockTab({ initialFilter, onNavigate }) {
     let rows = Object.entries(demandByBaseName).map(([base, d]) => {
       const needed = d.needed;
       const aggregateAvailable = availableByBaseName[base] ?? 0;
-      const shortfall = Math.max(0, needed - aggregateAvailable);
+      // Shortfall = how many stems we still need to procure.
+      //
+      // We deliberately compute this as max(0, -aggregateAvailable) rather than
+      // max(0, needed - aggregateAvailable). Reason: order lines deduct from
+      // stock at creation (orderService.editBouquetLines line 385 and the
+      // create-order flow). Once deducted, the demand is ALREADY reflected in
+      // Current Quantity — subtracting "needed" again would double-count.
+      // Example: base=0 → order 7 → base=-7. The -7 IS the shortfall; adding
+      // the committed 7 on top gives the nonsensical 14 that prompted this fix.
+      //
+      // The only case this misses is a manually-deferred line (owner toggled
+      // stockDeferred during order creation). That workflow is opt-in and
+      // requires the "Stock Deferred" field on Order Lines in Airtable. Until
+      // that field is added to the production base, deferred lines would be
+      // invisible here — but they're also invisible at order creation (no
+      // deduction occurs), so the negative-stock signal continues to apply
+      // whenever the florist tries to consume them.
+      const shortfall = Math.max(0, -aggregateAvailable);
       const hasPO = d.stockIds.some(id => !!pendingPO[id]);
       const earliestDate = d.orders.reduce((earliest, o) => {
         if (!o.requiredBy) return earliest;
@@ -840,7 +857,7 @@ export default function StockTab({ initialFilter, onNavigate }) {
                         <td className="px-2 py-1.5 text-right tabular-nums">
                           <div className="text-base font-bold text-red-600">-{row.shortfall}</div>
                           <div className="text-[10px] text-ios-tertiary font-normal">
-                            {row.currentQty} / {row.needed}
+                            {row.currentQty} {t.stems || 'stems'}
                           </div>
                         </td>
                         <td className="px-2 py-1.5 text-xs text-ios-secondary">{row.orders.length}</td>

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -381,19 +381,48 @@ router.get('/:id/usage', async (req, res, next) => {
     const displayName = stockItem['Display Name'] || '';
     const stockId = req.params.id;
 
-    // 1. Order lines — filter by Flower Name (linked record IDs aren't searchable
-    //    in Airtable formulas). Use exact Display Name only — not Purchase Name,
-    //    which would match all batches of the same flower type.
-    const safeName = sanitizeFormulaValue(displayName);
+    // Aggregate across sibling batches sharing the same base flower name.
+    // receiveIntoStock creates a new dated batch record for each receive,
+    // and order lines stay linked to whichever record existed at creation —
+    // so an order's usage and a PO's receipt often live on different stock
+    // records even though they refer to the same physical flower. The trace
+    // should show the full picture for the flower, not just this one record.
+    const dateBatchRe = /^(.+?)\s*\(\d{1,2}\.\w{3,4}\.?\)$/;
+    const baseName = (displayName.match(dateBatchRe)?.[1] || displayName).trim();
+    const safeBase = sanitizeFormulaValue(baseName);
+    // Find all sibling stock records: the base record itself, plus any
+    // "<base> (dd.Mmm.)" dated batches.
+    let siblingStocks = [];
+    try {
+      siblingStocks = await db.list(TABLES.STOCK, {
+        filterByFormula: `OR({Display Name} = '${safeBase}', FIND('${safeBase} (', {Display Name} & '') = 1)`,
+        fields: ['Display Name', 'Current Quantity'],
+      });
+    } catch {
+      siblingStocks = [stockItem];
+    }
+    // Ensure the requested record is always in the set (in case the formula
+    // misses due to whitespace/punctuation differences).
+    if (!siblingStocks.some(s => s.id === stockId)) siblingStocks.push(stockItem);
+    const siblingIds = new Set(siblingStocks.map(s => s.id));
+    const siblingNames = siblingStocks.map(s => s['Display Name']).filter(Boolean);
+
+    // 1. Order lines — build an OR-formula that matches any of the sibling
+    //    display names (the Flower Name stamped on each line at creation).
+    //    Then keep only lines whose Stock Item link resolves to one of the
+    //    siblings, so we don't accidentally pick up unrelated records that
+    //    happen to share a name fragment.
+    const orSafeNames = siblingNames.map(n => `{Flower Name} = '${sanitizeFormulaValue(n)}'`);
+    const orderLineFormula = orSafeNames.length > 0 ? `OR(${orSafeNames.join(', ')})` : `{Flower Name} = '${safeBase}'`;
     const orderLines = await db.list(TABLES.ORDER_LINES, {
-      filterByFormula: `{Flower Name} = '${safeName}'`,
+      filterByFormula: orderLineFormula,
       fields: ['Order', 'Flower Name', 'Quantity', 'Sell Price Per Unit', 'Cost Price Per Unit', 'Stock Item'],
     });
-    // Keep only lines linked to THIS specific stock item — excludes unlinked lines
-    // and lines from other batches that happen to share the same base name.
     const matchedLines = orderLines.filter(l => {
       const linkedId = l['Stock Item']?.[0];
-      return linkedId === stockId;
+      // No link → still keep if the name matched, so orphan lines are surfaced.
+      if (!linkedId) return true;
+      return siblingIds.has(linkedId);
     });
 
     // Fetch parent orders for context
@@ -441,7 +470,7 @@ router.get('/:id/usage', async (req, res, next) => {
           sort: [{ field: 'Date', direction: 'desc' }],
         });
         usageLosses = allLosses
-          .filter(l => l['Stock Item']?.[0] === stockId)
+          .filter(l => siblingIds.has(l['Stock Item']?.[0]))
           .map(l => ({
             type: 'writeoff',
             date: l.Date || null,
@@ -464,7 +493,7 @@ router.get('/:id/usage', async (req, res, next) => {
         sort: [{ field: 'Purchase Date', direction: 'desc' }],
         maxRecords: 500,
       });
-      const linePurchases = allPurchases.filter(p => p.Flower?.[0] === stockId);
+      const linePurchases = allPurchases.filter(p => siblingIds.has(p.Flower?.[0]));
 
       // Parse PO marker from Notes; batch-fetch the parent POs to resolve
       // Stock Order ID. The marker is a stable format produced by the


### PR DESCRIPTION
Two issues in the Needed/Trace panels surfaced by real data:

1. Shortfall was double-counting. For Peony Coral with Current Quantity = -7 and one committed order for 7 stems, the formula needed - aggregateAvailable gave 7 - (-7) = 14 (displayed as -14). The order's 7 stems are ALREADY in the -7 (stock was deducted at order creation); adding them again via committed overcounts.

   Switched to shortfall = max(0, -aggregateAvailable). Negative stock is the only direct signal that we owe stems we don't have. If the order is future-dated but stock is still positive, the deduction has already reserved what we need, so no shortfall is reported (Rose Spray Gizelle: base=0 + batch=4 covers the pre-deducted 6 in the order - or rather, the 6 were already taken from the original 10, leaving 4).

   Limitation noted in-code: manually-deferred lines (Stock Deferred = true) won't be surfaced until that field lands in the production Airtable base. The owner's toggle opt-in flow is not common; when she does use it, the florist sees the shortage via the negative stock signal as soon as she tries to compose the bouquet.

2. Trace only showed the PO arrival for Matthiola White, not the customer order that consumed stems, because the filter was `{Flower Name} = 'Matthiola White (16.Apr.)'` (exact match on the batch's display name) and the order line's Flower Name was the base "Matthiola White" linked to the original base record.

   /stock/:id/usage now finds all sibling stock records sharing the same base name (via OR formula on Display Name), then queries ORDER_LINES for any of those sibling names and keeps lines whose Stock Item link resolves to any sibling. Same expansion applied to Stock Loss Log and Stock Purchases lookups. Trace on any batch or base record now shows the full flower history (receipts
   + order usage + write-offs) regardless of which record the activity was posted against.