### PR TITLE
fix(wix): push PL/RU/UK collection translations + docs for Available Today nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,15 +99,55 @@ Three gaps all pointing at the same pattern:
   back to Airtable when it actually fills in missing values, so a steady
   log line is `[SETTINGS] Backfilled auto-category translations` once,
   then silence.
-- **Owner still needs a placeholder element** (`#availableTodayMenu` +
-  `#availableTodayMenuText`) on the Wix masterPage for the Velo helpers
-  to bind to. If those IDs don't exist yet, the console will show
-  "Available Today menu update failed"; the rest of the site is
-  unaffected.
 - **Cutoff behavior unchanged** — products are still removed from the
   collection only by owner action (deactivating the product) or when
   stock drops below `Min Stems`. The new visibility helper just mirrors
   whatever the backend reports.
+
+### Addendum — real root cause of the symptom (verified against the live site)
+
+The original description above assumed the Velo side of the fix was the
+new `#availableTodayMenu` / `#availableTodayMenuText` placeholder-element
+pattern. Verifying against the deployed Velo code (the adjacent
+`blossom-wix` repo, `src/pages/masterPage.js`) showed that's not how the
+site actually renders this nav item:
+
+- The deployed masterPage.js does NOT use `#availableTodayMenu` /
+  `#availableTodayMenuText`. It reads `$w('#horizontalMenu1').menuItems`,
+  finds the item whose `link` contains `/category/available-today`, and
+  mutates its label + position (or drops it when `productCount === 0`).
+- The Wix horizontal menu is translated **per-language** in the Wix
+  Editor. The owner added the Available Today item to the English menu
+  only, so the PL / RU / UK versions' `menuItems` didn't contain it —
+  nothing for Velo to rename or reorder, so the link never appeared.
+- `GET /api/public/categories` was verified against the live backend and
+  correctly returns `auto[0].productCount` plus `translations.{en,pl,ru,uk}`
+  for the available-today slug.
+
+**Owner action — required for the fix to take effect:** in the Wix
+Editor, switch to each non-English language (Polish, Russian, Ukrainian)
+and add an "Available Today" entry to the header horizontal menu,
+linked to `/category/available-today`. The label text is irrelevant —
+masterPage.js overwrites it from the backend translations on every page
+load. Velo cannot synthesize a menu item that isn't configured in the
+Editor for that language.
+
+The backend changes from this commit are still correct and still
+required:
+
+- `settings.js` translation seeds + backfill ensure the translated
+  labels exist once the owner adds the per-language menu items.
+- `wixProductSync.js` `updateWixCategory()` on Available Today mirrors
+  the seasonal path for consistency with how the Wix-native collection
+  name is kept in sync.
+- The 4 new Velo helpers (`getAvailableTodayMenuLabel`,
+  `getAvailableTodayTitle`, `getAvailableTodayDescription`,
+  `isAvailableTodayActive`) are harmless and usable for category-page
+  headings or any layout that binds Available Today to a standalone
+  text element. The deployed masterPage.js doesn't import them — it
+  inlines the lookup against the menu's items. The masterPage example
+  in `docs/wix-velo-categories.js` has been updated to match the real
+  pattern so a future paste won't conflict with the existing wiring.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,50 +104,54 @@ Three gaps all pointing at the same pattern:
   stock drops below `Min Stems`. The new visibility helper just mirrors
   whatever the backend reports.
 
-### Addendum — real root cause of the symptom (verified against the live site)
+### Addendum — real root cause + follow-up fix
 
-The original description above assumed the Velo side of the fix was the
-new `#availableTodayMenu` / `#availableTodayMenuText` placeholder-element
-pattern. Verifying against the deployed Velo code (the adjacent
-`blossom-wix` repo, `src/pages/masterPage.js`) showed that's not how the
-site actually renders this nav item:
+Two earlier guesses about the root cause were wrong. What actually
+blocked the PL / RU / UK menu link:
 
