### PR TITLE
Add multilingual support for "Available Today" category

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -158,7 +158,7 @@ Features and improvements tracked against original build phases.
 - [ ] **Error monitoring** — Sentry or similar for production error tracking
 - [ ] **Wix Velo integration** — frontend consuming public API (blocked on pre-build checklist)
   - [ ] Restrict same-day delivery slots to "Available Today" bouquets only (Velo checkout logic)
-  - [ ] Hide "Available Today" nav item via Velo when `/api/public/categories` omits it (post-cutoff)
+  - [x] Hide "Available Today" nav item via Velo when `/api/public/categories` omits it (post-cutoff) — Velo helpers `getAvailableTodayMenuLabel()` + `isAvailableTodayActive()` added in `docs/wix-velo-categories.js` (2026-04-17)
   - [ ] Use `filteredTimeSlots` from `/api/public/delivery-pricing?date=` for Wix checkout time picker
 
 ### PO Substitution — Phase B (2026-04-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,78 @@ AIRTABLE_PREMADE_BOUQUET_LINES_TABLE=tbl...  # Premade Bouquet Lines table ID
 
 ---
 
+## 2026-04-17 — Wix "Available Today" now multilingual
+
+The "Available Today" nav item only rendered on the English version of the
+storefront. Adding products with Lead Time = 0 and the `Available Today`
+category assignment correctly populated the Wix collection, but:
+
+- Polish / Russian / Ukrainian visitors never saw the menu link.
+- Clicking the English link and then switching language kept an English
+  heading on the category page.
+
+### Root cause
+
+Three gaps all pointing at the same pattern:
+
+1. **`backend/src/routes/settings.js:44-56`** — the default auto-category
+   entry shipped with empty `en/pl/ru/uk` translations. The Velo helper
+   `applyLang()` in `docs/wix-velo-categories.js` falls through to the
+   hardcoded English `cat.name` when translation strings are empty, so
+   the menu label stayed in English for every locale.
+2. **`docs/wix-velo-categories.js`** — a `getSeasonalMenuLabel()` helper +
+   masterPage example existed for the seasonal category, but nothing
+   equivalent for Available Today, so the owner had no language-aware way
+   to swap the menu text or hide the item when `productCount === 0`.
+3. **`backend/src/services/wixProductSync.js:637-674`** — the push path
+   assigned products to the Wix collection but (unlike the seasonal path
+   a few lines above) never called `updateWixCategory()` to sync the
+   collection's own name + description, so Wix's native menu fallback
+   stayed in whatever language the owner used when creating the
+   collection manually.
+
+### Changes
+
+- `backend/src/routes/settings.js`
+  - Seeded `storefrontCategories.auto[Available Today]` defaults with real
+    `en/pl/ru/uk` titles and descriptions.
+  - New `migrateAutoCategoryTranslations()` — on startup, backfills any
+    empty title/description fields from the defaults so the Airtable-stored
+    config catches up without the owner re-saving the settings tab.
+- `docs/wix-velo-categories.js`
+  - New helpers: `getAvailableTodayMenuLabel()`, `getAvailableTodayTitle()`,
+    `getAvailableTodayDescription()`, `isAvailableTodayActive()`. Mirrors
+    the seasonal helpers and reads `productCount` from
+    `/api/public/categories` to drive visibility.
+  - Extended the masterPage.js usage example to show how to set the menu
+    label text and `.expand()/.collapse()` the nav item based on
+    `isAvailableTodayActive()`. masterPage.js runs on every language
+    version, so one piece of code handles EN/PL/RU/UK.
+- `backend/src/services/wixProductSync.js`
+  - `runPush()` now pushes the Available Today collection's EN title +
+    description to Wix (only when a translation is configured), mirroring
+    the seasonal path. Keeps the Wix-native collection label in sync with
+    the owner's translations and prevents the nav item from disappearing
+    in other languages when Wix Multilingual resolves the collection name.
+
+### What to watch for
+
+- **Backfill runs on the next backend restart.** The migration only writes
+  back to Airtable when it actually fills in missing values, so a steady
+  log line is `[SETTINGS] Backfilled auto-category translations` once,
+  then silence.
+- **Owner still needs a placeholder element** (`#availableTodayMenu` +
+  `#availableTodayMenuText`) on the Wix masterPage for the Velo helpers
+  to bind to. If those IDs don't exist yet, the console will show
+  "Available Today menu update failed"; the rest of the site is
+  unaffected.
+- **Cutoff behavior unchanged** — products are still removed from the
+  collection only by owner action (deactivating the product) or when
+  stock drops below `Min Stems`. The new visibility helper just mirrors
+  whatever the backend reports.
+
+---
+
 ## 2026-04-16 — Bouquet Editor UX (florist app): live totals + single return-to-stock prompt
 
 Two annoyances in the florist bouquet editor surfaced while editing an

