### PR TITLE
feat(stock): persist Substitute For link on PO substitute receive

### DIFF
--- a/backend/src/routes/stockOrders.js
+++ b/backend/src/routes/stockOrders.js
@@ -550,7 +550,7 @@ async function purchaseAlreadyRecorded(poId, lineId, variant) {
 // sensible defaults without requiring the florist to fill a form.
 //
 // Sell price uses the global targetMarkup setting: sellPrice = costPerStem * markup.
-async function findOrCreateSubstituteStock(altFlowerName, altSupplier, costPerStem, originalStockItem, today) {
+async function findOrCreateSubstituteStock(altFlowerName, altSupplier, costPerStem, originalStockItem, originalStockId, today) {
   const trimmedName = (altFlowerName || '').trim();
   if (!trimmedName) {
     throw new Error('Cannot receive substitute with empty flower name');
@@ -564,7 +564,20 @@ async function findOrCreateSubstituteStock(altFlowerName, altSupplier, costPerSt
     maxRecords: 1,
   });
   if (existing.length > 0) {
-    return existing[0].id;
+    const found = existing[0];
+    // Phase B: stack multiple originals onto one substitute card. If this
+    // substitute was previously created for a different original flower,
+    // append the current originalStockId so the reconciliation query can
+    // find all affected originals from the substitute side.
+    if (originalStockId) {
+      const currentLinks = Array.isArray(found['Substitute For']) ? found['Substitute For'] : [];
+      if (!currentLinks.includes(originalStockId)) {
+        await db.update(TABLES.STOCK, found.id, {
+          'Substitute For': [...currentLinks, originalStockId],
+        });
+      }
+    }
+    return found.id;
   }
 
   // Not found → create a brand-new stock card for the substitute.
@@ -585,6 +598,7 @@ async function findOrCreateSubstituteStock(altFlowerName, altSupplier, costPerSt
     'Reorder Threshold':  originalStockItem?.['Reorder Threshold'] || 0,
     Active:               true,
     'Last Restocked':     today,
+    ...(originalStockId ? { 'Substitute For': [originalStockId] } : {}),
   });
   console.log(`[STOCK-ORDER] Created substitute stock card "${trimmedName}" (${created.id}) — cost ${costPerStem} zł, sell ${sellPerStem} zł`);
   return created.id;
@@ -794,7 +808,7 @@ router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), as
               ? await db.getById(TABLES.STOCK, stockItemId)
               : null;
             substituteStockId = await findOrCreateSubstituteStock(
-              altFlowerName, altSupplier, altCostPerStem, originalStockItem, evalDate
+              altFlowerName, altSupplier, altCostPerStem, originalStockItem, stockItemId, evalDate
             );
             const markup = Number(getConfig('targetMarkup')) || 1;
             const altSellPerStem = Math.round(altCostPerStem * markup * 100) / 100;

--- a/backend/src/services/airtableSchema.js
+++ b/backend/src/services/airtableSchema.js
@@ -46,6 +46,7 @@ const EXPECTED_WRITE_FIELDS = {
     'Display Name', 'Purchase Name', 'Category',
     'Current Quantity', 'Current Cost Price', 'Current Sell Price',
     'Supplier', 'Unit', 'Reorder Threshold', 'Active', 'Last Restocked',
+    'Substitute For',
   ],
   [TABLES.PREMADE_BOUQUETS]: [
     'Name', 'Created By', 'Price Override', 'Notes', 'Lines',


### PR DESCRIPTION
## Summary
Phase B Commit 1 of the PO substitute reconciliation rollout (locked plan: decisions 1A 2C 3A 4B 5A 6A).

- Add `Substitute For` to the STOCK block of `EXPECTED_WRITE_FIELDS` in [airtableSchema.js:45](backend/src/services/airtableSchema.js:45). Boot will now hard-fail until the owner adds the self-link field in Airtable (that's Commit 2). This is deliberate — we'd rather catch the missing field at deploy than as a silent 422 during PO evaluation.
- Thread `originalStockId` through `findOrCreateSubstituteStock` at [stockOrders.js:553](backend/src/routes/stockOrders.js:553) and its single caller at [stockOrders.js:796](backend/src/routes/stockOrders.js:796). On **create**, the new stock card is linked back to the original it's substituting for. On **find**, if the existing substitute card doesn't already include this original in its `Substitute For`, we append it — so one "Pink Roses" card accumulates all originals it has stood in for (decision 3A: stack multiple originals onto one card).
- No frontend changes, no deletions. The Phase B reconciliation UI and the drift-shape endpoint rewrite land in later commits.

## Test plan
- [ ] **Commit 2 first in Airtable:** owner adds self-link field `Substitute For` on the Stock table (links to Stock). Without this, backend boot will exit(1) with a clear schema-mismatch error — that's expected behavior, not a regression.
- [ ] Run a PO through evaluation with an `Alt Flower Name` whose substitute stock card does NOT yet exist. Verify the new card is created with `Substitute For` pointing at the original (negative-qty) stock record.
- [ ] Run a second PO where the same substitute is delivered for a DIFFERENT original. Verify the substitute card's `Substitute For` now contains both original stock IDs.
- [ ] Run a third PO where the same substitute is delivered again for an already-linked original. Verify no redundant update — the `includes()` guard skips the write.
- [ ] Edge case: PO line with no `Stock Item` link (new flower never in stock). `originalStockId` is null, the function skips the link write on both branches, and behavior is unchanged from today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)