-- The deployed masterPage.js does NOT use `#availableTodayMenu` /
-  `#availableTodayMenuText`. It reads `$w('#horizontalMenu1').menuItems`,
-  finds the item whose `link` contains `/category/available-today`, and
-  mutates its label + position (or drops it when `productCount === 0`).
-- The Wix horizontal menu is translated **per-language** in the Wix
-  Editor. The owner added the Available Today item to the English menu
-  only, so the PL / RU / UK versions' `menuItems` didn't contain it —
-  nothing for Velo to rename or reorder, so the link never appeared.
-- `GET /api/public/categories` was verified against the live backend and
-  correctly returns `auto[0].productCount` plus `translations.{en,pl,ru,uk}`
-  for the available-today slug.
+- Wix Stores menu items are Store-page links. They don't get per-language
+  translations from the Site Menu panel, and they don't get one from
+  `masterPage.js` renaming either — if the linked **Wix Stores collection
+  itself** has no translation for the visitor's locale, Wix strips the
+  link from the non-primary-language site entirely. No amount of Velo
+  mutation on `$w('#horizontalMenu1').menuItems` can add back a link
+  Wix refused to render in the first place.
+- 1fffa70 seeded PL / RU / UK strings in Airtable config and pushed the
+  EN title/description to the Wix collection via `updateWixCategory()`,
+  but never pushed the PL / RU / UK strings anywhere Wix would read them.
 
-**Owner action — required for the fix to take effect:** in the Wix
-Editor, switch to each non-English language (Polish, Russian, Ukrainian)
-and add an "Available Today" entry to the header horizontal menu,
-linked to `/category/available-today`. The label text is irrelevant —
-masterPage.js overwrites it from the backend translations on every page
-load. Velo cannot synthesize a menu item that isn't configured in the
-Editor for that language.
+**Follow-up fix (this addendum):**
 
-The backend changes from this commit are still correct and still
-required:
+- New `pushCollectionTranslations()` helper in
+  `backend/src/services/wixProductSync.js`. Writes PL / RU / UK
+  titles + descriptions to the Wix Multilingual Translation Content
+  API (schema `5b35dfe1-da21-4071-aab5-2cec870459c0` — Wix Stores
+  collections; fields `collection-name` + `category-description`),
+  marking them `published: true`. Runs after the existing EN
+  `updateWixCategory()` call for both seasonal and Available Today.
+  Query-then-create-or-update so re-runs are idempotent; skips any
+  locale whose Airtable config has blank title + description so
+  translations the owner typed by hand in the Wix Translation Manager
+  aren't overwritten.
+- Locale codes verified against `/locale-settings/v2/settings` — the
+  site uses short codes (`en`, `pl`, `ru`, `uk`), not regional
+  variants (`en-us`).
+- One-shot API call from this session pushed the PL / RU / UK
+  translations for Available Today directly, so the nav link appears
+  on non-English sites without waiting for the next backend redeploy.
 
-- `settings.js` translation seeds + backfill ensure the translated
-  labels exist once the owner adds the per-language menu items.
-- `wixProductSync.js` `updateWixCategory()` on Available Today mirrors
-  the seasonal path for consistency with how the Wix-native collection
-  name is kept in sync.
-- The 4 new Velo helpers (`getAvailableTodayMenuLabel`,
-  `getAvailableTodayTitle`, `getAvailableTodayDescription`,
-  `isAvailableTodayActive`) are harmless and usable for category-page
-  headings or any layout that binds Available Today to a standalone
-  text element. The deployed masterPage.js doesn't import them — it
-  inlines the lookup against the menu's items. The masterPage example
-  in `docs/wix-velo-categories.js` has been updated to match the real
-  pattern so a future paste won't conflict with the existing wiring.
+### What the earlier Velo correction is still good for
+
+The masterPage example rewrite in `docs/wix-velo-categories.js`
+(committed earlier on this branch) is independently useful: it matches
+the deployed `blossom-wix/src/pages/masterPage.js` pattern
+(`$w('#horizontalMenu1').menuItems` mutation) instead of the fictional
+`#availableTodayMenu` / `#availableTodayMenuText` placeholder elements
+that were in 1fffa70. So a future paste won't conflict with the
+existing header wiring. The four helpers (`getAvailableTodayMenuLabel`,
+`getAvailableTodayTitle`, `getAvailableTodayDescription`,
+`isAvailableTodayActive`) remain available for any page that binds
+Available Today to a standalone text element.
 
 ---
 

