### PR TITLE
Block date-less orders + surface orphan-date orders + owner parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,63 @@ AIRTABLE_PREMADE_BOUQUET_LINES_TABLE=tbl...  # Premade Bouquet Lines table ID
 
 ---
 
+## 2026-04-19 — Block date-less orders + surface orphan-date orders
+
+After the owner created a premade-bouquet order on the dashboard with no
+delivery/pickup date, the order saved successfully but became invisible:
+the dashboard's default sort puts null dates at position `'9999'`
+(`OrdersTab.jsx`), the Today/upcoming filters drop them, and Airtable's
+`IS_BEFORE` on a null `Required By` behaves unpredictably. The order existed
+in Airtable but no list view showed it — it looked "lost".
+
+Three layers of defence so this can't happen again:
+
+### 1. Backend validation — `Required By` is now mandatory
+
+- `backend/src/routes/orders.js` `POST /orders` — rejects `400` if no
+  `requiredBy` (or `delivery.date`) in `YYYY-MM-DD` form.
+- `backend/src/routes/premadeBouquets.js` `POST /:id/match` — same check.
+
+The Wix webhook (`backend/src/services/wix.js`) bypasses these routes and
+writes orders directly via `db.create`, so it's unaffected; Wix payloads
+always include a delivery date.
+
+### 2. Dashboard frontend parity — date now blocks Next + Submit
+
+`apps/dashboard/src/components/NewOrderTab.jsx`:
+- New `validateStep()` and `handleNext()` mirror the florist's flow
+  (`apps/florist/src/pages/NewOrderPage.jsx`). Step 2 → 3 is blocked unless
+  a date is set; Submit double-checks at line 113.
+- `apps/dashboard/src/components/steps/Step3Details.jsx` — date label and
+  field now show the same red `*` and `ring-1 ring-ios-red/30` the florist
+  app uses, so the requirement is visible before the user tries to advance.
+
+### 3. Orphan-date banner in both apps
+
+If any legacy/imported order has `Required By` and `Delivery Date` both
+empty, an amber banner appears with the count and a "Show only these"
+toggle so the owner can triage them.
+
+- `apps/dashboard/src/components/OrdersTab.jsx` — banner above the list,
+  filter via `noDateOnly` state.
+- `apps/florist/src/pages/OrderListPage.jsx` — same pattern, only shown in
+  the Active view (terminal orders don't need triage).
+- New translation keys in both `translations.js` files
+  (`ordersWithoutDate`, `showOnlyTheseOrders`, `showAll`).
+
+**Why it matters:** the backend is the only layer that can't be bypassed,
+so it's the real fix. The dashboard validation gives the owner an instant
+toast instead of a 400 from the server. The banner recovers any existing
+orders that already slipped through (including the missing one from the
+incident that prompted this change).
+
+**What to watch for:** the new backend check fires on every `POST /orders`
+and `POST /premade-bouquets/:id/match`. If any other client (e.g. a future
+script, a manual `curl`) submits without a date, it now gets a 400 instead
+of silently losing the order.
+
+---
+
 ## 2026-04-19 — Owner can assign drivers from order detail + full florist parity
 
 The owner reported that after creating a delivery order linked to a premade

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,48 @@ AIRTABLE_PREMADE_BOUQUET_LINES_TABLE=tbl...  # Premade Bouquet Lines table ID
 
 ---
 
+## 2026-04-19 — Owner can assign drivers from order detail + full florist parity
+
+The owner reported that after creating a delivery order linked to a premade
+bouquet, the full-page **OrderDetailPage** had no driver-picker (florist app,
+logged in as owner). The driver picker existed in the expandable `OrderCard`
+but not on the full-page detail view, so there was no way to assign a driver
+without bouncing back to the list and expanding the card. Same gap also
+existed for florists — neither role could assign a driver from the detail
+page. Separately, several florist-only entry points blocked the owner.
+
+### Frontend — `apps/florist/src/pages/OrderDetailPage.jsx`
+
+- Pulls `drivers` from `useConfigLists()`.
+- Adds a `patchDelivery()` helper that PATCHes `/deliveries/:id` (mirrors
+  `OrderCard.patchDelivery` so both views stay consistent).
+- Renders a driver-picker section after the read-only delivery details card,
+  guarded by `isDelivery && order.delivery && drivers.length > 0`. Tap to
+  toggle assignment; shows `t.noDriver` when none assigned.
+
+### Frontend — full owner parity in florist app
+
+- `apps/florist/src/App.jsx` — removed `FloristRoute` wrapper.
+  `/stock-evaluation` is now `PrivateRoute`, so the owner can use it too.
+- `apps/florist/src/pages/OrderListPage.jsx` — dropped the `!isOwner` guard on
+  the stock-evaluation banner; the owner now sees the same alert.
+- `apps/florist/src/components/BottomNav.jsx` — added "Stock Evaluation" entry
+  to the owner's More menu.
+- `apps/florist/CLAUDE.md` — `StockEvaluationPage` access changed from
+  `florist` to `all`.
+
+**Why it matters:** the owner uses the florist app on her phone for the same
+daily-task control she has on the dashboard. Anywhere a florist can act, she
+should be able to act too. Driver assignment from the detail page is the most
+visible miss; the role-gated routes/banners were the structural ones.
+
+**What to watch for:** the stock-evaluation flow assumes a single in-flight
+evaluator; if both the florist and the owner load the page at the same time
+they could race on accept/write-off actions. We don't have row-level locking
+in Airtable, so coordinate verbally for now or split orders across roles.
+
+---
+
 ## 2026-04-17 — Wix "Available Today" now multilingual
 
 The "Available Today" nav item only rendered on the English version of the

--- a/apps/dashboard/src/components/NewOrderTab.jsx
+++ b/apps/dashboard/src/components/NewOrderTab.jsx
@@ -110,7 +110,31 @@ export default function NewOrderTab({ onNavigate, initialFilter }) {
     setStep(1);
   }
 
+  // Match the florist app's blocking validation. Without these guards an
+  // owner can submit an order with no date — it then gets sorted to the
+  // bottom of every list view and looks "lost".
+  function validateStep(currentStep) {
+    if (currentStep === 1 && form.orderLines.length === 0) {
+      showToast(t.bouquetRequired || 'Add at least one item to the bouquet.', 'error');
+      return false;
+    }
+    if (currentStep === 2 && !form.deliveryDate) {
+      showToast(t.dateRequired || 'Date is required', 'error');
+      return false;
+    }
+    return true;
+  }
+
+  function handleNext() {
+    if (!validateStep(step)) return;
+    setStep(step + 1);
+  }
+
   async function handleSubmit() {
+    if (!form.customerId) { showToast(t.customerRequired || 'Customer is required.', 'error'); return; }
+    if (form.orderLines.length === 0) { showToast(t.bouquetRequired || 'Bouquet is required.', 'error'); return; }
+    if (!form.deliveryDate) { showToast(t.dateRequired || 'Date is required', 'error'); return; }
+
     setSubmitting(true);
     try {
       const body = {
@@ -259,7 +283,7 @@ export default function NewOrderTab({ onNavigate, initialFilter }) {
       {step >= 1 && step < 3 && (
         <div className="max-w-2xl mx-auto mt-6">
           <button
-            onClick={() => setStep(step + 1)}
+            onClick={handleNext}
             disabled={step === 1 && form.orderLines.length === 0}
             className="w-full h-14 rounded-2xl bg-brand-600 text-white text-base font-semibold
                        disabled:opacity-30 active:bg-brand-700 transition-colors shadow-lg"

--- a/apps/dashboard/src/components/OrdersTab.jsx
+++ b/apps/dashboard/src/components/OrdersTab.jsx
@@ -91,6 +91,7 @@ export default function OrdersTab({ initialFilter, onNavigate }) {
   const [showPremade, setShowPremade] = useState(false);
   const [sortBy, setSortBy]       = useState('deliveryDate');
   const [sortDir, setSortDir]     = useState('asc'); // 'asc' | 'desc' — bidirectional sort
+  const [noDateOnly, setNoDateOnly] = useState(false); // surface orphan-date orders
   const { showToast }             = useToast();
 
   const initialLoaded = useRef(false);
@@ -141,14 +142,22 @@ export default function OrdersTab({ initialFilter, onNavigate }) {
     return () => { clearInterval(interval); document.removeEventListener('visibilitychange', onVisible); };
   }, [fetchOrders]);
 
+  // Orders with no delivery/pickup date — these get sorted to the bottom of
+  // every default view and become "lost". Counted from the unfiltered list so
+  // the banner reflects reality even after the user narrows by search.
+  const noDateCount = orders.filter(o => !o['Delivery Date'] && !o['Required By']).length;
+
   // Client-side search filter
-  const filtered = search
+  let filtered = search
     ? orders.filter(o => {
         const q = search.toLowerCase();
         return (o['Customer Name'] || '').toLowerCase().includes(q)
           || (o['Customer Request'] || '').toLowerCase().includes(q);
       })
     : orders;
+  if (noDateOnly) {
+    filtered = filtered.filter(o => !o['Delivery Date'] && !o['Required By']);
+  }
 
   // Sort orders based on selected sort option + direction (bidirectional)
   const dirMul = sortDir === 'desc' ? -1 : 1;
@@ -349,6 +358,25 @@ export default function OrdersTab({ initialFilter, onNavigate }) {
             {t.clearAll}
           </button>
         </div>
+      )}
+
+      {/* Orphan-date warning — orders with no Required By / Delivery Date get
+          sorted to the bottom and disappear from Today/upcoming views.
+          Surface them explicitly so they can be triaged. */}
+      {!showPremade && noDateCount > 0 && (
+        <button
+          onClick={() => setNoDateOnly(v => !v)}
+          className={`w-full flex items-center justify-between px-4 py-3 rounded-2xl border text-sm font-medium transition-colors ${
+            noDateOnly
+              ? 'bg-amber-100 border-amber-300 text-amber-900'
+              : 'bg-amber-50 border-amber-200 text-amber-800 hover:bg-amber-100'
+          }`}
+        >
+          <span>⚠️ {t.ordersWithoutDate || 'Orders without a date'}: {noDateCount}</span>
+          <span className="text-xs underline">
+            {noDateOnly ? (t.showAll || 'Show all') : (t.showOnlyTheseOrders || 'Show only these')}
+          </span>
+        </button>
       )}
 
       {/* Premade inventory — replaces the orders list when the chip is active */}

--- a/apps/dashboard/src/components/steps/Step3Details.jsx
+++ b/apps/dashboard/src/components/steps/Step3Details.jsx
@@ -125,15 +125,15 @@ export default function Step3Details({ form, onChange }) {
 
       {/* Timing — date picker + time slot pills (fetched from server config) */}
       <div className="relative z-20">
-        <p className="ios-label">{form.deliveryType === 'Delivery' ? t.labelDeliveryTiming : t.requiredBy}</p>
-        <div className="ios-card overflow-visible divide-y divide-white/40">
+        <p className="ios-label">{form.deliveryType === 'Delivery' ? t.labelDeliveryTiming : t.requiredBy} <span className="text-ios-red">*</span></p>
+        <div className={`ios-card overflow-visible divide-y divide-white/40 ${!form.deliveryDate ? 'ring-1 ring-ios-red/30' : ''}`}>
           <div className="flex items-center gap-3 px-4 py-3.5">
-            <span className="text-sm text-ios-tertiary w-28 shrink-0">{t.deliveryDate}</span>
+            <span className="text-sm text-ios-tertiary w-28 shrink-0">{t.deliveryDate} <span className="text-ios-red">*</span></span>
             <div className="flex-1">
               <DatePicker
                 value={form.deliveryDate}
                 onChange={handleDateChange}
-                placeholder={t.optional}
+                placeholder={t.selectDate || t.optional}
               />
             </div>
           </div>

--- a/apps/dashboard/src/translations.js
+++ b/apps/dashboard/src/translations.js
@@ -30,6 +30,13 @@ const en = {
 
   // Orders tab
   allStatuses:      'All',
+  ordersWithoutDate: 'Orders without a date',
+  showOnlyTheseOrders: 'Show only these',
+  showAll:          'Show all',
+  dateRequired:     'Date is required.',
+  customerRequired: 'Customer is required.',
+  bouquetRequired:  'Bouquet is required.',
+  selectDate:       'Select date',
   statusNew:        'New',
   statusAccepted:   'Accepted',
   statusInPreparation: 'In Preparation',
@@ -766,6 +773,13 @@ const ru = {
 
   // Orders tab
   allStatuses:      'Все',
+  ordersWithoutDate: 'Заказы без даты',
+  showOnlyTheseOrders: 'Показать только их',
+  showAll:          'Показать все',
+  dateRequired:     'Укажите дату.',
+  customerRequired: 'Укажите клиента.',
+  bouquetRequired:  'Добавьте хотя бы один цветок.',
+  selectDate:       'Выберите дату',
   statusNew:        'Новый',
   statusAccepted:   'Accepted',
   statusInPreparation: 'В подготовке',

--- a/apps/florist/CLAUDE.md
+++ b/apps/florist/CLAUDE.md
@@ -13,7 +13,7 @@ The florist should see all relevant information at a glance — what to prepare 
 | OrderDetailPage | /orders/:id | all | Full-page order detail with inline editing, status transitions, bouquet editor |
 | NewOrderPage | /orders/new | all | 4-step wizard: Customer → Bouquet → Details → Review. AI text import shortcut. |
 | StockPanelPage | /stock | all | Inventory view with search, sort, filter, adjust, write-off, receive |
-| StockEvaluationPage | /stock-evaluation | florist | Quality inspection of incoming PO deliveries (accept/write-off per line) |
+| StockEvaluationPage | /stock-evaluation | all | Quality inspection of incoming PO deliveries (accept/write-off per line). Owner can do everything the florist can. |
 | PurchaseOrderPage | /purchase-orders | owner | PO management — create from negative stock, assign drivers, track lifecycle |
 | ShoppingSupportPage | /shopping-support | owner | Real-time supervision of active PO shopping runs (SSE + polling) |
 | FloristHoursPage | /hours | all | Florists log time windows; owner sees monthly payroll summary |

--- a/apps/florist/src/App.jsx
+++ b/apps/florist/src/App.jsx
@@ -39,14 +39,8 @@ function OwnerRoute({ children }) {
   return children;
 }
 
-// FloristRoute — blocks the owner, allows florist role only.
-// Owner has her own pages for the same workflows (e.g. shopping support instead of evaluation).
-function FloristRoute({ children }) {
-  const { pin, role } = useAuth();
-  if (!pin) return <Navigate to="/login" replace />;
-  if (role === 'owner') return <Navigate to="/orders" replace />;
-  return children;
-}
+// (FloristRoute removed — the owner can do everything the florist can,
+// including stock evaluation. ShoppingSupportPage is still owner-only.)
 
 // Layout — wraps authenticated pages with the bottom tab bar.
 // Like mounting the factory floor signage above every workstation.
@@ -101,7 +95,7 @@ export default function App() {
         } />
 
         <Route path="/stock-evaluation" element={
-          <FloristRoute><Layout><StockEvaluationPage /></Layout></FloristRoute>
+          <PrivateRoute><Layout><StockEvaluationPage /></Layout></PrivateRoute>
         } />
 
         <Route path="/reconcile-substitutes" element={

--- a/apps/florist/src/components/BottomNav.jsx
+++ b/apps/florist/src/components/BottomNav.jsx
@@ -65,11 +65,13 @@ export default function BottomNav() {
     window.location.href = window.location.pathname + '?_cb=' + Date.now();
   }
 
-  // "More" menu items differ by role
+  // "More" menu items differ by role.
+  // Owner gets all florist actions plus owner-only ones (day summary, etc.).
   const moreItems = isOwner
     ? [
         { label: t.daySummary,    action: () => navigate('/day-summary') },
         { label: t.floristHours,  action: () => navigate('/hours') },
+        { label: t.stockEvaluation || 'Stock Evaluation', action: () => navigate('/stock-evaluation') },
         { label: t.help,          action: () => navigate('/orders') }, // Help handled by HelpPanel on OrderListPage
         { label: `↻ ${t.refresh}`, action: hardRefresh },
         { label: t.logout,        action: logout, destructive: true },

--- a/apps/florist/src/pages/OrderDetailPage.jsx
+++ b/apps/florist/src/pages/OrderDetailPage.jsx
@@ -143,7 +143,7 @@ export default function OrderDetailPage() {
   const { id } = useParams();
   const navigate = useNavigate();
   const { showToast } = useToast();
-  const { paymentMethods, timeSlots } = useConfigLists();
+  const { paymentMethods, timeSlots, drivers } = useConfigLists();
 
   const [order, setOrder]     = useState(null);
   const [loading, setLoading] = useState(true);
@@ -178,6 +178,24 @@ export default function OrderDetailPage() {
       showToast('Updated!', 'success');
     } catch (err) {
       const msg = err.response?.data?.error || 'Failed to update order.';
+      showToast(msg, 'error');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Patch the linked delivery record (address, recipient, fee, driver assignment).
+  // Mirrors OrderCard.patchDelivery so the full-page detail and the list card stay in sync.
+  async function patchDelivery(fields) {
+    const deliveryId = order?.delivery?.id;
+    if (!deliveryId) return;
+    setSaving(true);
+    try {
+      await client.patch(`/deliveries/${deliveryId}`, fields);
+      setOrder(prev => prev ? { ...prev, delivery: { ...prev.delivery, ...fields } } : prev);
+      showToast(t.updated || 'Updated!', 'success');
+    } catch (err) {
+      const msg = err.response?.data?.error || t.updateError || 'Failed to update delivery.';
       showToast(msg, 'error');
     } finally {
       setSaving(false);
@@ -484,6 +502,36 @@ export default function OrderDetailPage() {
                     </div>
                   )}
                   <Row label={t.deliveryFee || 'Fee'} value={order.delivery['Delivery Fee'] ? `${order.delivery['Delivery Fee']} zł` : null} />
+                </div>
+              </div>
+            )}
+
+            {/* Driver assignment — same picker as the expanded OrderCard. */}
+            {isDelivery && order.delivery && drivers.length > 0 && (
+              <div>
+                <p className="ios-label">{t.assignedDriver}</p>
+                <div className="ios-card p-4">
+                  <div className="flex flex-wrap gap-1.5">
+                    {drivers.map(driver => (
+                      <button
+                        key={driver}
+                        onClick={() => patchDelivery({
+                          'Assigned Driver': order.delivery['Assigned Driver'] === driver ? '' : driver,
+                        })}
+                        disabled={saving}
+                        className={`px-3.5 py-1.5 rounded-full text-sm font-medium border transition-colors active-scale disabled:opacity-40 ${
+                          order.delivery['Assigned Driver'] === driver
+                            ? 'bg-brand-600 text-white border-brand-600 shadow-sm'
+                            : 'bg-gray-100 dark:bg-gray-700 text-ios-secondary dark:text-gray-300 border-gray-200 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600'
+                        }`}
+                      >
+                        {driver}
+                      </button>
+                    ))}
+                  </div>
+                  {!order.delivery['Assigned Driver'] && (
+                    <p className="text-xs text-ios-tertiary mt-2">{t.noDriver}</p>
+                  )}
                 </div>
               </div>
             )}

--- a/apps/florist/src/pages/OrderListPage.jsx
+++ b/apps/florist/src/pages/OrderListPage.jsx
@@ -88,6 +88,7 @@ export default function OrderListPage() {
   const [viewMode, setViewMode]     = useState(VIEW_MODES.ACTIVE);
   const [date, setDate]             = useState(''); // only used in completed view
   const [status, setStatus]         = useState('');
+  const [noDateOnly, setNoDateOnly] = useState(false); // surface orphan-date orders
   const [fabOpen, setFabOpen]       = useState(false);
   const [showImport, setShowImport] = useState(false);
 
@@ -247,6 +248,34 @@ export default function OrderListPage() {
           </div>
         </div>
       </header>
+
+      {/* Orphan-date warning — orders with no Required By / Delivery Date end up
+          sorted unpredictably and are easy to miss. Surface them so they get
+          a date assigned promptly. Only shown in Active view (Completed orders
+          are by definition done — date doesn't matter for triage). */}
+      {viewMode === VIEW_MODES.ACTIVE && (() => {
+        const noDateCount = orders.filter(o => !o['Delivery Date'] && !o['Required By']).length;
+        if (noDateCount === 0) return null;
+        return (
+          <div className="px-4 pt-3 max-w-2xl mx-auto">
+            <button
+              onClick={() => setNoDateOnly(v => !v)}
+              className={`w-full flex items-center justify-between rounded-2xl px-4 py-3 active-scale border ${
+                noDateOnly
+                  ? 'bg-amber-100 border-amber-300'
+                  : 'bg-amber-50 border-amber-200'
+              }`}
+            >
+              <span className="text-sm font-semibold text-amber-700">
+                ⚠️ {t.ordersWithoutDate || 'Orders without a date'} ({noDateCount})
+              </span>
+              <span className="text-amber-600 text-sm font-medium">
+                {noDateOnly ? (t.showAll || 'Show all') : (t.showOnlyTheseOrders || 'Show only')} →
+              </span>
+            </button>
+          </div>
+        );
+      })()}
 
       {/* Stock evaluation banner — visible to florist and owner */}
       {evalCount > 0 && (
@@ -438,7 +467,12 @@ export default function OrderListPage() {
           </div>
         ) : (
           <div className="flex flex-col gap-2.5 mt-1">
-            {(viewMode === VIEW_MODES.ACTIVE ? sortByEarliestNeeded(orders) : sortByStatus(orders)).map(order => (
+            {(() => {
+              const base = noDateOnly
+                ? orders.filter(o => !o['Delivery Date'] && !o['Required By'])
+                : orders;
+              return viewMode === VIEW_MODES.ACTIVE ? sortByEarliestNeeded(base) : sortByStatus(base);
+            })().map(order => (
               <OrderCard
                 key={order.id}
                 order={order}

--- a/apps/florist/src/pages/OrderListPage.jsx
+++ b/apps/florist/src/pages/OrderListPage.jsx
@@ -248,8 +248,8 @@ export default function OrderListPage() {
         </div>
       </header>
 
-      {/* Stock evaluation banner — florist only */}
-      {!isOwner && evalCount > 0 && (
+      {/* Stock evaluation banner — visible to florist and owner */}
+      {evalCount > 0 && (
         <div className="px-4 pt-3 max-w-2xl mx-auto">
           <button
             onClick={() => navigate('/stock-evaluation')}

--- a/apps/florist/src/translations.js
+++ b/apps/florist/src/translations.js
@@ -254,6 +254,9 @@ const en = {
   // Stock evaluation
   stockEvaluation:       'Stock Evaluation',
   stockEvalBanner:       'Stock delivery to evaluate',
+  ordersWithoutDate:     'Orders without a date',
+  showOnlyTheseOrders:   'Show only these',
+  showAll:               'Show all',
   driverFound:           'Driver found',
   accept:                'Accept',
   writeOffQty:           'Write off',
@@ -776,6 +779,9 @@ const ru = {
   // Stock evaluation
   stockEvaluation:       'Оценка цветов',
   stockEvalBanner:       'Цветы для оценки',
+  ordersWithoutDate:     'Заказы без даты',
+  showOnlyTheseOrders:   'Показать только их',
+  showAll:               'Показать все',
   driverFound:           'Водитель нашёл',
   accept:                'Принять',
   writeOffQty:           'Списать',

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -261,6 +261,13 @@ router.post('/', async (req, res, next) => {
     if (deliveryType === 'Delivery' && (!delivery || !delivery.address || typeof delivery.address !== 'string' || !delivery.address.trim())) {
       return res.status(400).json({ error: 'delivery.address is required and must be non-empty when deliveryType is "Delivery".' });
     }
+    // Required By is mandatory — orders without a date silently disappear
+    // from every default list view (sorted last in Orders, excluded from
+    // Today/upcoming filters). Fail loudly here instead.
+    const effectiveRequiredBy = requiredBy || delivery?.date;
+    if (!effectiveRequiredBy || typeof effectiveRequiredBy !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(effectiveRequiredBy)) {
+      return res.status(400).json({ error: 'requiredBy (delivery/pickup date, YYYY-MM-DD) is required.' });
+    }
     if (priceOverride !== undefined && priceOverride !== null && (typeof priceOverride !== 'number' || priceOverride < 0)) {
       return res.status(400).json({ error: 'priceOverride must be a number >= 0 if provided.' });
     }

--- a/backend/src/routes/premadeBouquets.js
+++ b/backend/src/routes/premadeBouquets.js
@@ -146,6 +146,11 @@ router.post('/:id/match', async (req, res, next) => {
     if (deliveryType === 'Delivery' && (!delivery || !delivery.address || typeof delivery.address !== 'string' || !delivery.address.trim())) {
       return res.status(400).json({ error: 'delivery.address is required when deliveryType is "Delivery".' });
     }
+    // Required By is mandatory — see POST /orders for the rationale.
+    const effectiveRequiredBy = requiredBy || delivery?.date;
+    if (!effectiveRequiredBy || typeof effectiveRequiredBy !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(effectiveRequiredBy)) {
+      return res.status(400).json({ error: 'requiredBy (delivery/pickup date, YYYY-MM-DD) is required.' });
+    }
     if (paymentStatus && !VALID_PAYMENT_STATUSES.includes(paymentStatus)) {
       return res.status(400).json({ error: `paymentStatus must be one of: ${VALID_PAYMENT_STATUSES.join(', ')}` });
     }


### PR DESCRIPTION
## Summary

This PR implements three layers of defence to prevent orders from becoming "lost" when created without a delivery/pickup date, adds visibility for any existing orphan-date orders, and grants the owner full parity with florist actions in the florist app.

## Key Changes

### 1. Backend validation — `Required By` is now mandatory
- `backend/src/routes/orders.js` `POST /orders` — rejects with 400 if no `requiredBy` or `delivery.date` in `YYYY-MM-DD` format
- `backend/src/routes/premadeBouquets.js` `POST /:id/match` — same validation applied
- Prevents orders from silently disappearing due to unpredictable sorting and filtering behavior

### 2. Dashboard frontend validation — date blocks progression
- `apps/dashboard/src/components/NewOrderTab.jsx` — added `validateStep()` and `handleNext()` to block Step 2→3 transition without a date
- `apps/dashboard/src/components/steps/Step3Details.jsx` — date field now displays red `*` indicator and `ring-1 ring-ios-red/30` styling to signal requirement
- Submit button double-checks all required fields including date before sending

### 3. Orphan-date banner in both apps
- `apps/dashboard/src/components/OrdersTab.jsx` — amber banner above orders list showing count of date-less orders with toggle to filter and view only these
- `apps/florist/src/pages/OrderListPage.jsx` — same pattern in Active view (terminal orders don't need triage)
- New translation keys added to both `translations.js` files: `ordersWithoutDate`, `showOnlyTheseOrders`, `showAll`

### 4. Owner can assign drivers from order detail page
- `apps/florist/src/pages/OrderDetailPage.jsx` — added driver-picker section after delivery details, mirrors the `OrderCard` picker for consistency
- New `patchDelivery()` helper method to update delivery records via `PATCH /deliveries/:id`

### 5. Full owner parity in florist app
- `apps/florist/src/App.jsx` — removed `FloristRoute` wrapper; `/stock-evaluation` is now `PrivateRoute` so owner can access it
- `apps/florist/src/pages/OrderListPage.jsx` — dropped `!isOwner` guard on stock-evaluation banner
- `apps/florist/src/components/BottomNav.jsx` — added "Stock Evaluation" to owner's More menu
- `apps/florist/CLAUDE.md` — updated `StockEvaluationPage` access from `florist` to `all`

## Implementation Details

- Backend validation is the primary defence layer since it cannot be bypassed by any client
- Frontend validation provides instant user feedback via toast instead of waiting for server 400
- Orphan-date banner recovers any legacy/imported orders that already lack dates
- Driver assignment from detail page uses the same styling and logic as the card view to maintain consistency
- Owner role now has unrestricted access to florist workflows while maintaining role-specific pages (e.g., ShoppingSupport remains owner-only)

https://claude.ai/code/session_01FaX2UirZ6z1tM1n1fL2Ppy