### PR TITLE
feat(customers): segment filters, fixed + Filter, richer timeline, drawer

### DIFF
--- a/apps/dashboard/src/components/CustomerDrawer.jsx
+++ b/apps/dashboard/src/components/CustomerDrawer.jsx
@@ -1,0 +1,43 @@
+// CustomerDrawer — narrow-viewport wrapper around CustomerDetailView.
+// On <1280px screens the side-by-side split layout collapses: the list
+// takes full width and the detail pane floats in from the right as a
+// slide-over, mirroring HelpPanel.jsx. On desktop (xl+) this whole element
+// is hidden via `xl:hidden` and the dashboard uses the inline split pane.
+//
+// Think of it as a production bay vs. an offsite satellite unit: on a wide
+// factory floor you run both lines parallel; on a narrow floor you swap
+// bays in and out as you need them.
+
+import { useEffect } from 'react';
+import CustomerDetailView from './CustomerDetailView.jsx';
+
+export default function CustomerDrawer({ customerId, onUpdate, onNavigate, onClose }) {
+  useEffect(() => {
+    function onKey(e) { if (e.key === 'Escape') onClose(); }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  if (!customerId) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end xl:hidden">
+      <div className="absolute inset-0 bg-black/30" onClick={onClose} />
+
+      <div className="relative w-[92vw] max-w-[560px] h-full bg-white shadow-2xl animate-slide-right overflow-y-auto">
+        <button
+          onClick={onClose}
+          className="sticky top-3 ml-auto mr-3 z-10 w-8 h-8 rounded-full bg-gray-100 flex items-center justify-center text-ios-tertiary text-sm hover:bg-gray-200 transition-colors float-right"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+        <CustomerDetailView
+          customerId={customerId}
+          onUpdate={onUpdate}
+          onNavigate={onNavigate}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/CustomerFilterBar.jsx
+++ b/apps/dashboard/src/components/CustomerFilterBar.jsx
@@ -56,8 +56,24 @@ export default function CustomerFilterBar({ filters, setFilters, customers, onCl
   const [editingDim, setEditingDim]   = useState(null);
   const rootRef = useRef(null);
 
-  const activeDims = useMemo(() => DIMENSIONS.filter(d => isActive(filters, d)), [filters]);
-  const inactiveDims = useMemo(() => DIMENSIONS.filter(d => !isActive(filters, d)), [filters]);
+  // displayDims includes every currently-active filter PLUS whichever
+  // dimension the owner just picked from "+ Filter" (editingDim). Without
+  // the editingDim bit, activating a multi-select dimension was invisible
+  // — its chip didn't render until a value was picked, but the picker lives
+  // inside the chip, so there was no way to pick one. Think of it as
+  // opening the workstation toolbox before any parts are selected.
+  const activeKeys = useMemo(
+    () => new Set(DIMENSIONS.filter(d => isActive(filters, d)).map(d => d.key)),
+    [filters]
+  );
+  const displayDims = useMemo(
+    () => DIMENSIONS.filter(d => activeKeys.has(d.key) || editingDim === d.key),
+    [activeKeys, editingDim]
+  );
+  const addableDims = useMemo(
+    () => DIMENSIONS.filter(d => !activeKeys.has(d.key) && editingDim !== d.key),
+    [activeKeys, editingDim]
+  );
   const count = activeFilterCount(filters);
 
   // Close popovers on outside click
@@ -106,7 +122,7 @@ export default function CustomerFilterBar({ filters, setFilters, customers, onCl
 
   return (
     <div ref={rootRef} className="flex flex-wrap items-center gap-1.5 relative">
-      {activeDims.map(dim => (
+      {displayDims.map(dim => (
         <FilterChip
           key={dim.key}
           dim={dim}
@@ -115,7 +131,7 @@ export default function CustomerFilterBar({ filters, setFilters, customers, onCl
           customers={customers}
           editing={editingDim === dim.key}
           onToggleEditor={() => setEditingDim(editingDim === dim.key ? null : dim.key)}
-          onClear={() => clearDimension(dim)}
+          onClear={() => { clearDimension(dim); setEditingDim(null); }}
         />
       ))}
 
@@ -126,9 +142,9 @@ export default function CustomerFilterBar({ filters, setFilters, customers, onCl
         >
           + {t.addFilter}
         </button>
-        {addMenuOpen && inactiveDims.length > 0 && (
+        {addMenuOpen && addableDims.length > 0 && (
           <div className="absolute z-20 left-0 mt-1 bg-white rounded-lg shadow-lg border border-gray-200 min-w-[200px] py-1 max-h-80 overflow-y-auto">
-            {inactiveDims.map(dim => (
+            {addableDims.map(dim => (
               <button
                 key={dim.key}
                 onClick={() => activateDimension(dim)}
@@ -162,6 +178,7 @@ function FilterChip({ dim, filters, setFilters, customers, editing, onToggleEdit
     const values = [...set];
     if (values.length === 1) display = `${label}: ${values[0]}`;
     else if (values.length > 1) display = `${label}: ${values[0]} +${values.length - 1}`;
+    else display = `${label}: ${t.chooseValues || '…'}`;
   } else if (dim.kind === 'withinDays') {
     display = `${label} ${filters.lastOrderWithinDays}d`;
   } else if (dim.kind === 'minNumber') {

--- a/apps/dashboard/src/components/CustomerTimeline.jsx
+++ b/apps/dashboard/src/components/CustomerTimeline.jsx
@@ -28,10 +28,45 @@ const LEGACY_FIELD_ORDER = [
 const APP_FIELD_ORDER = [
   'Order Date',
   'Status',
+  'Delivery Type',
+  'Delivery Date',
+  'Delivery Time',
+  'Payment Status',
   'Customer Request',
+  'Bouquet Summary',
   'Price Override',
+  'Final Price',
   'Order Lines',
 ];
+
+// Status → pill color. Same palette as OrdersTab so the owner reads the same
+// colors everywhere on the dashboard. Unknown statuses fall back to gray.
+const STATUS_COLORS = {
+  New:               'bg-indigo-100 text-indigo-700',
+  Ready:             'bg-amber-100 text-amber-700',
+  'Out for Delivery':'bg-sky-100 text-sky-700',
+  Delivered:         'bg-emerald-100 text-emerald-700',
+  'Picked Up':       'bg-teal-100 text-teal-700',
+  Cancelled:         'bg-rose-100 text-rose-700',
+};
+
+// Best-effort description for the collapsed row. Falls through a chain so
+// orders never show "—" when the backend actually has something useful.
+function rowDescription(order) {
+  if (order.description) return order.description;
+  const r = order.raw || {};
+  if (order.source === 'app') {
+    if (r['Bouquet Summary']) return r['Bouquet Summary'];
+    if (r['Customer Request']) return r['Customer Request'];
+    const lineCount = Array.isArray(r['Order Lines']) ? r['Order Lines'].length : 0;
+    if (lineCount > 0) return `${lineCount} \u00D7 ${lineCount === 1 ? 'line item' : 'line items'}`;
+  } else {
+    if (r['Flowers+Details of order']) return r['Flowers+Details of order'];
+    if (r['Order Reason']) return r['Order Reason'];
+    if (r['Oder Number'] || r['Order Number']) return r['Oder Number'] || r['Order Number'];
+  }
+  return '\u2014';
+}
 
 export default function CustomerTimeline({ orders, onNavigate }) {
   const [typeFilter, setTypeFilter] = useState('all');
@@ -91,8 +126,13 @@ export default function CustomerTimeline({ orders, onNavigate }) {
 }
 
 function TimelineRow({ order, expanded, onToggle, onNavigate }) {
-  const { source, date, description, amount, status } = order;
+  const { source, date, amount, status, raw = {} } = order;
   const isLegacy = source === 'legacy';
+  const description = rowDescription(order);
+  const deliveryType = raw['Delivery Type'];
+  const paymentStatus = raw['Payment Status'];
+  const isUnpaid = paymentStatus === 'Unpaid';
+  const fulfilmentIcon = deliveryType === 'Delivery' ? '\uD83D\uDE97' : deliveryType === 'Pickup' ? '\uD83C\uDFEA' : null;
 
   return (
     <div className="border-b border-white/30 last:border-b-0">
@@ -111,11 +151,23 @@ function TimelineRow({ order, expanded, onToggle, onNavigate }) {
         }`}>
           {isLegacy ? t.legacyOrder : t.appOrder}
         </span>
+        {fulfilmentIcon && (
+          <span className="text-sm shrink-0" title={deliveryType}>{fulfilmentIcon}</span>
+        )}
         <span className="text-sm text-ios-label truncate flex-1 min-w-0">
-          {description || '—'}
+          {description}
         </span>
+        {isUnpaid && (
+          <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-rose-100 text-rose-700 shrink-0 uppercase tracking-wide">
+            {t.unpaid || 'Unpaid'}
+          </span>
+        )}
         {status && (
-          <span className="text-xs text-ios-secondary shrink-0">{status}</span>
+          <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded shrink-0 ${
+            STATUS_COLORS[status] || 'bg-gray-100 text-gray-600'
+          }`}>
+            {status}
+          </span>
         )}
         <span className="text-sm font-medium text-ios-label shrink-0 w-20 text-right">
           {amount ? `${amount.toFixed(0)} ${t.zl}` : '—'}

--- a/apps/dashboard/src/components/CustomersTab.jsx
+++ b/apps/dashboard/src/components/CustomersTab.jsx
@@ -6,6 +6,7 @@ import client from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import t from '../translations.js';
 import CustomerDetailView from './CustomerDetailView.jsx';
+import CustomerDrawer from './CustomerDrawer.jsx';
 import CustomerListPane from './CustomerListPane.jsx';
 import { SkeletonTable } from './Skeleton.jsx';
 import {
@@ -84,14 +85,6 @@ export default function CustomersTab({ initialFilter, onNavigate }) {
     }));
   }
 
-  // Insights-bar RFM card click: toggle rfmSegment filter
-  const toggleRfm = useCallback(segKey => {
-    setFilters(prev => ({
-      ...prev,
-      rfmSegment: prev.rfmSegment === segKey ? null : segKey,
-    }));
-  }, []);
-
   // Insights-bar source pill click: toggle membership in sources Set
   const toggleSource = useCallback(src => {
     setFilters(prev => {
@@ -111,42 +104,22 @@ export default function CustomersTab({ initialFilter, onNavigate }) {
     [customers, selectedId]
   );
 
+  // Toggle membership in the segments Set (same pattern as Acquisition Source).
+  // Reuses the existing filters.segments state so the + Filter chip and these
+  // pills stay in sync as a single source of truth.
+  const toggleSegment = useCallback(seg => {
+    setFilters(prev => {
+      const next = new Set(prev.segments);
+      if (next.has(seg)) next.delete(seg); else next.add(seg);
+      return { ...prev, segments: next };
+    });
+  }, []);
+
   return (
     <div className="space-y-4">
-      {/* Insights bar — unchanged visually; clicks now mutate filter state */}
-      {insights?.rfm?.summary && (
-        <div className="mb-4">
-          <p className="text-xs font-semibold text-ios-tertiary uppercase tracking-wide mb-2">{t.customerHealth}</p>
-          <div className="grid grid-cols-5 gap-3">
-            {[
-              { key: 'Champions', color: 'bg-emerald-50 border-emerald-200 text-emerald-700', icon: '\u2605' },
-              { key: 'Loyal',     color: 'bg-blue-50 border-blue-200 text-blue-700', icon: '\u2665' },
-              { key: 'At Risk',   color: 'bg-amber-50 border-amber-200 text-amber-700', icon: '\u26A0' },
-              { key: 'Lost',      color: 'bg-rose-50 border-rose-200 text-rose-700', icon: '\u2717' },
-              { key: 'New',       color: 'bg-purple-50 border-purple-200 text-purple-700', icon: '\u2726' },
-            ].map(seg => {
-              const count = insights.rfm.summary[seg.key] || 0;
-              const rev = insights.rfm.revenue?.[seg.key] || 0;
-              const active = filters.rfmSegment === seg.key;
-              return (
-                <button key={seg.key}
-                  onClick={() => toggleRfm(seg.key)}
-                  className={`rounded-xl border p-3 text-center transition-all ${seg.color} ${
-                    active ? 'ring-2 ring-brand-400 shadow-md' : 'hover:shadow-sm'
-                  }`}>
-                  <div className="text-lg">{seg.icon}</div>
-                  <div className="text-2xl font-bold">{count}</div>
-                  <div className="text-xs font-medium">{t[`rfm${seg.key.replace(' ', '')}`] || seg.key}</div>
-                  {rev > 0 && <div className="text-xs opacity-70 mt-0.5">{Math.round(rev)} {t.zl}</div>}
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      )}
-
+      {/* Acquisition Source pills — click to toggle the 'sources' multi-filter */}
       {insights?.acquisitionBySource && Object.keys(insights.acquisitionBySource).length > 0 && (
-        <div className="mb-4">
+        <div>
           <p className="text-xs font-semibold text-ios-tertiary uppercase tracking-wide mb-2">{t.acquisitionSource}</p>
           <div className="flex flex-wrap gap-2">
             {Object.entries(insights.acquisitionBySource)
@@ -168,43 +141,46 @@ export default function CustomersTab({ initialFilter, onNavigate }) {
         </div>
       )}
 
-      {insights && (
-        <div className="grid grid-cols-2 lg:grid-cols-5 gap-3">
-          {Object.entries(insights.segments || {}).map(([seg, count]) => (
-            <div key={seg} className="bg-white rounded-2xl shadow-sm px-4 py-3 text-center">
-              <p className="text-2xl font-bold text-ios-label">{count}</p>
-              <p className={`text-xs font-medium mt-1 inline-block px-2 py-0.5 rounded-full ${
-                SEGMENT_COLORS[seg] || 'bg-gray-100 text-gray-600'
-              }`}>
-                {seg}
-              </p>
-              {insights.segmentRevenue?.[seg] > 0 && (
-                <p className="text-xs text-ios-tertiary mt-1">{Math.round(insights.segmentRevenue[seg])} {t.zl}</p>
-              )}
-            </div>
-          ))}
-
-          {insights.churnRisk?.length > 0 && (
-            <div
-              onClick={toggleChurn}
-              className={`bg-white rounded-2xl shadow-sm px-4 py-3 text-center cursor-pointer hover:bg-ios-orange/10 transition-colors ${
-                filters.churnRisk ? 'ring-2 ring-ios-orange' : ''
-              }`}>
-              <p className="text-2xl font-bold text-ios-orange">{insights.churnRisk.length}</p>
-              <p className="text-xs text-ios-orange font-medium mt-1">{t.churnRisk}</p>
-              {insights.totalRevenueAtRisk > 0 && (
-                <span className="text-xs text-rose-500 font-medium ml-1">
-                  {Math.round(insights.totalRevenueAtRisk)} {t.zl} {t.revenueAtRisk}
-                </span>
-              )}
-            </div>
-          )}
+      {/* Segment (client) pills — click to toggle the 'segments' multi-filter.
+           Same interaction model as Acquisition Source for a single mental model. */}
+      {insights && Object.keys(insights.segments || {}).length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-ios-tertiary uppercase tracking-wide mb-2">{t.segment}</p>
+          <div className="flex flex-wrap gap-2">
+            {Object.entries(insights.segments || {})
+              .sort(([,a], [,b]) => b - a)
+              .map(([seg, count]) => {
+                const active = filters.segments.has(seg);
+                const color = SEGMENT_COLORS[seg] || 'bg-gray-100 text-ios-label';
+                return (
+                  <button key={seg}
+                    onClick={() => toggleSegment(seg)}
+                    className={`px-3 py-1 rounded-full text-sm transition-all ${
+                      active ? 'bg-brand-600 text-white shadow-sm' : `${color} hover:opacity-80`
+                    }`}>
+                    {seg}{' '}
+                    <span className={active ? 'text-white/70' : 'opacity-60'}>{count}</span>
+                  </button>
+                );
+              })}
+            {insights.churnRisk?.length > 0 && (
+              <button onClick={toggleChurn}
+                className={`px-3 py-1 rounded-full text-sm transition-all ${
+                  filters.churnRisk ? 'bg-ios-orange text-white shadow-sm' : 'bg-ios-orange/15 text-ios-orange hover:bg-ios-orange/25'
+                }`}>
+                {t.churnRisk}{' '}
+                <span className={filters.churnRisk ? 'text-white/70' : 'opacity-60'}>{insights.churnRisk.length}</span>
+              </button>
+            )}
+          </div>
         </div>
       )}
 
       {loading && <SkeletonTable rows={6} cols={4} />}
 
-      {/* Split view: list pane left, detail pane right (or below on narrow viewports) */}
+      {/* Desktop split-view (≥1280px): list + inline detail pane side by side.
+           Below 1280px the inline detail pane is hidden (xl:block); a
+           CustomerDrawer slides in instead — see below. */}
       {!loading && (
         <div className="grid grid-cols-1 xl:grid-cols-[420px_1fr] gap-4" style={{ height: '70vh', minHeight: 500 }}>
           <div className="h-full">
@@ -219,7 +195,7 @@ export default function CustomersTab({ initialFilter, onNavigate }) {
               onClearAll={clearAll}
             />
           </div>
-          <div className="bg-white rounded-2xl shadow-sm overflow-auto">
+          <div className="hidden xl:block bg-white rounded-2xl shadow-sm overflow-auto">
             {selectedCustomer ? (
               <CustomerDetailView
                 customerId={selectedCustomer.id}
@@ -234,6 +210,16 @@ export default function CustomersTab({ initialFilter, onNavigate }) {
           </div>
         </div>
       )}
+
+      {/* Narrow-viewport drawer (<1280px). Hidden on desktop via xl:hidden
+           inside the component, so on wide screens the inline pane above
+           handles the detail view. */}
+      <CustomerDrawer
+        customerId={selectedCustomer?.id || null}
+        onUpdate={fetchCustomers}
+        onNavigate={onNavigate}
+        onClose={() => setSelected(null)}
+      />
     </div>
   );
 }

--- a/apps/dashboard/src/components/OrdersTab.jsx
+++ b/apps/dashboard/src/components/OrdersTab.jsx
@@ -86,6 +86,10 @@ export default function OrdersTab({ initialFilter, onNavigate }) {
   const [paymentMethodFilter, setPaymentMethod] = useState(f.paymentMethod || '');
   const [excludeCancelled, setExcludeCancelled] = useState(!!f.excludeCancelled);
   const [expandedId, setExpanded] = useState(f.orderId || null);
+  // When the owner navigates here from a customer timeline, only the clicked
+  // order should be visible — otherwise it's buried among all other orders
+  // in the date range. A dismissable banner lets them return to the full list.
+  const [focusOrderId, setFocusOrderId] = useState(f.orderId || null);
   const [selected, setSelected]   = useState(new Set());
   const [upcomingMode, setUpcoming] = useState(!f.dateFrom && !f.orderId);
   const [showPremade, setShowPremade] = useState(false);
@@ -157,6 +161,9 @@ export default function OrdersTab({ initialFilter, onNavigate }) {
     : orders;
   if (noDateOnly) {
     filtered = filtered.filter(o => !o['Delivery Date'] && !o['Required By']);
+  }
+  if (focusOrderId) {
+    filtered = filtered.filter(o => o.id === focusOrderId);
   }
 
   // Sort orders based on selected sort option + direction (bidirectional)
@@ -321,6 +328,24 @@ export default function OrdersTab({ initialFilter, onNavigate }) {
           {sortDir === 'asc' ? '↑' : '↓'}
         </button>
       </div>
+
+      {/* Focused-order banner — when navigating from a customer timeline, we
+          hide every other order so the target row is always visible without
+          scrolling. The banner keeps an obvious escape hatch back to the full
+          list (otherwise the list would look mysteriously empty). */}
+      {focusOrderId && (
+        <div className="flex items-center justify-between px-4 py-2.5 rounded-xl bg-brand-50 border border-brand-200">
+          <span className="text-sm text-brand-700 font-medium">
+            📌 {t.showingSingleOrder || 'Focused on a single order from customer profile'}
+          </span>
+          <button
+            onClick={() => setFocusOrderId(null)}
+            className="text-xs text-brand-700 hover:text-brand-800 font-medium underline"
+          >
+            {t.showAllOrders || 'Show all orders'}
+          </button>
+        </div>
+      )}
 
       {/* Active filter badges — show when any filter is active so the user
           always has a path to undo state. Used to only track cross-tab filters,

--- a/apps/dashboard/src/translations.js
+++ b/apps/dashboard/src/translations.js
@@ -177,6 +177,9 @@ const en = {
   // Customer Tab v2.0 — list + filter bar
   searchAnyField:   'Search any field...',
   addFilter:        'Filter',
+  chooseValues:     'choose…',
+  showingSingleOrder: 'Focused on a single order from customer profile',
+  showAllOrders:    'Show all orders',
   remove:           'Remove',
   customers:        'customers',
   sortBy:           'Sort by',
@@ -989,6 +992,9 @@ const ru = {
   // Customer Tab v2.0 — list + filter bar
   searchAnyField:   'Поиск по любому полю...',
   addFilter:        'Фильтр',
+  chooseValues:     'выбрать…',
+  showingSingleOrder: 'Показан один заказ из профиля клиента',
+  showAllOrders:    'Показать все заказы',
   remove:           'Убрать',
   customers:        'клиентов',
   sortBy:           'Сортировка',


### PR DESCRIPTION
## Summary
- Removed top Customer Health (RFM) strip — owner said it wasn't useful
- Segment row is now clickable filter pills (mirrors Acquisition Source)
- Fixed the **+ Filter** dropdown: multi-select dimensions (Sex/Business, Language, etc.) now actually open their value picker
- Richer timeline rows: description fallback (`Bouquet Summary → Customer Request → N × line items`), delivery/pickup icon, Unpaid badge, color-coded status pill
- "Open in Orders tab" now focuses the list to that single order with a dismissable banner
- **Iteration 4:** CustomerDrawer slides in from the right on <1280px viewports; inline split pane remains the desktop default

## Test plan
- [x] Customers tab loads without Customer Health block
- [x] Clicking a Segment pill (e.g. Constant) narrows list to 58/1095
- [x] + Filter → Sex/Business → picker opens with 4 checkboxes; selecting Male narrows to 565/1095
- [x] Anna Leonova timeline row shows `Приложение · 🚗 · 2 × line items · Delivered · 200 zł` (no more bare `—`)
- [x] "Open in Orders tab" lands on Orders with exactly 1 order visible + dismissable banner
- [x] At 768×1024 the detail drawer slides in; backdrop + Esc both close it
- [x] ErrorBoundary clean on current build (historical HMR errors from mid-edit are gone after reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)