### PR TITLE
fix(pull): delete orphaned variant rows when their Wix product still exists

### DIFF
--- a/backend/src/services/wixProductSync.js
+++ b/backend/src/services/wixProductSync.js
@@ -568,10 +568,39 @@ export async function runPull() {
       }
     }
 
-    // Deactivate rows whose Wix product/variant no longer exists
+    // Reconcile rows whose Wix product/variant no longer exists.
+    //
+    // Two cases, two behaviors:
+    //
+    //  1. The Wix PRODUCT is still alive but this specific variant ID is
+    //     gone. That happens when the owner removes a variant option in
+    //     the Wix Editor (e.g., drops the "Bouquet: 1/2/3/4/5" option and
+    //     goes back to a single default variant). The old Airtable row is
+    //     orphaned — its Product Name becomes misleading as the product
+    //     gets renamed, and it clutters the dashboard as a ghost group.
+    //     → Delete the row.
+    //
+    //  2. The whole Wix PRODUCT is gone (deleted from the store). We don't
+    //     delete the Airtable row because the owner may want to review
+    //     history before removing it, and downstream references (order
+    //     lines, sync log) might still point to it.
+    //     → Deactivate only (legacy behavior).
+    const wixProductIds = new Set(wixProducts.map(p => p.id));
+
     for (const row of existingRows) {
       const key = `${row['Wix Product ID']}::${row['Wix Variant ID']}`;
-      if (!seenKeys.has(key) && row['Active']) {
+      if (seenKeys.has(key)) continue;
+
+      const productStillAlive = wixProductIds.has(row['Wix Product ID']);
+
+      if (productStillAlive) {
+        try {
+          await db.deleteRecord(TABLES.PRODUCT_CONFIG, row.id);
+          stats.deleted = (stats.deleted || 0) + 1;
+        } catch (err) {
+          stats.errors.push(`Delete orphaned variant ${row['Product Name']}/${row['Variant Name']}: ${err.message}`);
+        }
+      } else if (row['Active']) {
         try {
           await db.update(TABLES.PRODUCT_CONFIG, row.id, { 'Active': false });
           stats.deactivated++;


### PR DESCRIPTION
## Symptom
After restructuring Wix products (Option A setup: multiple single-variant products), three existing products were renamed in-place in the Wix Editor and had their Bouquet option dropped:

| Wix Product ID | New name | Old name (stale in Airtable) |
|---|---|---|
| e81b1dc3 | Mix of the day 2 - M | Mix of the day - L |
| 0071549d | Mix of the day 1 - M | Mix of the day - M |
| 101c3e01 | Mix of the day 1 - L | Mix of the day - S |

The dashboard still showed three \"Mix of the day - L/M/S\" groups with 6 ghost variants each, alongside the correctly-named live products. Effectively the rename didn't propagate.

## Root cause
The pull matches Airtable rows to Wix variants on the composite key \`(productId, variantId)\`. When the owner dropped the Bouquet option, the variant IDs changed — old Airtable rows became orphaned. Previous behavior was to deactivate them (set \`Active=false\`) while preserving the row, which left the stale Product Name visible in the dashboard.

## Fix
In the post-loop reconciliation, split into two paths:
- **Variant orphaned but product still exists** → delete the row. This is the \"owner removed a variant option\" case; the row has nothing left to reference.
- **Whole product gone** → keep row, mark inactive. Preserves history for downstream review (order lines, sync log).

Adds \`stats.deleted\` counter to the push/pull summary.

## Test plan
- [ ] Merge + deploy
- [ ] Run pull from the dashboard
- [ ] Confirm the 3 stale \"Mix of the day - L/M/S\" groups disappear
- [ ] Confirm new groups \"Mix of the day 2 - M\", \"1 - M\", \"1 - L\" appear with their current Wix names
- [ ] \`stats.deleted\` in the sync log shows a count of removed orphans (~18 if all three old products had 5 stem variants + a default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)