### PR TITLE
Add role-specific owner notes, customer call buttons, and driver navigation options

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -191,6 +191,14 @@ substitutes no longer silently fill in for the original, so the original can end
 - [ ] **Hardcoded categories/units** — StockTab uses inline arrays instead of `useConfigLists`
 - [ ] **StockPickupPage empty state** — shows `t.noDeliveries` instead of a stock-pickup-specific message
 
+### Owner-notes + customer call + driver nav (2026-04-21)
+- [x] Split owner-authored notes by audience: `Florist Note` (ORDERS) + `Driver Instructions` (DELIVERIES), each prominent on the right role's collapsed card; customer's note stays as `Notes Original`, driver's own note stays as `Driver Notes`.
+- [x] Editable at every order stage from dashboard + florist app (no status gate) — owner can add a post-delivery note if needed.
+- [x] Customer phone rendered as a one-tap `CallButton` on florist collapsed card, delivery collapsed card, and both detail views. Dashboard recipient phone is also a call link.
+- [x] Delivery card: explicit "Details ▾" button for discoverable expand (card body still tappable).
+- [x] Three-way navigation strip on delivery card + sheet: Google Maps / Waze / Apple Maps (text-address based — no geocoding).
+- [ ] Consider adding a tiny `Florist Note` field to the new-order wizard Step 3 so the owner can capture it at creation time (today she has to open the order after creation).
+
 ### Tier 1 Bugs — Blocking Daily Operations (consolidated 2026-04-19)
 
 Consolidated from two divergent sections ("2026-04-03" and "2026-04-07"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Changes made to the **dev base** that must be replicated in **production** befor
 | 2026-03-18 | Florist Hours | New field: `Rate Type` (Single line text) — stores rate type name per entry | ❌ |
 | 2026-04-11 | Premade Bouquets | **New table** — standalone bouquet compositions the florist prepares before any order. Fields: `Name` (Single line text, required), `Created At` (Created time, auto), `Created By` (Single line text), `Price Override` (Number, optional), `Notes` (Long text), `Lines` (link → Premade Bouquet Lines). | ❌ |
 | 2026-04-11 | Premade Bouquet Lines | **New table** — line items for a premade bouquet. Fields: `Premade Bouquet` (link → Premade Bouquets), `Stock Item` (link → Stock, required), `Flower Name` (Single line text), `Quantity` (Number), `Cost Price Per Unit` (Number, snapshot), `Sell Price Per Unit` (Number, snapshot). | ❌ |
+| 2026-04-21 | App Orders | New field: `Florist Note` (Long text) — owner-authored guidance for the florist, separate from the customer's `Notes Original`. Visible on florist collapsed card + editable at every order stage from both dashboard and florist app. | ❌ |
+| 2026-04-21 | Deliveries | New field: `Driver Instructions` (Long text) — owner-authored instructions for the driver, separate from the driver's own `Driver Notes`. Visible on delivery collapsed card + editable from dashboard and florist app. | ❌ |
 
 ### Env vars
 
@@ -36,6 +38,59 @@ Add to `.env.dev` and `.env` (before the feature ships):
 AIRTABLE_PREMADE_BOUQUETS_TABLE=tbl...       # Premade Bouquets table ID
 AIRTABLE_PREMADE_BOUQUET_LINES_TABLE=tbl...  # Premade Bouquet Lines table ID
 ```
+
+---
+
+## 2026-04-21 — Role-specific owner notes, customer call button, driver nav options
+
+The owner needed to direct the florist and the driver with separate
+instructions on every order, and the florist / driver needed a one-tap
+call to the customer (not the recipient). The driver card hid its
+expand affordance behind call and navigate links, and Google Maps was
+the only navigation option.
+
+### Airtable schema (owner action required before deploy)
+- **App Orders → new field `Florist Note` (Long text)** — owner-authored note for the florist, shown as a green 🌸 block on the florist card. Distinct from the customer's `Notes Original` (kept as a blue 📝 block).
+- **Deliveries → new field `Driver Instructions` (Long text)** — owner-authored instructions for the driver, shown as an orange ⚠ block on the delivery card. Distinct from the driver's own `Driver Notes` (kept as the driver-editable note).
+
+### Backend (`backend/src/`)
+- `routes/orders.js` — `Florist Note` added to `ORDERS_PATCH_ALLOWED`; POST /orders accepts `floristNote`; convert-to-delivery accepts `driverInstructions`; list endpoint now enriches `Customer Phone` so florist cards can call the customer without an extra fetch.
+- `routes/deliveries.js` — `Driver Instructions` added to `DELIVERIES_PATCH_ALLOWED`.
+- `services/orderService.js` — `createOrder` writes `Florist Note` on order + `Driver Instructions` on delivery at creation time.
+- `services/airtableSchema.js` — startup validator now checks both new fields so a missing field fails the boot instead of silently 422'ing PATCH calls.
+
+### Shared package (`packages/shared/`)
+- New `utils/phone.js` (`cleanPhone`, `telHref`) + tests.
+- New `utils/navigation.js` (`googleMapsUrl`, `wazeUrl`, `appleMapsUrl`) + tests.
+- New `components/CallButton.jsx` — consistent green click-to-call pill with `stopPropagation` so it can sit inside clickable cards.
+- New `components/NavButtons.jsx` — three-up Google / Waze / Apple nav strip.
+- 12 tests, all green. Package-level `npm test` script added.
+
+### Dashboard (`apps/dashboard/`)
+- `OrderDetailPanel.jsx` — Notes section restructured into three rows: customer note (read-only, `Notes Original`), florist note (editable, `Florist Note`), driver instructions (editable, delivery orders only). Recipient phone row gains a `CallButton` via the new `trailing` prop on `EditableRow`.
+- New translation keys added (EN + RU): `customerNote`, `floristNote`, `driverInstructions`, placeholders, `callCustomer`, `callRecipient`, `customer`, `recipient`.
+
+### Florist app (`apps/florist/`)
+- `OrderCardSummary.jsx` — collapsed card now shows florist note in a green block (first) and customer note in the existing blue block; customer phone sits next to the customer name as a `CallButton`.
+- `OrderCard.jsx` (expanded) — two inline editors added (green for florist note, orange for driver instructions). Editable at every status so the owner can add instructions after "Delivered" if needed.
+- `OrderDetailPage.jsx` — same two editors, customer phone converted to `CallButton`.
+- New translation keys mirroring the dashboard set.
+
+### Delivery app (`apps/delivery/`)
+- `DeliveryCard.jsx` — address is now plain text above the three-way nav strip (Google / Waze / Apple), two `CallButton`s (customer + recipient), owner's `Driver Instructions` shown in an orange block (falls back to the legacy `Special Instructions` for old data), explicit "Details ▾" button makes the expand action discoverable without competing with call/navigate.
+- `DeliverySheet.jsx` — nav strip in its own section, both phone rows converted to `CallButton`, owner's driver instructions rendered read-only above the driver's own notes editor.
+- New translation keys: `driverInstructions`, `callCustomer`, `callRecipient`, `customer`, `details`, `navigate`.
+
+### Why it matters
+- The owner now has a single, clear authoring surface (dashboard + florist mobile) to talk to each role independently; florists and drivers read the message meant for them on the collapsed card, not buried in the sheet.
+- Drivers no longer have to guess where to tap to expand — the explicit "Details" button removes that ambiguity — and can choose their preferred map app instead of being forced into Google Maps.
+- Customer phone is one tap away on every card the florist or driver touches, with `CallButton` centralizing formatting (`cleanPhone` strips spaces once, instead of four times).
+
+### What to watch for
+- `Driver Instructions` is separate from the existing `Driver Notes`. The driver's own post-delivery observations still live in `Driver Notes`; only the owner writes `Driver Instructions`. If anyone starts re-using `Driver Notes` for owner messages, it will collide with what the driver types.
+- The florist card's florist-note block renders only when `Florist Note` is non-empty. Orders created before this deploy will have no green block — that's expected, not a regression.
+- Apple Maps on Android falls back to Google Maps in the browser; this is acceptable but means Android drivers effectively see "Google Google Waze". Worth confirming on a real Android device during verification.
+- `airtableSchema.js` will now fail boot if either new field is missing from the base. Create both in Airtable before deploying the backend.
 
 ---
 

--- a/apps/dashboard/src/components/OrderDetailPanel.jsx
+++ b/apps/dashboard/src/components/OrderDetailPanel.jsx
@@ -8,7 +8,7 @@ import t from '../translations.js';
 import Pills from './Pills.jsx';
 import InlineEdit from './InlineEdit.jsx';
 import useConfigLists from '../hooks/useConfigLists.js';
-import { DissolvePremadesDialog, computePremadeShortfalls } from '@flower-studio/shared';
+import { DissolvePremadesDialog, computePremadeShortfalls, CallButton } from '@flower-studio/shared';
 
 // Split "Rose Red (14.Mar.)" into { name: "Rose Red", batch: "14.Mar." }
 function parseBatchName(displayName) {
@@ -949,7 +949,8 @@ export default function OrderDetailPanel({ orderId, onUpdate }) {
             <EditableRow label={t.recipientName} value={o.delivery['Recipient Name']}
               onSave={v => patchDelivery({ 'Recipient Name': v })} disabled={saving} />
             <EditableRow label={t.phone} value={o.delivery['Recipient Phone']}
-              onSave={v => patchDelivery({ 'Recipient Phone': v })} disabled={saving} />
+              onSave={v => patchDelivery({ 'Recipient Phone': v })} disabled={saving}
+              trailing={<CallButton phone={o.delivery['Recipient Phone']} label={t.callRecipient} variant="subtle" />} />
             <EditableRow label={t.deliveryAddress} value={o.delivery['Delivery Address']}
               onSave={v => patchDelivery({ 'Delivery Address': v })} disabled={saving} multiline />
             <EditableRow label={t.deliveryFee} value={o.delivery['Delivery Fee'] ? String(o.delivery['Delivery Fee']) : ''}
@@ -959,15 +960,48 @@ export default function OrderDetailPanel({ orderId, onUpdate }) {
         </div>
       )}
 
-      {/* Notes */}
+      {/* Notes — owner writes separate guidance for florist and driver */}
       <Section label={t.notes}>
-        <InlineEdit
-          value={o['Notes Original'] || ''}
-          multiline
-          placeholder="—"
-          onSave={v => patchOrder({ 'Notes Original': v })}
-          disabled={saving}
-        />
+        <div className="space-y-3">
+          <div>
+            <p className="text-[10px] font-semibold text-ios-tertiary uppercase tracking-wide mb-1">
+              {t.customerNote}
+            </p>
+            <InlineEdit
+              value={o['Notes Original'] || ''}
+              multiline
+              placeholder="—"
+              onSave={v => patchOrder({ 'Notes Original': v })}
+              disabled={saving}
+            />
+          </div>
+          <div>
+            <p className="text-[10px] font-semibold text-green-700 uppercase tracking-wide mb-1">
+              🌸 {t.floristNote}
+            </p>
+            <InlineEdit
+              value={o['Florist Note'] || ''}
+              multiline
+              placeholder={t.floristNotePlaceholder}
+              onSave={v => patchOrder({ 'Florist Note': v })}
+              disabled={saving}
+            />
+          </div>
+          {o.delivery && (
+            <div>
+              <p className="text-[10px] font-semibold text-orange-700 uppercase tracking-wide mb-1">
+                🚗 {t.driverInstructions}
+              </p>
+              <InlineEdit
+                value={o.delivery['Driver Instructions'] || ''}
+                multiline
+                placeholder={t.driverInstructionsPlaceholder}
+                onSave={v => patchDelivery({ 'Driver Instructions': v })}
+                disabled={saving}
+              />
+            </div>
+          )}
+        </div>
       </Section>
 
       {/* Action buttons */}
@@ -1051,11 +1085,11 @@ function Section({ label, children }) {
 }
 
 // Editable key-value row for delivery info
-function EditableRow({ label, value, onSave, disabled, multiline, type, suffix }) {
+function EditableRow({ label, value, onSave, disabled, multiline, type, suffix, trailing }) {
   return (
     <div className="flex items-start gap-3">
       <span className="text-xs text-ios-tertiary w-20 shrink-0 pt-0.5">{label}</span>
-      <div className="flex-1 flex items-center gap-1">
+      <div className="flex-1 flex items-center gap-2">
         <InlineEdit
           value={value || ''}
           onSave={onSave}
@@ -1065,6 +1099,7 @@ function EditableRow({ label, value, onSave, disabled, multiline, type, suffix }
           placeholder="—"
         />
         {suffix && value && <span className="text-xs text-ios-tertiary">{suffix}</span>}
+        {trailing}
       </div>
     </div>
   );

--- a/apps/dashboard/src/translations.js
+++ b/apps/dashboard/src/translations.js
@@ -815,6 +815,17 @@ const en = {
   fixesApplied:             'Corrections applied',
   currentStock:             'Current',
   expectedDeduction:        'Expected deduction',
+
+  // Owner-authored role-specific notes + customer call
+  customerNote:                 'Customer note',
+  floristNote:                  'Florist note',
+  driverInstructions:           'Driver instructions',
+  floristNotePlaceholder:       'Note for the florist…',
+  driverInstructionsPlaceholder:'Instructions for the driver…',
+  callCustomer:                 'Call customer',
+  callRecipient:                'Call recipient',
+  customer:                     'Customer',
+  recipient:                    'Recipient',
 };
 
 const ru = {
@@ -1631,6 +1642,17 @@ const ru = {
   fixesApplied:             'Корректировки применены',
   currentStock:             'Текущий',
   expectedDeduction:        'Ожидаемое списание',
+
+  // Owner-authored role-specific notes + customer call
+  customerNote:                 'Заметка клиента',
+  floristNote:                  'Заметка для флориста',
+  driverInstructions:           'Инструкции водителю',
+  floristNotePlaceholder:       'Заметка для флориста…',
+  driverInstructionsPlaceholder:'Инструкции водителю…',
+  callCustomer:                 'Позвонить клиенту',
+  callRecipient:                'Позвонить получателю',
+  customer:                     'Клиент',
+  recipient:                    'Получатель',
 };
 
 // ── Proxy-based dynamic translation ──

--- a/apps/delivery/src/components/DeliveryCard.jsx
+++ b/apps/delivery/src/components/DeliveryCard.jsx
@@ -1,8 +1,11 @@
 // DeliveryCard — a compact card for each delivery in the list.
-// Tap the card to open the detail sheet. Quick-action buttons for Maps and phone.
-// Think of it as a dispatch slip: recipient, address, time, and one-tap actions.
+// Tap the card (or the explicit "Details" button) to open the detail
+// sheet. Call and navigation buttons open their respective apps
+// without triggering expand, so the driver can decide: expand, call,
+// or navigate — without accidental taps.
 
 import t from '../translations.js';
+import { CallButton, NavButtons } from '@flower-studio/shared';
 
 export default function DeliveryCard({ delivery, onTap, onStatusChange, onProblem, dimmed }) {
   const d = delivery;
@@ -11,16 +14,17 @@ export default function DeliveryCard({ delivery, onTap, onStatusChange, onProble
   const isOut      = status === 'Out for Delivery';
   const isDone     = status === 'Delivered';
 
-  const address       = d['Delivery Address'] || '';
-  const phone         = d['Recipient Phone'] || '';
-  const time          = d['Delivery Time'] || '';
-  const recipient     = d['Recipient Name'] || 'Unknown';
-  const fee           = d['Delivery Fee'];
-  const deliveredAt     = d['Delivered At'];
-  const deliveryResult  = d['Delivery Result'] || '';
-  const orderContents   = d['Order Contents'] || '';
-  const specialInstr  = d['Special Instructions'] || '';
-  const paymentStatus = d['Payment Status'] || '';
+  const address          = d['Delivery Address'] || '';
+  const recipientPhone   = d['Recipient Phone'] || '';
+  const customerPhone    = d['Customer Phone'] || '';
+  const time             = d['Delivery Time'] || '';
+  const recipient        = d['Recipient Name'] || 'Unknown';
+  const deliveredAt      = d['Delivered At'];
+  const deliveryResult   = d['Delivery Result'] || '';
+  // Owner-authored instructions (new) fall back to the legacy translated
+  // customer note so existing data still renders.
+  const driverInstr      = d['Driver Instructions'] || d['Special Instructions'] || '';
+  const paymentStatus    = d['Payment Status'] || '';
 
   // Payment status badge styling
   function paymentBadge() {
@@ -38,14 +42,6 @@ export default function DeliveryCard({ delivery, onTap, onStatusChange, onProble
   function handleStatusChange(newStatus) {
     onStatusChange(newStatus);
   }
-
-  // Build Google Maps URL for the address
-  const mapsUrl = address
-    ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}`
-    : null;
-
-  // Build tel: link
-  const telUrl = phone ? `tel:${phone.replace(/\s/g, '')}` : null;
 
   return (
     <div
@@ -81,35 +77,47 @@ export default function DeliveryCard({ delivery, onTap, onStatusChange, onProble
           </div>
         </div>
 
-        {/* Address — tappable to open Maps */}
+        {/* Address — plain text; nav strip below offers three map apps */}
         {address && (
-          <a
-            href={mapsUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={e => e.stopPropagation()}
-            className="flex items-start gap-1.5 text-xs text-ios-blue active:underline"
-          >
+          <p className="flex items-start gap-1.5 text-xs text-ios-label">
             <span className="shrink-0 mt-0.5">📍</span>
             <span className="line-clamp-2">{address}</span>
-          </a>
+          </p>
         )}
 
-        {/* Phone — tappable to call */}
-        {phone && (
-          <a
-            href={telUrl}
-            onClick={e => e.stopPropagation()}
-            className="flex items-center gap-1.5 text-xs text-ios-blue active:underline"
-          >
-            <span className="shrink-0">📱</span>
-            <span>{phone}</span>
-          </a>
+        {/* Three-way navigation: Google / Waze / Apple */}
+        {address && <NavButtons address={address} />}
+
+        {/* Call buttons — customer (who placed) and recipient (who receives) */}
+        {(customerPhone || recipientPhone) && (
+          <div className="flex flex-wrap gap-2">
+            {customerPhone && (
+              <CallButton
+                phone={customerPhone}
+                label={t.callCustomer}
+                variant="subtle"
+              />
+            )}
+            {recipientPhone && (
+              <CallButton
+                phone={recipientPhone}
+                label={t.callRecipient}
+                variant="subtle"
+              />
+            )}
+          </div>
         )}
 
-        {/* Special instructions */}
-        {specialInstr && (
-          <p className="text-xs text-ios-orange line-clamp-2">⚠ {specialInstr}</p>
+        {/* Owner's instructions to the driver */}
+        {driverInstr && (
+          <div className="bg-orange-50 border-l-4 border-orange-400 rounded-lg px-3 py-1.5">
+            <p className="text-[10px] font-bold uppercase tracking-wide text-orange-700 mb-0.5">
+              ⚠ {t.driverInstructions}
+            </p>
+            <p className="text-xs text-ios-label leading-snug whitespace-pre-wrap line-clamp-2">
+              {driverInstr}
+            </p>
+          </div>
         )}
 
         {/* Delivered timestamp */}
@@ -123,6 +131,15 @@ export default function DeliveryCard({ delivery, onTap, onStatusChange, onProble
             <span className="text-orange-500 font-medium">{deliveryResult}</span>
           )}
         </div>
+
+        {/* Explicit "Details" button — makes the expand action discoverable
+            even when call/nav buttons occupy most of the card. */}
+        <button
+          onClick={e => { e.stopPropagation(); onTap?.(); }}
+          className="w-full text-center text-xs font-medium text-ios-tertiary py-1.5 border-t border-gray-100 active-scale"
+        >
+          {t.details || 'Details'} ▾
+        </button>
 
         {/* Action button */}
         {!dimmed && (isPending || isOut) && (

--- a/apps/delivery/src/components/DeliverySheet.jsx
+++ b/apps/delivery/src/components/DeliverySheet.jsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect } from 'react';
 import t from '../translations.js';
+import { CallButton, NavButtons } from '@flower-studio/shared';
 
 export default function DeliverySheet({ delivery, onClose, onStatusChange, onProblem, onSaveNote }) {
   const d = delivery;
@@ -30,14 +31,12 @@ export default function DeliverySheet({ delivery, onClose, onStatusChange, onPro
   const customerPhone  = d['Customer Phone'] || '';
   const orderContents  = d['Order Contents'] || '';
   const specialInstr   = d['Special Instructions'] || '';
+  // Owner-authored instructions take priority; legacy translated note
+  // is the fallback for data that existed before the new field.
+  const driverInstr    = d['Driver Instructions'] || specialInstr;
   const paymentStatus  = d['Payment Status'] || '';
   // Only show customer info when it differs from recipient (gift orders)
   const showCustomer = customerPhone && customerPhone !== phone;
-
-  const mapsUrl = address
-    ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(address)}`
-    : null;
-  const telUrl = phone ? `tel:${phone.replace(/\s/g, '')}` : null;
 
   async function handleSaveNote() {
     setSaving(true);
@@ -76,18 +75,11 @@ export default function DeliverySheet({ delivery, onClose, onStatusChange, onPro
               </div>
             )}
 
-            {/* Address */}
+            {/* Address (plain) — nav buttons live in their own section below */}
             {address && (
-              <div className="flex items-center justify-between px-4 py-3">
-                <span className="text-sm text-ios-tertiary">{t.address}</span>
-                <a
-                  href={mapsUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm font-medium text-ios-blue text-right max-w-[60%] active:underline"
-                >
-                  📍 {address}
-                </a>
+              <div className="flex items-start justify-between px-4 py-3 gap-3">
+                <span className="text-sm text-ios-tertiary shrink-0">{t.address}</span>
+                <span className="text-sm font-medium text-ios-label text-right">📍 {address}</span>
               </div>
             )}
 
@@ -95,9 +87,7 @@ export default function DeliverySheet({ delivery, onClose, onStatusChange, onPro
             {phone && (
               <div className="flex items-center justify-between px-4 py-3">
                 <span className="text-sm text-ios-tertiary">{t.phone}</span>
-                <a href={telUrl} className="text-sm font-medium text-ios-blue active:underline">
-                  📱 {phone}
-                </a>
+                <CallButton phone={phone} label={phone} icon="📱" variant="subtle" />
               </div>
             )}
 
@@ -105,13 +95,11 @@ export default function DeliverySheet({ delivery, onClose, onStatusChange, onPro
             {showCustomer && (
               <div className="flex items-center justify-between px-4 py-3 bg-brand-50/30">
                 <span className="text-sm text-ios-tertiary">{t.orderedBy}</span>
-                <div className="text-right">
+                <div className="flex flex-col items-end gap-1">
                   {customerName && (
                     <p className="text-sm font-medium text-ios-label">{customerName}</p>
                   )}
-                  <a href={`tel:${customerPhone.replace(/\s/g, '')}`} className="text-sm text-ios-blue active:underline">
-                    📱 {customerPhone}
-                  </a>
+                  <CallButton phone={customerPhone} label={customerPhone} icon="📱" variant="subtle" />
                 </div>
               </div>
             )}
@@ -134,6 +122,14 @@ export default function DeliverySheet({ delivery, onClose, onStatusChange, onPro
             )}
           </div>
 
+          {/* Three-way navigation */}
+          {address && (
+            <div>
+              <p className="ios-label">{t.navigate || 'Navigate'}</p>
+              <NavButtons address={address} />
+            </div>
+          )}
+
           {/* Payment status badge */}
           {paymentStatus && (
             <div className="flex items-center gap-2">
@@ -149,12 +145,12 @@ export default function DeliverySheet({ delivery, onClose, onStatusChange, onPro
             </div>
           )}
 
-          {/* Special instructions */}
-          {specialInstr && (
+          {/* Owner's instructions to the driver (read-only) */}
+          {driverInstr && (
             <div>
-              <p className="ios-label">{t.specialInstructions}</p>
-              <div className="ios-card px-4 py-3 border border-amber-200 bg-amber-50/50">
-                <p className="text-sm text-ios-label">⚠ {specialInstr}</p>
+              <p className="ios-label">{t.driverInstructions}</p>
+              <div className="ios-card px-4 py-3 border border-orange-200 bg-orange-50/50">
+                <p className="text-sm text-ios-label whitespace-pre-wrap">⚠ {driverInstr}</p>
               </div>
             </div>
           )}

--- a/apps/delivery/src/translations.js
+++ b/apps/delivery/src/translations.js
@@ -113,6 +113,14 @@ const en = {
   packs:         'packs',
   lotsFound:     'Lots found',
   totalStems:    'Total stems',
+
+  // Owner-authored driver instructions + customer call + expand + nav
+  driverInstructions: 'Driver instructions',
+  callCustomer:       'Call customer',
+  callRecipient:      'Call recipient',
+  customer:           'Customer',
+  details:            'Details',
+  navigate:           'Navigate',
 };
 
 const ru = {
@@ -227,6 +235,14 @@ const ru = {
   packs:         'уп.',
   lotsFound:     'Упаковок найдено',
   totalStems:    'Всего штук',
+
+  // Owner-authored driver instructions + customer call + expand + nav
+  driverInstructions: 'Инструкции водителю',
+  callCustomer:       'Позвонить клиенту',
+  callRecipient:      'Позвонить получателю',
+  customer:           'Клиент',
+  details:            'Подробнее',
+  navigate:           'Навигация',
 };
 
 // ── Proxy-based dynamic translation ──

--- a/apps/florist/src/components/OrderCard.jsx
+++ b/apps/florist/src/components/OrderCard.jsx
@@ -1018,13 +1018,45 @@ export default function OrderCard({ order, onOrderUpdated, isOwner }) {
                 </div>
               )}
 
-              {/* ── Order date + Notes ── */}
-              {(d['Order Date'] || detail['Notes Original']) && (
+              {/* ── Order date ── */}
+              {d['Order Date'] && (
                 <div className="bg-gray-50 rounded-xl px-3 py-1 space-y-0">
-                  {d['Order Date'] && <Row label={t.labelOrderDate} value={fmtDate(d['Order Date'])} />}
-                  {detail['Notes Original'] && <Row label={t.labelNotes} value={detail['Notes Original']} />}
+                  <Row label={t.labelOrderDate} value={fmtDate(d['Order Date'])} />
+                  {detail['Notes Original'] && <Row label={t.customerNote} value={detail['Notes Original']} />}
                 </div>
               )}
+
+              {/* ── Owner-authored notes (editable at any stage) ── */}
+              <div className="space-y-2">
+                <div>
+                  <p className="text-[10px] font-bold uppercase tracking-wide text-green-700 dark:text-green-300 mb-1">
+                    🌸 {t.floristNote}
+                  </p>
+                  <textarea
+                    defaultValue={detail['Florist Note'] || ''}
+                    onBlur={e => { if (e.target.value !== (detail['Florist Note'] || '')) patch({ 'Florist Note': e.target.value }); }}
+                    placeholder={t.floristNotePlaceholder}
+                    disabled={saving}
+                    rows={2}
+                    className="w-full text-sm text-ios-label bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-700 rounded-lg px-2.5 py-1.5 outline-none disabled:opacity-40 whitespace-pre-wrap"
+                  />
+                </div>
+                {isDelivery && detail.delivery && (
+                  <div>
+                    <p className="text-[10px] font-bold uppercase tracking-wide text-orange-700 dark:text-orange-300 mb-1">
+                      🚗 {t.driverInstructions}
+                    </p>
+                    <textarea
+                      defaultValue={detail.delivery['Driver Instructions'] || ''}
+                      onBlur={e => { if (e.target.value !== (detail.delivery['Driver Instructions'] || '')) patchDelivery({ 'Driver Instructions': e.target.value }); }}
+                      placeholder={t.driverInstructionsPlaceholder}
+                      disabled={saving}
+                      rows={2}
+                      className="w-full text-sm text-ios-label bg-orange-50 dark:bg-orange-900/30 border border-orange-200 dark:border-orange-700 rounded-lg px-2.5 py-1.5 outline-none disabled:opacity-40 whitespace-pre-wrap"
+                    />
+                  </div>
+                )}
+              </div>
             </>
           )}
 

--- a/apps/florist/src/components/OrderCardSummary.jsx
+++ b/apps/florist/src/components/OrderCardSummary.jsx
@@ -1,5 +1,6 @@
 import t from '../translations.js';
 import fmtDate from '../utils/formatDate.js';
+import { CallButton } from '@flower-studio/shared';
 
 const STATUS_STYLES = {
   'New':              { label: 'bg-indigo-50 text-indigo-600' },
@@ -85,7 +86,10 @@ export default function OrderCardSummary({ order, d, currentStatus, currentPaid,
         )}
       </div>
 
-      <p className="text-base font-semibold text-ios-label">{d['Customer Name'] || order['Customer Name'] || '—'}</p>
+      <div className="flex items-center gap-2 flex-wrap">
+        <p className="text-base font-semibold text-ios-label">{d['Customer Name'] || order['Customer Name'] || '—'}</p>
+        <CallButton phone={order['Customer Phone']} label={t.callCustomer} variant="subtle" />
+      </div>
       {request && (
         <p className={`text-sm text-ios-tertiary mt-0.5 ${expanded ? '' : 'line-clamp-1'}`}>{request}</p>
       )}
@@ -120,11 +124,22 @@ export default function OrderCardSummary({ order, d, currentStatus, currentPaid,
           {order['Delivery Time'] ? ` · ${order['Delivery Time']}` : ''}
         </p>
       )}
-      {/* Florist note — prominent, distinct from card message */}
+      {/* Florist note — owner-authored guidance to the florist */}
+      {!expanded && order['Florist Note'] && (
+        <div className="mt-2 bg-green-50 dark:bg-green-900/30 border-l-4 border-green-500 rounded-lg px-3 py-2">
+          <p className="text-[10px] font-bold uppercase tracking-wide text-green-700 dark:text-green-300 mb-0.5">
+            🌸 {t.floristNote}
+          </p>
+          <p className="text-sm text-ios-label dark:text-gray-200 leading-snug whitespace-pre-wrap line-clamp-2">
+            {order['Florist Note']}
+          </p>
+        </div>
+      )}
+      {/* Customer note — original request from the buyer */}
       {!expanded && (order['Notes Original'] || order['Notes Translated']) && (
         <div className="mt-2 bg-blue-50 dark:bg-blue-900/30 border-l-4 border-blue-400 rounded-lg px-3 py-2">
           <p className="text-[10px] font-bold uppercase tracking-wide text-blue-700 dark:text-blue-300 mb-0.5">
-            📝 {t.note || 'Note'}
+            📝 {t.customerNote || t.note || 'Note'}
           </p>
           <p className="text-sm text-ios-label dark:text-gray-200 leading-snug whitespace-pre-wrap line-clamp-2">
             {order['Notes Translated'] || order['Notes Original']}

--- a/apps/florist/src/pages/OrderDetailPage.jsx
+++ b/apps/florist/src/pages/OrderDetailPage.jsx
@@ -9,6 +9,7 @@ import { useAuth } from '../context/AuthContext.jsx';
 import { useToast } from '../context/ToastContext.jsx';
 import t from '../translations.js';
 import useConfigLists from '../hooks/useConfigLists.js';
+import { CallButton } from '@flower-studio/shared';
 
 // Split "Rose Red (14.Mar.)" into { name: "Rose Red", batch: "14.Mar." }
 function parseBatchName(displayName) {
@@ -266,11 +267,9 @@ export default function OrderDetailPage() {
                   <Row label="Nickname" value={order['Customer Nickname']} />
                 )}
                 {order['Customer Phone'] && (
-                  <div className="flex justify-between gap-4 py-2 border-b border-gray-100 last:border-0">
-                    <span className="text-sm text-ios-tertiary shrink-0">Phone</span>
-                    <a href={`tel:${order['Customer Phone']}`} className="text-sm text-brand-600 font-medium">
-                      {order['Customer Phone']}
-                    </a>
+                  <div className="flex justify-between items-center gap-4 py-2 border-b border-gray-100 last:border-0">
+                    <span className="text-sm text-ios-tertiary shrink-0">{t.labelPhone || 'Phone'}</span>
+                    <CallButton phone={order['Customer Phone']} label={order['Customer Phone']} variant="subtle" />
                   </div>
                 )}
               </div>
@@ -586,16 +585,48 @@ export default function OrderDetailPage() {
               </div>
             </div>
 
-            {/* Source + notes */}
+            {/* Source + customer note (read-only display) */}
             {(order['Source'] || order['Notes Original']) && (
               <div>
                 <p className="ios-label">Info</p>
                 <div className="ios-card px-4 py-2">
                   <Row label="Source" value={order['Source']} />
-                  <Row label="Notes"  value={order['Notes Original']} />
+                  <Row label={t.customerNote} value={order['Notes Original']} />
                 </div>
               </div>
             )}
+
+            {/* Owner-authored notes (editable at any stage) */}
+            <div className="space-y-2">
+              <div>
+                <p className="text-[10px] font-bold uppercase tracking-wide text-green-700 mb-1">
+                  🌸 {t.floristNote}
+                </p>
+                <textarea
+                  defaultValue={order['Florist Note'] || ''}
+                  onBlur={e => { if (e.target.value !== (order['Florist Note'] || '')) patch({ 'Florist Note': e.target.value }); }}
+                  placeholder={t.floristNotePlaceholder}
+                  disabled={saving}
+                  rows={2}
+                  className="w-full text-sm text-ios-label bg-green-50 border border-green-200 rounded-lg px-2.5 py-1.5 outline-none disabled:opacity-40 whitespace-pre-wrap"
+                />
+              </div>
+              {order.delivery && (
+                <div>
+                  <p className="text-[10px] font-bold uppercase tracking-wide text-orange-700 mb-1">
+                    🚗 {t.driverInstructions}
+                  </p>
+                  <textarea
+                    defaultValue={order.delivery['Driver Instructions'] || ''}
+                    onBlur={e => { if (e.target.value !== (order.delivery['Driver Instructions'] || '')) patchDelivery({ 'Driver Instructions': e.target.value }); }}
+                    placeholder={t.driverInstructionsPlaceholder}
+                    disabled={saving}
+                    rows={2}
+                    className="w-full text-sm text-ios-label bg-orange-50 border border-orange-200 rounded-lg px-2.5 py-1.5 outline-none disabled:opacity-40 whitespace-pre-wrap"
+                  />
+                </div>
+              )}
+            </div>
           </>
         )}
       </div>

--- a/apps/florist/src/translations.js
+++ b/apps/florist/src/translations.js
@@ -527,6 +527,18 @@ const en = {
   noMismatches:             'All stock quantities match',
   applyFixes:               'Apply corrections',
   fixesApplied:             'Corrections applied',
+
+  // Owner-authored role-specific notes + customer call
+  customerNote:                 'Customer note',
+  floristNote:                  'Florist note',
+  driverInstructions:           'Driver instructions',
+  floristNotePlaceholder:       'Note for the florist…',
+  driverInstructionsPlaceholder:'Instructions for the driver…',
+  callCustomer:                 'Call customer',
+  callRecipient:                'Call recipient',
+  customer:                     'Customer',
+  recipient:                    'Recipient',
+  details:                      'Details',
 };
 
 const ru = {
@@ -1053,6 +1065,18 @@ const ru = {
   noMismatches:             'Расхождений не найдено',
   applyFixes:               'Применить корректировки',
   fixesApplied:             'Корректировки применены',
+
+  // Owner-authored role-specific notes + customer call
+  customerNote:                 'Заметка клиента',
+  floristNote:                  'Заметка для флориста',
+  driverInstructions:           'Инструкции водителю',
+  floristNotePlaceholder:       'Заметка для флориста…',
+  driverInstructionsPlaceholder:'Инструкции водителю…',
+  callCustomer:                 'Позвонить клиенту',
+  callRecipient:                'Позвонить получателю',
+  customer:                     'Клиент',
+  recipient:                    'Получатель',
+  details:                      'Подробнее',
 };
 
 // ── Proxy-based dynamic translation ──

--- a/backend/src/routes/deliveries.js
+++ b/backend/src/routes/deliveries.js
@@ -12,7 +12,8 @@ router.use(authorize('deliveries'));
 const DELIVERIES_PATCH_ALLOWED = [
   'Delivery Address', 'Recipient Name', 'Recipient Phone',
   'Delivery Date', 'Delivery Time', 'Assigned Driver', 'Status',
-  'Driver Payment Status', 'Driver Notes', 'Delivered At', 'Delivery Fee',
+  'Driver Payment Status', 'Driver Notes', 'Driver Instructions',
+  'Delivered At', 'Delivery Fee',
   'Delivery Result', 'Delivery Method', 'Driver Payout', 'Taxi Cost',
 ];
 

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -20,7 +20,7 @@ router.use(authorize('orders'));
 
 const ORDERS_PATCH_ALLOWED = [
   'Status', 'Payment Status', 'Payment Method', 'Price Override',
-  'Notes Original', 'Greeting Card Text', 'Customer Request',
+  'Notes Original', 'Florist Note', 'Greeting Card Text', 'Customer Request',
   'Delivery Type', 'Required By', 'Source', 'Delivery Fee', 'Delivery Time',
   'Payment 1 Amount', 'Payment 1 Method', 'Payment 2 Amount', 'Payment 2 Method',
 ];
@@ -118,7 +118,7 @@ router.get('/', async (req, res, next) => {
         maxRecords: 1000,
       }),
       listByIds(TABLES.CUSTOMERS, uniqueCustomerIds, {
-        fields: ['Name', 'Nickname'],
+        fields: ['Name', 'Nickname', 'Phone'],
       }),
       listByIds(TABLES.DELIVERIES, allDeliveryIds, {
         fields: ['Delivery Date', 'Delivery Time', 'Delivery Fee', 'Delivery Address', 'Assigned Driver', 'Delivery Method', 'Status'],
@@ -155,6 +155,7 @@ router.get('/', async (req, res, next) => {
     for (const order of orders) {
       const custId = order.Customer?.[0];
       order['Customer Name'] = customerMap[custId]?.Name || customerMap[custId]?.Nickname || '';
+      order['Customer Phone'] = customerMap[custId]?.Phone || '';
 
       if (!order['Price Override'] && totalByOrder[order.id] !== undefined) {
         order['Sell Total'] = totalByOrder[order.id];
@@ -244,7 +245,7 @@ router.post('/', async (req, res, next) => {
   try {
     const {
       customer, customerRequest, source, communicationMethod, deliveryType,
-      orderLines = [], delivery, notes, paymentStatus, paymentMethod,
+      orderLines = [], delivery, notes, floristNote, paymentStatus, paymentMethod,
       priceOverride, requiredBy, cardText, deliveryTime,
       payment1Amount, payment1Method,
     } = req.body;
@@ -289,7 +290,7 @@ router.post('/', async (req, res, next) => {
     try {
       const result = await createOrder({
         customer, customerRequest, source, communicationMethod, deliveryType,
-        orderLines, delivery, notes,
+        orderLines, delivery, notes, floristNote,
         paymentStatus: paymentStatus || PAYMENT_STATUS.UNPAID,
         paymentMethod, priceOverride, requiredBy, cardText, deliveryTime,
         payment1Amount, payment1Method,
@@ -409,7 +410,7 @@ router.post('/:id/convert-to-delivery', async (req, res, next) => {
       return res.status(400).json({ error: 'Delivery record already exists for this order.' });
     }
 
-    const { address, recipientName, recipientPhone, date, time, fee, driver } = req.body;
+    const { address, recipientName, recipientPhone, date, time, fee, driver, driverInstructions } = req.body;
 
     const delivery = await db.create(TABLES.DELIVERIES, {
       'Linked Order':     [req.params.id],
@@ -420,6 +421,7 @@ router.post('/:id/convert-to-delivery', async (req, res, next) => {
       'Delivery Time':    time || order['Delivery Time'] || '',
       'Assigned Driver':  driver || getDriverOfDay() || null,
       'Delivery Fee':     fee ?? getConfig('defaultDeliveryFee'),
+      'Driver Instructions': driverInstructions || '',
       'Delivery Method': 'Driver',
       'Driver Payout':   getConfig('driverCostPerDelivery') || 0,
       Status:             DELIVERY_STATUS.PENDING,

--- a/backend/src/services/airtableSchema.js
+++ b/backend/src/services/airtableSchema.js
@@ -66,6 +66,15 @@ const EXPECTED_WRITE_FIELDS = {
     'Key person 1 (important DATE)', 'Key person 2 (important DATE)',
     'Communication method', 'Order Source',
   ],
+  // Partial entries — only fields added by the owner-notes feature are
+  // validated here. Older ORDERS / DELIVERIES fields rely on runtime 422
+  // failures since this guard was added after those fields were in use.
+  [TABLES.ORDERS]: [
+    'Florist Note',
+  ],
+  [TABLES.DELIVERIES]: [
+    'Driver Instructions',
+  ],
 };
 
 /**

--- a/backend/src/services/orderService.js
+++ b/backend/src/services/orderService.js
@@ -57,7 +57,7 @@ export async function autoMatchStock(lines) {
 export async function createOrder(params, config, opts = {}) {
   const {
     customer, customerRequest, source, communicationMethod, deliveryType,
-    orderLines, delivery, notes, paymentStatus, paymentMethod, priceOverride,
+    orderLines, delivery, notes, floristNote, paymentStatus, paymentMethod, priceOverride,
     requiredBy, cardText, deliveryTime, createdBy, isOwner,
     payment1Amount, payment1Method,
   } = params;
@@ -82,6 +82,7 @@ export async function createOrder(params, config, opts = {}) {
       'Order Date':         new Date().toISOString().split('T')[0],
       'Required By':        requiredBy || delivery?.date || null,
       'Notes Original':     notes || '',
+      'Florist Note':       floristNote || '',
       'Greeting Card Text': cardText || delivery?.cardText || '',
       'Delivery Time':      deliveryTime || delivery?.time || '',
       'Payment Status':     paymentStatus,
@@ -204,6 +205,7 @@ export async function createOrder(params, config, opts = {}) {
         'Delivery Time':    delivery.time || '',
         'Assigned Driver':  delivery.driver || getDriverOfDay() || null,
         'Delivery Fee':     delivery.fee ?? getConfig('defaultDeliveryFee'),
+        'Driver Instructions': delivery.driverInstructions || '',
         'Delivery Method':  'Driver',
         'Driver Payout':    getConfig('driverCostPerDelivery') || 0,
         Status:             DELIVERY_STATUS.PENDING,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4621,6 +4621,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4642,6 +4643,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4663,6 +4665,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4684,6 +4687,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4705,6 +4709,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4726,6 +4731,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4747,6 +4753,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4768,6 +4775,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4789,6 +4797,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4810,6 +4819,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4831,6 +4841,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/packages/shared/components/CallButton.jsx
+++ b/packages/shared/components/CallButton.jsx
@@ -1,0 +1,32 @@
+import { telHref } from '../utils/phone.js';
+
+// A click-to-call pill. Renders nothing if no phone is provided so
+// consumers can always mount it conditionally-free.
+// stopPropagation() keeps the parent card (which is often the expand
+// target) from also toggling when the user taps the button.
+export default function CallButton({
+  phone,
+  label,
+  icon = '📞',
+  className = '',
+  variant = 'solid',
+}) {
+  const href = telHref(phone);
+  if (!href) return null;
+
+  const base = 'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-sm font-semibold active-scale whitespace-nowrap';
+  const styles = variant === 'subtle'
+    ? 'bg-ios-green/10 text-ios-green'
+    : 'bg-ios-green text-white';
+
+  return (
+    <a
+      href={href}
+      onClick={e => e.stopPropagation()}
+      className={`${base} ${styles} ${className}`}
+    >
+      <span>{icon}</span>
+      <span className="truncate">{label || phone}</span>
+    </a>
+  );
+}

--- a/packages/shared/components/NavButtons.jsx
+++ b/packages/shared/components/NavButtons.jsx
@@ -1,0 +1,42 @@
+import { googleMapsUrl, wazeUrl, appleMapsUrl } from '../utils/navigation.js';
+
+// Three-up nav strip: Google Maps, Waze, Apple Maps.
+// Renders nothing when the address is empty so the driver card
+// doesn't show dead buttons for pickup-only orders.
+export default function NavButtons({ address, className = '' }) {
+  if (!address) return null;
+  const stop = e => e.stopPropagation();
+  const base = 'flex-1 text-center px-3 py-2 rounded-xl text-xs font-semibold active-scale';
+
+  return (
+    <div className={`flex gap-2 ${className}`}>
+      <a
+        onClick={stop}
+        href={googleMapsUrl(address)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${base} bg-blue-50 text-blue-700`}
+      >
+        Google
+      </a>
+      <a
+        onClick={stop}
+        href={wazeUrl(address)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${base} bg-cyan-50 text-cyan-700`}
+      >
+        Waze
+      </a>
+      <a
+        onClick={stop}
+        href={appleMapsUrl(address)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`${base} bg-gray-100 text-gray-800`}
+      >
+        Apple
+      </a>
+    </div>
+  );
+}

--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -11,3 +11,7 @@ export { computePremadeShortfalls } from './utils/dissolvePremades.js';
 export { default as apiClient, setClientPin, getClientPin } from './api/client.js';
 export { LanguageProvider, useLanguage, LangToggle } from './context/LanguageContext.jsx';
 export { AuthProvider, useAuth } from './context/AuthContext.jsx';
+export { default as CallButton } from './components/CallButton.jsx';
+export { default as NavButtons } from './components/NavButtons.jsx';
+export { cleanPhone, telHref } from './utils/phone.js';
+export { googleMapsUrl, wazeUrl, appleMapsUrl } from './utils/navigation.js';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "type": "module",
   "main": "index.js",
+  "scripts": {
+    "test": "vitest run"
+  },
   "peerDependencies": {
     "react": "^18.0.0",
     "axios": "^1.0.0"

--- a/packages/shared/test/navigation.test.js
+++ b/packages/shared/test/navigation.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { googleMapsUrl, wazeUrl, appleMapsUrl } from '../utils/navigation.js';
+
+const ADDRESS = 'ul. Floriańska 5, 31-019 Kraków';
+const ENCODED = encodeURIComponent(ADDRESS);
+
+describe('googleMapsUrl', () => {
+  it('URL-encodes Polish diacritics', () => {
+    expect(googleMapsUrl(ADDRESS))
+      .toBe(`https://www.google.com/maps/search/?api=1&query=${ENCODED}`);
+  });
+
+  it('returns null for empty input', () => {
+    expect(googleMapsUrl('')).toBeNull();
+    expect(googleMapsUrl(null)).toBeNull();
+    expect(googleMapsUrl(undefined)).toBeNull();
+  });
+});
+
+describe('wazeUrl', () => {
+  it('builds a text-search navigate link', () => {
+    expect(wazeUrl(ADDRESS))
+      .toBe(`https://waze.com/ul?q=${ENCODED}&navigate=yes`);
+  });
+
+  it('returns null for empty input', () => {
+    expect(wazeUrl('')).toBeNull();
+  });
+});
+
+describe('appleMapsUrl', () => {
+  it('builds an Apple Maps query URL', () => {
+    expect(appleMapsUrl(ADDRESS))
+      .toBe(`https://maps.apple.com/?q=${ENCODED}`);
+  });
+
+  it('returns null for empty input', () => {
+    expect(appleMapsUrl('')).toBeNull();
+  });
+});

--- a/packages/shared/test/phone.test.js
+++ b/packages/shared/test/phone.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { cleanPhone, telHref } from '../utils/phone.js';
+
+describe('cleanPhone', () => {
+  it('strips whitespace', () => {
+    expect(cleanPhone('+48 123 456 789')).toBe('+48123456789');
+  });
+
+  it('returns empty string for falsy input', () => {
+    expect(cleanPhone(null)).toBe('');
+    expect(cleanPhone(undefined)).toBe('');
+    expect(cleanPhone('')).toBe('');
+  });
+
+  it('coerces non-string input to string', () => {
+    expect(cleanPhone(123456)).toBe('123456');
+  });
+
+  it('passes already-clean E.164 through unchanged', () => {
+    expect(cleanPhone('+48123456789')).toBe('+48123456789');
+  });
+});
+
+describe('telHref', () => {
+  it('produces a tel: link from a formatted phone', () => {
+    expect(telHref('+48 123 456 789')).toBe('tel:+48123456789');
+  });
+
+  it('returns null for empty input', () => {
+    expect(telHref(null)).toBeNull();
+    expect(telHref('')).toBeNull();
+    expect(telHref(undefined)).toBeNull();
+  });
+});

--- a/packages/shared/utils/navigation.js
+++ b/packages/shared/utils/navigation.js
@@ -1,0 +1,21 @@
+// Navigation URL builders for external map apps.
+// Text-address based — no lat/lng required, since the Delivery record
+// only stores the address as free text today.
+//
+// Apple Maps falls back to Google Maps in the browser on Android, which
+// is acceptable: iOS drivers get native Apple Maps, Android drivers
+// still reach a map.
+
+const enc = encodeURIComponent;
+
+export function googleMapsUrl(address) {
+  return address ? `https://www.google.com/maps/search/?api=1&query=${enc(address)}` : null;
+}
+
+export function wazeUrl(address) {
+  return address ? `https://waze.com/ul?q=${enc(address)}&navigate=yes` : null;
+}
+
+export function appleMapsUrl(address) {
+  return address ? `https://maps.apple.com/?q=${enc(address)}` : null;
+}

--- a/packages/shared/utils/phone.js
+++ b/packages/shared/utils/phone.js
@@ -1,0 +1,14 @@
+// Phone helpers shared across florist / delivery / dashboard apps.
+// All three apps want consistent tel: link handling and null-safe
+// formatting — centralise it so a formatting tweak touches one file,
+// not four.
+
+export function cleanPhone(raw) {
+  if (!raw) return '';
+  return String(raw).replace(/\s+/g, '');
+}
+
+export function telHref(raw) {
+  const p = cleanPhone(raw);
+  return p ? `tel:${p}` : null;
+}


### PR DESCRIPTION
## Summary
This PR introduces owner-authored role-specific notes (`Florist Note` on orders, `Driver Instructions` on deliveries), one-tap call buttons for customers and recipients, and multi-app navigation options (Google Maps, Waze, Apple Maps) for drivers. The changes improve communication clarity by separating owner guidance from customer notes, and enhance driver UX by making call and navigation actions discoverable without hiding the expand affordance.

## Key Changes

### Schema & Backend
- **Airtable schema**: New fields `Florist Note` (ORDERS, Long text) and `Driver Instructions` (DELIVERIES, Long text)
- **Backend routes**: Updated `ORDERS_PATCH_ALLOWED` and `DELIVERIES_PATCH_ALLOWED` to include new fields; enriched order list endpoint with `Customer Phone` so florist cards can call without extra fetch
- **Schema validation**: Added startup checks for both new fields to fail boot if missing, preventing silent 422 errors

### Shared Package
- **New utilities**: `phone.js` (`cleanPhone`, `telHref`) and `navigation.js` (`googleMapsUrl`, `wazeUrl`, `appleMapsUrl`) with full test coverage
- **New components**: 
  - `CallButton.jsx` — consistent green click-to-call pill with `stopPropagation()` to prevent accidental card expansion
  - `NavButtons.jsx` — three-up navigation strip (Google / Waze / Apple) that renders only when address is present
- **Package test script**: Added `npm test` to run vitest suite (12 tests, all passing)

### Delivery App
- **DeliveryCard.jsx**: 
  - Replaced inline Maps/phone links with `NavButtons` and `CallButton` components
  - Split phone into `customerPhone` and `recipientPhone` for separate call buttons
  - Renamed `specialInstr` → `driverInstr` with fallback to legacy field for backward compatibility
  - Added explicit "Details" button to make expand action discoverable
  - Styled driver instructions as prominent orange warning block
- **DeliverySheet.jsx**: Replaced inline tel/maps links with `CallButton` and `NavButtons` components; improved layout for customer info section

### Dashboard
- **OrderDetailPanel.jsx**: 
  - Restructured Notes section into three rows: customer note (read-only), florist note (editable), driver instructions (editable, delivery orders only)
  - Added `CallButton` to recipient phone row via new `trailing` prop on `EditableRow`
  - Improved visual hierarchy with color-coded labels (blue for customer, green for florist, orange for driver)

### Florist App
- **OrderDetailPage.jsx**: Added editable florist note and driver instructions sections with color-coded styling; added `CallButton` to customer phone
- **OrderCard.jsx**: 
  - Added florist note display on collapsed card (green block, visible when not expanded)
  - Added editable florist note and driver instructions sections in expanded view
  - Added `CallButton` to customer name row
- **OrderCardSummary.jsx**: Added `CallButton` for customer call on collapsed card

### Translations
- Added 14 new translation keys (EN + RU) for customer/florist/driver labels, placeholders, and call actions across all three apps

## Implementation Details
- **Backward compatibility**: Driver instructions fall back to legacy `Special Instructions` field for existing data
- **Event handling**: All call and navigation buttons use `stopPropagation()` to prevent unintended card expansion
- **Null safety**: Navigation buttons render nothing for empty addresses; call buttons render nothing for missing phones
- **Styling**: Color-coded note blocks (blue customer, green florist, orange driver) for quick visual scanning
- **Accessibility**: Explicit "Details" button makes expand action discoverable even when call/nav buttons occupy card space

https://claude.ai/code/session_011xC3kbqd9iHaJdw4b64k15