### PR TITLE
fix(customers): restore name search + show legacy orders in detail panel

### DIFF
--- a/apps/dashboard/src/components/CustomerDetailPanel.jsx
+++ b/apps/dashboard/src/components/CustomerDetailPanel.jsx
@@ -18,14 +18,12 @@ export default function CustomerDetailPanel({ customerId, onUpdate }) {
       try {
         const [custRes, ordersRes] = await Promise.all([
           client.get(`/customers/${customerId}`),
-          client.get('/orders', { params: {} }),
+          client.get(`/customers/${customerId}/orders`),
         ]);
         setCust(custRes.data);
-        // Filter orders that belong to this customer
-        const custOrders = ordersRes.data.filter(o =>
-          o.Customer?.[0] === customerId
-        );
-        setOrders(custOrders);
+        // Backend returns merged legacy + app orders, already sorted date-desc
+        // and normalized: { id, source, date, description, amount, status, link, lines, raw }
+        setOrders(ordersRes.data);
       } catch {
         showToast(t.error, 'error');
       } finally {
@@ -60,13 +58,13 @@ export default function CustomerDetailPanel({ customerId, onUpdate }) {
 
   return (
     <div className="border-t border-white/40 px-4 py-4 bg-white/20 space-y-4">
-      {/* Lifetime summary — computed from order history */}
+      {/* Lifetime summary — computed from order history (legacy + app combined) */}
       {orders.length > 0 && (() => {
-        const totalSpend = orders.reduce((sum, o) => sum + (o['Effective Price'] || o['Price Override'] || o['Final Price'] || 0), 0);
+        const totalSpend = orders.reduce((sum, o) => sum + (o.amount || 0), 0);
         const avgOrderValue = Math.round(totalSpend / orders.length);
 
-        // Avg days between orders
-        const sortedDates = orders.map(o => new Date(o['Order Date'])).filter(d => !isNaN(d)).sort((a, b) => a - b);
+        // Avg days between orders — works on the normalized ISO date string
+        const sortedDates = orders.map(o => new Date(o.date)).filter(d => !isNaN(d)).sort((a, b) => a - b);
         let avgDaysBetween = 0;
         if (sortedDates.length > 1) {
           const gaps = [];
@@ -76,10 +74,10 @@ export default function CustomerDetailPanel({ customerId, onUpdate }) {
           avgDaysBetween = Math.round(gaps.reduce((s, g) => s + g, 0) / gaps.length);
         }
 
-        // Preferred source
+        // Preferred source — only app orders have Source; legacy falls into Unknown
         const sourceCounts = {};
         for (const o of orders) {
-          const src = o.Source || 'Unknown';
+          const src = o.raw?.Source || (o.source === 'legacy' ? 'Legacy' : 'Unknown');
           sourceCounts[src] = (sourceCounts[src] || 0) + 1;
         }
         const preferredSource = Object.entries(sourceCounts).sort(([,a],[,b]) => b - a)[0]?.[0] || '\u2014';
@@ -197,12 +195,13 @@ export default function CustomerDetailPanel({ customerId, onUpdate }) {
         multiline
       />
 
-      {/* Flowers ordered — aggregated from all order bouquet summaries */}
+      {/* Flowers ordered — aggregated from app-order bouquet summaries.
+          Legacy orders have free-text descriptions that don't parse; skipped. */}
       {orders.length > 0 && (() => {
-        // Parse "5x Roses, 3x Tulips" from Bouquet Summary across all orders
+        // Parse "5x Roses, 3x Tulips" from raw Bouquet Summary across all orders
         const flowerMap = {};
         for (const o of orders) {
-          const summary = o['Bouquet Summary'] || '';
+          const summary = o.raw?.['Bouquet Summary'] || '';
           if (!summary) continue;
           for (const part of summary.split(',')) {
             const match = part.trim().match(/^(\d+)\s*[x×]\s*(.+)$/i);
@@ -255,13 +254,20 @@ export default function CustomerDetailPanel({ customerId, onUpdate }) {
               <tbody>
                 {orders.map(o => (
                   <tr key={o.id} className="border-b border-white/20">
-                    <td className="px-3 py-2 text-ios-tertiary">{o['Order Date']}</td>
-                    <td className="px-3 py-2 truncate max-w-[200px]">{o['Customer Request'] || '—'}</td>
+                    <td className="px-3 py-2 text-ios-tertiary whitespace-nowrap">
+                      {o.date || '—'}
+                      {o.source === 'legacy' && (
+                        <span className="ml-1.5 text-[10px] bg-gray-200 text-gray-600 px-1.5 py-0.5 rounded uppercase tracking-wide">
+                          legacy
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 truncate max-w-[240px]">{o.description || '—'}</td>
                     <td className="px-3 py-2">
-                      <span className="text-xs">{o.Status}</span>
+                      <span className="text-xs">{o.status || '—'}</span>
                     </td>
                     <td className="px-3 py-2 text-right font-medium">
-                      {(o['Final Price'] || o['Price Override'] || o['Sell Price Total'] || 0).toFixed(0)} {t.zl}
+                      {o.amount ? `${o.amount.toFixed(0)} ${t.zl}` : '—'}
                     </td>
                   </tr>
                 ))}

--- a/backend/src/routes/customers.js
+++ b/backend/src/routes/customers.js
@@ -4,6 +4,7 @@ import * as db from '../services/airtable.js';
 import { TABLES } from '../config/airtable.js';
 import { pickAllowed } from '../utils/fields.js';
 import { listByIds } from '../utils/batchQuery.js';
+import { sanitizeFormulaValue } from '../utils/sanitize.js';
 
 const router = Router();
 router.use(authorize('customers'));
@@ -144,16 +145,29 @@ async function getAggregateMap() {
 }
 
 // GET /api/customers
-// Returns ALL customers (~1094 rows, ~30KB gzipped), each enriched with
-// _agg: { lastOrderDate, orderCount, totalSpend } computed over legacy + app
-// orders combined. Universal search and filtering happen client-side against
-// this one payload (see Customer Tab v2.0 plan).
+// Without ?search: returns ALL customers (~1094 rows), each enriched with
+// _agg: { lastOrderDate, orderCount, totalSpend } computed over legacy + app.
+// With ?search=X: applies the old server-side OR(SEARCH()) filter across
+// Name/Nickname/Phone/Link/Email so the legacy Customer tab's search input
+// keeps working until the v2.0 frontend lands with client-side universal search.
 router.get('/', async (req, res, next) => {
   try {
+    const { search } = req.query;
+
+    const listOptions = { sort: [{ field: 'Name', direction: 'asc' }] };
+    if (search) {
+      const q = sanitizeFormulaValue(search);
+      listOptions.filterByFormula = `OR(
+        SEARCH(LOWER('${q}'), LOWER({Name})),
+        SEARCH(LOWER('${q}'), LOWER({Nickname})),
+        SEARCH('${q}', {Phone}),
+        SEARCH(LOWER('${q}'), LOWER({Link})),
+        SEARCH(LOWER('${q}'), LOWER({Email}))
+      )`;
+    }
+
     const [customers, aggMap] = await Promise.all([
-      db.list(TABLES.CUSTOMERS, {
-        sort: [{ field: 'Name', direction: 'asc' }],
-      }),
+      db.list(TABLES.CUSTOMERS, listOptions),
       getAggregateMap(),
     ]);
 


### PR DESCRIPTION
## Summary
Two follow-ups after PR #97 landed — both observed in prod by the owner on 2026-04-19:

1. **Name search went dead.** PR #97 dropped the server-side `?search=` handler on the theory the new v2.0 frontend would filter client-side. But the old Customer tab still sends `?search=X` and expects server-filtered results. Restored the old `filterByFormula` behavior when `search` is present; unchanged when absent.
2. **Legacy orders still invisible in the detail panel.** PR #97 added the `/customers/:id/orders` endpoint but no frontend called it yet. Wired `CustomerDetailPanel.jsx` to use it so the owner sees legacy + app orders merged today, without waiting for the full v2.0 frontend rewrite. Added a small "legacy" badge on the row's date cell so pre-app orders are visually distinguishable.

## Files changed
- `backend/src/routes/customers.js` — add back `?search=` branch in GET `/`
- `apps/dashboard/src/components/CustomerDetailPanel.jsx` — fetch from new endpoint, adapt rendering to normalized shape `{id, source, date, description, amount, status, ...}`

## Test plan
- [ ] Owner opens Customer tab, types "megan" — list narrows to Megan Burnett entries
- [ ] Owner clicks the Megan Burnett with full name (`recIjrwnXIMCFcrFG`) — detail panel shows 2 legacy orders with dates 2023-10-14 and 2023-04-15, both marked with a `legacy` badge
- [ ] Lifetime summary strip above shows Orders: 2 and Avg value: ~117zł (235zł total / 2 orders)
- [ ] Any customer with app orders still renders normally (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)