--- a/backend/src/services/wixProductSync.js
+++ b/backend/src/services/wixProductSync.js
@@ -218,6 +218,84 @@ async function updateWixCategory(id, { name, description }) {
   }
 }
 
+// Schema identifying Wix Stores Collections in the Wix Multilingual Translation
+// Content API. Discovered by querying an existing collection's translation
+// content. Field keys: "collection-name" and "category-description".
+const STORES_COLLECTION_SCHEMA_ID = '5b35dfe1-da21-4071-aab5-2cec870459c0';
+const SECONDARY_LOCALES = ['pl', 'ru', 'uk'];
+
+/**
+ * Push PL/RU/UK translations to Wix Multilingual for a Stores collection.
+ * Wix hides untranslated store collections from non-primary language menus,
+ * so without this the category's menu link never renders on the PL/RU/UK
+ * sites. EN is the primary locale and lives directly on the Stores
+ * collection — updated via updateWixCategory().
+ *
+ * Flow: query → create missing locales, update existing locales.
+ * Skips any locale whose Airtable config has blank title + description,
+ * so we don't overwrite translations the owner added via Wix Translation
+ * Manager.
+ */
+async function pushCollectionTranslations(entityId, translations) {
+  if (!entityId || !translations) return;
+
+  const targetFields = {};
+  for (const locale of SECONDARY_LOCALES) {
+    const t = translations[locale];
+    if (!t) continue;
+    const fields = {};
+    if (t.title) fields['collection-name'] = { textValue: t.title, published: true, updatedBy: 'USER' };
+    if (t.description) fields['category-description'] = { textValue: t.description, published: true, updatedBy: 'USER' };
+    if (Object.keys(fields).length > 0) targetFields[locale] = fields;
+  }
+  if (Object.keys(targetFields).length === 0) return;
+
+  const qRes = await fetch(`${WIX_API_URL}/translation-content/v1/contents/query`, {
+    method: 'POST',
+    headers: wixHeaders(),
+    body: JSON.stringify({ query: { filter: { entityId }, cursorPaging: { limit: 50 } } }),
+  });
+  if (!qRes.ok) {
+    throw new Error(`Translation query failed for ${entityId}: ${await qRes.text()}`);
+  }
+  const existingByLocale = ((await qRes.json()).contents || []).reduce((m, c) => {
+    m[c.locale] = c.id;
+    return m;
+  }, {});
+
+  const toCreate = [];
+  const toUpdate = [];
+  for (const [locale, fields] of Object.entries(targetFields)) {
+    if (existingByLocale[locale]) {
+      toUpdate.push({ content: { id: existingByLocale[locale], schemaId: STORES_COLLECTION_SCHEMA_ID, fields } });
+    } else {
+      toCreate.push({ schemaId: STORES_COLLECTION_SCHEMA_ID, entityId, locale, fields });
+    }
+  }
+
+  if (toCreate.length > 0) {
+    const cRes = await fetch(`${WIX_API_URL}/translation-content/v1/bulk/contents/create`, {
+      method: 'POST',
+      headers: wixHeaders(),
+      body: JSON.stringify({ contents: toCreate, returnEntity: false }),
+    });
+    if (!cRes.ok) {
+      throw new Error(`Translation bulk create failed for ${entityId}: ${await cRes.text()}`);
+    }
+  }
+
+  if (toUpdate.length > 0) {
+    const uRes = await fetch(`${WIX_API_URL}/translation-content/v1/bulk/contents/update`, {
+      method: 'POST',
+      headers: wixHeaders(),
+      body: JSON.stringify({ contents: toUpdate, returnEntity: false }),
+    });
+    if (!uRes.ok) {
+      throw new Error(`Translation bulk update failed for ${entityId}: ${await uRes.text()}`);
+    }
+  }
+}
+
 /**
  * Assign products to a Wix collection.
  * Adds products first, then removes ones that shouldn't be there.
@@ -626,6 +704,11 @@ export async function runPush() {
               description: enDesc || '',
             });
           }
+          try {
+            await pushCollectionTranslations(seasonalWixId, seasonal.translations);
+          } catch (err) {
+            stats.errors.push(`Seasonal translations: ${err.message}`);
+          }
           stats.categoriesSynced++;
         } catch (err) {
           stats.errors.push(`Seasonal: ${err.message}`);
@@ -642,8 +725,8 @@ export async function runPush() {
         // without this, the Wix-native collection label stays whatever the
         // owner typed when creating the collection, which meant Wix only
         // rendered the nav item in the primary (English) language.
+        const availEntry = (sc.auto || []).find(a => a && a.slug === 'available-today');
         try {
-          const availEntry = (sc.auto || []).find(a => a && a.slug === 'available-today');
           const enTitle = availEntry?.translations?.en?.title;
           const enDesc = availEntry?.translations?.en?.description;
           if (enTitle || enDesc) {
@@ -654,6 +737,11 @@ export async function runPush() {
           }
         } catch (err) {
           stats.errors.push(`Available Today category name: ${err.message}`);
+        }
+        try {
+          await pushCollectionTranslations(availTodayId, availEntry?.translations);
+        } catch (err) {
+          stats.errors.push(`Available Today translations: ${err.message}`);
         }
 
         const stockCheck = await db.list(TABLES.STOCK, {

--- a/docs/available-today-multilingual.md
+++ b/docs/available-today-multilingual.md
@@ -1,0 +1,113 @@
+# Available Today — multilingual playbook
+
+End-to-end reference for how the **Available Today** nav link and category
+page render across EN / PL / RU / UK, and what to do if it silently
+disappears on one of the non-primary languages again.
+
+## The short version
+
+Three independent systems write a label for this category. If any of them
+drifts, the visible result drifts too.
+
+| Layer | Source | Rendered on |
+|---|---|---|
+| **Velo override** | `/api/public/categories` → `auto[slug=available-today].translations` | Nav menu (`masterPage.js`) and the category page heading (`Category Page.qyxgv.js`) |
+| **Wix Multilingual Translation Content** | Owner in Airtable → pushed by `pushCollectionTranslations()` on each sync | Breadcrumbs, Wix Stores native UI, and anywhere Velo doesn't override |
+| **Wix Stores collection native name** | `updateWixCategory(id, { name, description })` on each sync — EN only | Wix Editor menu preview and the EN site when nothing else overrides |
+
+All three ultimately originate from the Blossom App (Airtable) translations
+for the auto-category entry. Keep edits in one place; don't edit in the
+Wix Translation Manager manually or the next sync will reconcile back.
+
+## How to edit a translation
+
+1. Open the Blossom app → settings → storefront categories → Available
+   Today → edit title/description for PL / RU / UK.
+2. Save. `backend/src/routes/settings.js` persists to Airtable App Config.
+3. Within ~5 minutes: `masterPage.js` picks up the new string because it
+   fetches `/api/public/categories` fresh each page load (5-min Wix-side
+   cache). Nav + category-page heading update without a site publish.
+4. At the next scheduled `runPush` (or a manual trigger): the backend's
+   `pushCollectionTranslations()` writes PL / RU / UK to Wix Multilingual
+   Translation Content. Breadcrumbs and native Wix Stores UI update.
+5. Republish the site only if you want the Wix Editor preview to match
+   (editor doesn't run Velo, so it shows the native Wix Store collection
+   name — which only updates when EN changes).
+
+## The fix path, layered
+
+Historical reference — each layer was a necessary step and the earlier
+ones don't substitute for the later ones.
+
+1. **Seed the backend defaults** (1fffa70): filled in real EN / PL / RU /
+   UK translation strings in `DEFAULTS.storefrontCategories.auto` so
+   `applyLang()` in `docs/wix-velo-categories.js` doesn't fall through to
+   the hardcoded English `cat.name` on secondary languages. Added a
+   `migrateAutoCategoryTranslations()` backfill so existing Airtable
+   configs catch up on next restart.
+2. **Push EN collection name to Wix** (1fffa70 + f191de5): mirrored the
+   seasonal path by calling `updateWixCategory(availTodayId, { name,
+   description })` with the EN translation, so the Wix-native collection
+   label matches the owner's configured name.
+3. **Push PL / RU / UK to Wix Multilingual** (`pushCollectionTranslations`
+   in `backend/src/services/wixProductSync.js`): without a published
+   translation per locale, Wix Stores strips the collection link from the
+   non-primary-language menus entirely. Writes to the Translation Content
+   API with `published: true`. Query-then-create-or-update so re-runs are
+   idempotent; skips any locale whose config has blank title + description
+   to preserve hand-typed Translation Manager edits.
+4. **Synthesize the nav item in Velo when missing** (blossom-wix
+   `src/pages/masterPage.js`): the horizontal menu's items are
+   per-language in the Wix Editor, and the owner only configured Available
+   Today for the EN menu. When `menuItems` on the current language doesn't
+   contain a link matching `/category/available-today`, `masterPage.js`
+   constructs a fresh item `{ label, link: '/category/available-today' }`
+   instead of silently dropping the entry. Still driven by `productCount`
+   so zero qualifying products hides it.
+
+## Known-good reference IDs
+
+Useful when calling the Wix REST API directly (one-shot fixes via the
+Wix MCP or a backfill script).
+
+| Name | Value |
+|---|---|
+| Blossom site ID | `f4c4624f-6142-4b4c-a629-312adfb37faf` |
+| Wix Stores Collection translation schema ID | `5b35dfe1-da21-4071-aab5-2cec870459c0` |
+| Schema key (for Published Content queries) | `appId=1380b703-ce81-ff05-f115-39571d94dfcd`, `entityType=collection` (singular!), `scope=GLOBAL` |
+| Translation field keys | `collection-name`, `category-description` |
+| Site locale codes | `en`, `pl`, `ru`, `uk` (short form, no regional variants) |
+| Available Today collection ID | `0c66971a-d341-9a59-1b89-57bfaecb702e` |
+| Peonies (currently active seasonal) collection ID | `bd8e21a0-e41a-be29-67d5-5dd1b19fcd37` |
+
+## Diagnostic checklist when the nav link disappears
+
+1. **Is `productCount > 0`?** `curl https://flower-studio-backend-production.up.railway.app/api/public/categories | jq '.auto[] | select(.slug=="available-today").productCount'`. Zero means no Lead-Time-0 products in stock — expected hide.
+2. **Are backend translations non-empty?** Same endpoint, check `auto[…].translations.pl.title` is set. If blank, owner never filled them in — fix in Blossom app.
+3. **Does the live site's `masterPage.js` log `synthesized` or `existing`?** Open DevTools Console on `/pl/` → look for `[masterPage] Available Today: showing (N products, …)`. `hidden` means productCount 0; nothing logged at all means masterPage.js crashed earlier — check the first `[masterPage] …` line.
+4. **Are Wix Multilingual translations published?** Query
+   ```
+   POST /translation-published-content/v3/published-contents/query
+   { "query": { "filter": {
+       "schemaKey.appId":{"$eq":"1380b703-ce81-ff05-f115-39571d94dfcd"},
+       "schemaKey.entityType":{"$eq":"collection"},
+       "schemaKey.scope":{"$eq":"GLOBAL"},
+       "entityId":{"$eq":"0c66971a-d341-9a59-1b89-57bfaecb702e"}
+   }}}
+   ```
+   Should return three entries (`pl`, `ru`, `uk`) with `collection-name` and `category-description` fields populated.
+5. **Did the backend actually run `pushCollectionTranslations`?** Check server logs for `Available Today translations:` or `Seasonal translations:` in `stats.errors`. An empty translations config silently skips.
+6. **Does the owner need a republish?** For Velo-driven layers (nav + category heading) no. For breadcrumb / Wix-native UI that reads from Wix Multilingual Published Content: yes, republish the site.
+
+## Source files in this repo
+
+- `backend/src/routes/settings.js` — `DEFAULTS.storefrontCategories.auto` + `migrateAutoCategoryTranslations()`.
+- `backend/src/routes/public.js` — `/api/public/categories` endpoint shape.
+- `backend/src/services/wixProductSync.js` — `updateWixCategory()`, `pushCollectionTranslations()`, `STORES_COLLECTION_SCHEMA_ID`.
+- `docs/wix-velo-categories.js` — Velo helpers + `masterPage.js` example (reference implementation).
+
+## Source files in blossom-wix
+
+- `src/pages/masterPage.js` — nav rename + synthesize for Available Today and seasonal.
+- `src/pages/Category Page.qyxgv.js` — category page heading override.
+- `src/backend/products.jsw` — Wix-side fetch wrapper around `/api/public/categories`.

--- a/docs/wix-velo-categories.js
+++ b/docs/wix-velo-categories.js
@@ -179,43 +179,80 @@ export async function getAllCategories() {
 // ────────────────────────────────────────────────────────────
 // MASTER PAGE CODE — paste this into masterPage.js
 // ────────────────────────────────────────────────────────────
-// masterPage.js runs on every language version of the site, so updating
-// element text here translates the menu items for EN / PL / RU / UK in
-// one place. Use placeholder text elements (e.g. #seasonalMenuText,
-// #availableTodayMenuText) inside your header menu and let Velo fill
-// them with the translated label.
+// The Blossom site header uses a horizontal menu (`#horizontalMenu1`)
+// whose items are configured in the Wix Editor. masterPage.js runs on
+// every language version and mutates the menu's `menuItems` array to
+// rename the Seasonal + Available Today labels, and to add / remove
+// the Available Today entry based on `productCount` from the backend.
 //
-// import {
-//   getSeasonalMenuLabel,
-//   getAvailableTodayMenuLabel,
-//   isAvailableTodayActive,
-// } from 'public/blossomCategories.js';
+// IMPORTANT — owner action required for non-English languages:
+//   The horizontal menu's items are translated per-language in the Wix
+//   Editor. In each language (Polish, Russian, Ukrainian), open the
+//   header menu and add an "Available Today" menu item whose link is
+//   `/category/available-today` (the label is irrelevant — Velo
+//   overwrites it). Velo can rename, reorder, and remove existing menu
+//   items, but it cannot synthesize an item that isn't configured in
+//   the Editor menu for that language.
+//
+// import { getCategories } from 'backend/products.jsw';
+// import wixWindowFrontend from 'wix-window-frontend';
 //
 // $w.onReady(async function () {
-//   // Seasonal
 //   try {
-//     const menuLabel = await getSeasonalMenuLabel();
-//     $w('#seasonalMenuText').text = menuLabel;
-//   } catch (e) { console.error('Seasonal menu update failed:', e); }
+//     var categories = await getCategories();
+//     var seasonal = categories.seasonal;
+//     var lang = 'en';
+//     try { lang = wixWindowFrontend.multilingual.currentLanguage || 'en'; } catch (e) {}
 //
-//   // Available Today — show in ALL languages when products qualify,
-//   // hide when the backend reports productCount === 0 (e.g. no lead-time-0
-//   // items left after the cutoff).
-//   try {
-//     const [label, active] = await Promise.all([
-//       getAvailableTodayMenuLabel(),
-//       isAvailableTodayActive(),
-//     ]);
-//     $w('#availableTodayMenuText').text = label;
-//     if (active) {
-//       $w('#availableTodayMenu').expand();
-//       $w('#availableTodayMenu').show();
-//     } else {
-//       $w('#availableTodayMenu').collapse();
-//       $w('#availableTodayMenu').hide();
+//     // Seasonal label (rename SEASONAL / SPRING / WIOSNA / ВЕСНА → current translation).
+//     var seasonalLabel = null;
+//     if (seasonal && seasonal.name) {
+//       var st = seasonal.translations || {};
+//       var stitle = (st[lang] && st[lang].title) || (st.en && st.en.title) || seasonal.name;
+//       seasonalLabel = stitle.toUpperCase();
+//       try { $w('#button7').label = seasonalLabel; } catch (e) {}  // homepage seasonal button
 //     }
-//   } catch (e) { console.error('Available Today menu update failed:', e); }
+//
+//     // Available Today: translated label + visibility driven by productCount.
+//     var availToday = (categories.auto || []).find(function (a) { return a && a.slug === 'available-today'; });
+//     var showAvailToday = availToday && availToday.productCount > 0;
+//     var atT = availToday ? (availToday.translations || {}) : {};
+//     var atTitle = (atT[lang] && atT[lang].title) || (atT.en && atT.en.title) || 'Available Today';
+//
+//     var menu = $w('#horizontalMenu1');
+//     if (menu && menu.menuItems) {
+//       // 1. Rename seasonal menu item.
+//       var updated = menu.menuItems.map(function (item) {
+//         var upper = (item.label || '').toUpperCase();
+//         if (seasonalLabel && (upper === 'SEASONAL' || upper === 'WIOSNA' || upper === 'SPRING' || upper === 'ВЕСНА')) {
+//           return Object.assign({}, item, { label: seasonalLabel });
+//         }
+//         return item;
+//       });
+//
+//       // 2. Pull Available Today out; rename + reorder to first, or drop it entirely.
+//       var atItem = null;
+//       var rest = [];
+//       for (var i = 0; i < updated.length; i++) {
+//         if ((updated[i].link || '').indexOf('available-today') !== -1) atItem = updated[i];
+//         else rest.push(updated[i]);
+//       }
+//       if (showAvailToday && atItem) {
+//         updated = [Object.assign({}, atItem, { label: atTitle.toUpperCase() })].concat(rest);
+//       } else {
+//         updated = rest;  // productCount=0 OR item not configured in this language's menu
+//       }
+//       menu.menuItems = updated;
+//     }
+//   } catch (err) { console.error('[masterPage]', err.message); }
 // });
+//
+// Note: the getAvailableTodayMenuLabel() / getAvailableTodayTitle() /
+// getAvailableTodayDescription() / isAvailableTodayActive() helpers above
+// are useful when Available Today is bound to a standalone text or
+// container element (e.g. a category page heading). The deployed
+// masterPage.js does not use them — it inlines the translation lookup
+// against the horizontal menu's items directly.
 //
 // ────────────────────────────────────────────────────────────
 // CATEGORY PAGE CODE — works for ALL category pages


### PR DESCRIPTION
## Summary

- `backend/src/services/wixProductSync.js`: new `pushCollectionTranslations()` helper. Queries existing Wix Multilingual Translation Content for the collection, then bulk-creates missing locales and bulk-updates existing ones. Marks fields `published: true`. Wired into both the seasonal and Available Today branches of `runPush()`. Schema `5b35dfe1-da21-4071-aab5-2cec870459c0` (Wix Stores Collections), fields `collection-name` + `category-description`, locales `pl` / `ru` / `uk`.
- `docs/wix-velo-categories.js`: rewrote the masterPage example to match the actually-deployed pattern in blossom-wix (`$w('#horizontalMenu1').menuItems` mutation — not `#availableTodayMenu` / `#availableTodayMenuText` placeholder elements that 1fffa70 suggested). The four helpers (`getAvailableTodayMenuLabel` / `…Title` / `…Description` / `isAvailableTodayActive`) remain for standalone-text-element layouts.
- `CHANGELOG.md`: replaced the earlier "owner-action" addendum under 2026-04-17 with the real fix path.
- `docs/available-today-multilingual.md` (new): single playbook covering the three label-rendering layers, how edits propagate, diagnostic checklist with concrete API queries, and reference IDs.

A companion commit in blossom-wix ([PR #1](https://github.com/OliwerO/Blossom-Wix/pull/1)) makes `masterPage.js` synthesize the Available Today menu item on any language where the Wix Editor menu doesn't already contain one — closing the last gap where Velo previously could only rename, not create.

## Why

The reported symptom — Polish / Russian / Ukrainian visitors never saw the Available Today nav link even though English worked and backend had translations — turned out to need three distinct fixes:

1. Seed the backend default translations (1fffa70 — already landed on master).
2. Push PL/RU/UK to Wix Multilingual so Wix Stores doesn't strip the collection link from non-primary-language menus (**this PR**).
3. Have Velo synthesize the menu item where the Editor menu doesn't have one, because the horizontal menu's `menuItems` list is per-language in the Editor (companion PR in blossom-wix).

Verified against the live site via the Wix MCP: published translations land in the Translation Content v3 published-contents layer, and the live PL/RU/UK sites now render the nav link.

## Test plan

- [ ] Deploy backend; check logs for `Available Today translations:` or `Seasonal translations:` in `stats.errors` on the next `runPush`.
- [ ] Fetch `/translation-published-content/v3/published-contents/query` filtered by the Available Today `entityId` — confirm `pl` / `ru` / `uk` present with current Airtable strings.
- [ ] Edit a translation in the Blossom app, trigger a push, confirm the update propagates to Wix Multilingual (not just backend).
- [ ] Confirm locales with blank config (e.g. permanent categories whose translations owner never filled in) are skipped, not overwritten with empty strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)