--- a/backend/src/routes/settings.js
+++ b/backend/src/routes/settings.js
@@ -42,7 +42,17 @@ const DEFAULTS = {
       { name: 'Christmas',       slug: 'christmas',      from: '12-01', to: '12-26', description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
     ],
     auto: [
-      { name: 'Available Today', slug: 'available-today', description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
+      {
+        name: 'Available Today',
+        slug: 'available-today',
+        description: 'Bouquets ready for same-day delivery or pickup.',
+        translations: {
+          en: { title: 'Available Today',   description: 'Bouquets ready for same-day delivery or pickup.' },
+          pl: { title: 'Dostępne dziś',     description: 'Bukiety gotowe do dostawy lub odbioru tego samego dnia.' },
+          ru: { title: 'Доступно сегодня',  description: 'Букеты, готовые к доставке или самовывозу сегодня.' },
+          uk: { title: 'Доступно сьогодні', description: 'Букети, готові до доставки або самовивозу сьогодні.' },
+        },
+      },
     ],
     autoSchedule: true,
     manualOverride: null,
@@ -94,6 +104,8 @@ async function loadConfig() {
         migrateSeasonalDates();
         // Migrate: convert permanent/auto from string arrays to object arrays
         migrateCategoryObjects();
+        // Migrate: backfill default translations for auto categories if empty
+        migrateAutoCategoryTranslations();
         // Migrate: floristRates from flat { name: number } to { name: { type: number } }
         migrateFloristRates();
       }
@@ -228,6 +240,54 @@ function migrateCategoryObjects() {
   if (changed) {
     saveConfig().catch(err =>
       console.error('[SETTINGS] Category migration save failed:', err.message)
+    );
+  }
+}
+
+/**
+ * Backfill default translations for auto categories (e.g. "Available Today")
+ * when the stored config has empty title/description strings. The Wix site's
+ * Velo code resolves menu labels by slug and falls through to the hardcoded
+ * English `cat.name` when translations are empty — which is why the menu only
+ * rendered in the English language. Filling in real EN/PL/RU/UK strings lets
+ * the menu label translate automatically across all languages.
+ */
+function migrateAutoCategoryTranslations() {
+  const sc = config.storefrontCategories;
+  if (!sc?.auto || !Array.isArray(sc.auto)) return;
+  let changed = false;
+
+  for (const stored of sc.auto) {
+    if (!stored || typeof stored !== 'object') continue;
+    const defaultEntry = (DEFAULTS.storefrontCategories.auto || [])
+      .find(d => d.slug === stored.slug);
+    if (!defaultEntry) continue;
+    if (!stored.translations) stored.translations = {};
+
+    for (const lang of ['en', 'pl', 'ru', 'uk']) {
+      const storedLang = stored.translations[lang] || {};
+      const defaultLang = defaultEntry.translations?.[lang] || {};
+      if (!storedLang.title && defaultLang.title) {
+        storedLang.title = defaultLang.title;
+        changed = true;
+      }
+      if (!storedLang.description && defaultLang.description) {
+        storedLang.description = defaultLang.description;
+        changed = true;
+      }
+      stored.translations[lang] = storedLang;
+    }
+
+    if (!stored.description && defaultEntry.description) {
+      stored.description = defaultEntry.description;
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    console.log('[SETTINGS] Backfilled auto-category translations');
+    saveConfig().catch(err =>
+      console.error('[SETTINGS] Auto-category translation backfill save failed:', err.message)
     );
   }
 }

--- a/backend/src/services/wixProductSync.js
+++ b/backend/src/services/wixProductSync.js
@@ -637,6 +637,25 @@ export async function runPush() {
       const availTodayId = catMap['available-today'];
       console.log(`[PUSH] Available Today: wixCatId=${availTodayId}`);
       if (availTodayId) {
+        // Keep the Wix collection's own name/description in sync with the
+        // owner-configured EN translation. Mirrors the seasonal path above —
+        // without this, the Wix-native collection label stays whatever the
+        // owner typed when creating the collection, which meant Wix only
+        // rendered the nav item in the primary (English) language.
+        try {
+          const availEntry = (sc.auto || []).find(a => a && a.slug === 'available-today');
+          const enTitle = availEntry?.translations?.en?.title;
+          const enDesc = availEntry?.translations?.en?.description;
+          if (enTitle || enDesc) {
+            await updateWixCategory(availTodayId, {
+              name: enTitle || availEntry?.name || 'Available Today',
+              description: enDesc || '',
+            });
+          }
+        } catch (err) {
+          stats.errors.push(`Available Today category name: ${err.message}`);
+        }
+
         const stockCheck = await db.list(TABLES.STOCK, {
           filterByFormula: '{Active} = TRUE()',
           fields: ['Display Name', 'Current Quantity'],

--- a/docs/wix-velo-categories.js
+++ b/docs/wix-velo-categories.js
@@ -102,6 +102,58 @@ export async function getSeasonalDescription() {
   return result.description;
 }
 
+// ── Available Today helpers ──────────────────────────────────
+// Mirror of the seasonal helpers so masterPage.js can render the
+// "Available Today" nav item in every language (not just English).
+// Visibility is driven by `productCount` returned by the backend —
+// show only when there's at least one qualifying product.
+
+function findAuto(data, slug) {
+  if (!data) return null;
+  if (data.categoryMap && data.categoryMap[slug]) return data.categoryMap[slug];
+  return (data.auto || []).find(a => a && a.slug === slug) || null;
+}
+
+/**
+ * True when the "Available Today" category has qualifying products.
+ * `productCount` is set server-side in /api/public/categories.
+ * Returns false if the backend is unreachable (safer to hide than to
+ * show a category that leads to an empty page).
+ */
+export async function isAvailableTodayActive() {
+  const data = await getCategories();
+  const cat = findAuto(data, 'available-today');
+  if (!cat) return false;
+  return typeof cat.productCount === 'number' && cat.productCount > 0;
+}
+
+/**
+ * Get the "Available Today" category name for the NAV MENU — always CAPS.
+ * e.g., "AVAILABLE TODAY", "DOSTĘPNE DZIŚ", "ДОСТУПНО СЕГОДНЯ", "ДОСТУПНО СЬОГОДНІ".
+ */
+export async function getAvailableTodayMenuLabel() {
+  const data = await getCategories();
+  const cat = findAuto(data, 'available-today');
+  if (!cat) return 'AVAILABLE TODAY';
+  return applyLang(cat, getCurrentLang()).menuLabel;
+}
+
+/** Get the "Available Today" category title (normal case, for page headings). */
+export async function getAvailableTodayTitle() {
+  const data = await getCategories();
+  const cat = findAuto(data, 'available-today');
+  if (!cat) return 'Available Today';
+  return applyLang(cat, getCurrentLang()).name;
+}
+
+/** Get the "Available Today" category description (translated). */
+export async function getAvailableTodayDescription() {
+  const data = await getCategories();
+  const cat = findAuto(data, 'available-today');
+  if (!cat) return '';
+  return applyLang(cat, getCurrentLang()).description;
+}
+
 /**
  * Get full category structure with translations applied for current language.
  */
@@ -127,14 +179,42 @@ export async function getAllCategories() {
 // ────────────────────────────────────────────────────────────
 // MASTER PAGE CODE — paste this into masterPage.js
 // ────────────────────────────────────────────────────────────
+// masterPage.js runs on every language version of the site, so updating
+// element text here translates the menu items for EN / PL / RU / UK in
+// one place. Use placeholder text elements (e.g. #seasonalMenuText,
+// #availableTodayMenuText) inside your header menu and let Velo fill
+// them with the translated label.
 //
-// import { getSeasonalMenuLabel } from 'public/blossomCategories.js';
+// import {
+//   getSeasonalMenuLabel,
+//   getAvailableTodayMenuLabel,
+//   isAvailableTodayActive,
+// } from 'public/blossomCategories.js';
 //
 // $w.onReady(async function () {
+//   // Seasonal
 //   try {
 //     const menuLabel = await getSeasonalMenuLabel();
 //     $w('#seasonalMenuText').text = menuLabel;
-//   } catch (e) { console.error('Menu update failed:', e); }
+//   } catch (e) { console.error('Seasonal menu update failed:', e); }
+//
+//   // Available Today — show in ALL languages when products qualify,
+//   // hide when the backend reports productCount === 0 (e.g. no lead-time-0
+//   // items left after the cutoff).
+//   try {
+//     const [label, active] = await Promise.all([
+//       getAvailableTodayMenuLabel(),
+//       isAvailableTodayActive(),
+//     ]);
+//     $w('#availableTodayMenuText').text = label;
+//     if (active) {
+//       $w('#availableTodayMenu').expand();
+//       $w('#availableTodayMenu').show();
+//     } else {
+//       $w('#availableTodayMenu').collapse();
+//       $w('#availableTodayMenu').hide();
+//     }
+//   } catch (e) { console.error('Available Today menu update failed:', e); }
 // });
 //
 // ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The "Available Today" nav item was only rendering on the English version of the storefront, even though products with Lead Time = 0 were correctly assigned to the category. This PR adds full multilingual support (EN/PL/RU/UK) for the category menu label, title, and description, and ensures the Wix collection itself stays in sync with the owner's translations.

## Key Changes

- **`backend/src/routes/settings.js`**
  - Seeded the "Available Today" auto-category defaults with real EN/PL/RU/UK titles and descriptions
  - Added `migrateAutoCategoryTranslations()` function to backfill empty translation fields from defaults on startup, ensuring the Airtable-stored config catches up without manual re-save

- **`docs/wix-velo-categories.js`**
  - Added four new helper functions mirroring the seasonal category pattern:
    - `isAvailableTodayActive()` — checks if the category has qualifying products (reads `productCount` from backend)
    - `getAvailableTodayMenuLabel()` — returns the translated menu label in CAPS
    - `getAvailableTodayTitle()` — returns the translated category title
    - `getAvailableTodayDescription()` — returns the translated description
  - Extended the masterPage.js code example to show how to bind the menu label text and control visibility (expand/collapse/show/hide) based on `isAvailableTodayActive()`
  - Updated comments to clarify that masterPage.js runs on every language version, so one piece of code handles all locales

- **`backend/src/services/wixProductSync.js`**
  - Modified `runPush()` to sync the "Available Today" collection's EN title and description to Wix, mirroring the seasonal category behavior
  - This ensures the Wix-native collection label stays in sync with owner translations and prevents the nav item from disappearing in other languages

- **`CHANGELOG.md`**
  - Documented the root causes, changes, and migration behavior for this fix

## Implementation Details

- The migration runs automatically on the next backend restart and only writes to Airtable if it actually fills in missing values
- The Velo helpers read from `/api/public/categories` which includes `productCount` set server-side, allowing the menu to hide when no qualifying products exist
- Owners must have placeholder elements (`#availableTodayMenu` and `#availableTodayMenuText`) on their Wix masterPage for the helpers to bind to
- The cutoff behavior is unchanged — products are removed from the collection only by owner action or when stock drops below minimum

https://claude.ai/code/session_01QYpjARK8ucWadGBTBTegw7