### PR TITLE
refactor(delivery): clearer card hierarchy + higher-contrast nav buttons

### DIFF
--- a/apps/delivery/src/components/DeliveryCard.jsx
+++ b/apps/delivery/src/components/DeliveryCard.jsx
@@ -1,8 +1,20 @@
 // DeliveryCard — a compact card for each delivery in the list.
-// Tap the card (or the explicit "Details" button) to open the detail
-// sheet. Call and navigation buttons open their respective apps
-// without triggering expand, so the driver can decide: expand, call,
-// or navigate — without accidental taps.
+//
+// Layout priorities (top to bottom):
+//   1. Status / timing / payment    — is this urgent? already paid?
+//   2. Who (labelled)               — recipient + customer so the driver
+//                                     can't confuse them (gift orders are
+//                                     common — the person at the door is
+//                                     NOT the person who paid).
+//   3. Owner's message to the driver — promoted above the address so it
+//                                     can't be missed mid-scroll.
+//   4. Where + how to navigate      — address then the three-map strip.
+//   5. How to call                  — recipient + customer, labelled.
+//   6. Details / status actions.
+//
+// Call and nav buttons use stopPropagation so tapping them never
+// expands the card by accident — the "Details" row is the only expand
+// surface besides the card body itself.
 
 import t from '../translations.js';
 import { CallButton, NavButtons } from '@flower-studio/shared';
@@ -18,13 +30,17 @@ export default function DeliveryCard({ delivery, onTap, onStatusChange, onProble
   const recipientPhone   = d['Recipient Phone'] || '';
   const customerPhone    = d['Customer Phone'] || '';
   const time             = d['Delivery Time'] || '';
-  const recipient        = d['Recipient Name'] || 'Unknown';
+  const recipient        = d['Recipient Name'] || '—';
+  const customerName     = d['Customer Name'] || '';
   const deliveredAt      = d['Delivered At'];
   const deliveryResult   = d['Delivery Result'] || '';
   // Owner-authored instructions (new) fall back to the legacy translated
   // customer note so existing data still renders.
   const driverInstr      = d['Driver Instructions'] || d['Special Instructions'] || '';
   const paymentStatus    = d['Payment Status'] || '';
+  // Gift orders: customer ≠ recipient. Only surface the buyer's info
+  // when it actually differs, otherwise it's redundant.
+  const showBuyer        = customerName && customerName !== recipient;
 
   // Payment status badge styling
   function paymentBadge() {
@@ -43,6 +59,8 @@ export default function DeliveryCard({ delivery, onTap, onStatusChange, onProble
     onStatusChange(newStatus);
   }
 
+  const divider = 'border-t border-gray-100 pt-3';
+
   return (
     <div
       onClick={onTap}
@@ -50,7 +68,7 @@ export default function DeliveryCard({ delivery, onTap, onStatusChange, onProble
         dimmed ? 'opacity-60' : ''
       }`}
     >
-      <div className="px-4 py-3 space-y-2">
+      <div className="px-4 py-3 space-y-3">
         {/* Unpaid warning — driver must collect payment before handing over */}
         {paymentStatus && paymentStatus !== 'Paid' && status !== 'Delivered' && (
           <div className="bg-red-50 border border-red-200 rounded-lg px-3 py-1.5 flex items-center gap-2">
@@ -59,14 +77,11 @@ export default function DeliveryCard({ delivery, onTap, onStatusChange, onProble
           </div>
         )}
 
-        {/* Top row: recipient + order ID + time badge + payment badge */}
+        {/* Top row: order ID + payment badge + time badge */}
         <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2 flex-1 min-w-0">
-            {d['App Order ID'] && (
-              <span className="text-[11px] font-mono text-ios-tertiary shrink-0">#{d['App Order ID']}</span>
-            )}
-            <h3 className="text-sm font-semibold text-ios-label truncate">{recipient}</h3>
-          </div>
+          {d['App Order ID'] ? (
+            <span className="text-[11px] font-mono text-ios-tertiary shrink-0">#{d['App Order ID']}</span>
+          ) : <span />}
           <div className="flex items-center gap-1.5 shrink-0">
             {paymentBadge()}
             {time && (
@@ -77,60 +92,91 @@ export default function DeliveryCard({ delivery, onTap, onStatusChange, onProble
           </div>
         </div>
 
-        {/* Address — plain text; nav strip below offers three map apps */}
-        {address && (
-          <p className="flex items-start gap-1.5 text-xs text-ios-label">
-            <span className="shrink-0 mt-0.5">📍</span>
-            <span className="line-clamp-2">{address}</span>
-          </p>
-        )}
-
-        {/* Three-way navigation: Google / Waze / Apple */}
-        {address && <NavButtons address={address} />}
-
-        {/* Call buttons — customer (who placed) and recipient (who receives) */}
-        {(customerPhone || recipientPhone) && (
-          <div className="flex flex-wrap gap-2">
-            {customerPhone && (
-              <CallButton
-                phone={customerPhone}
-                label={t.callCustomer}
-                variant="subtle"
-              />
-            )}
-            {recipientPhone && (
-              <CallButton
-                phone={recipientPhone}
-                label={t.callRecipient}
-                variant="subtle"
-              />
-            )}
+        {/* Who — labelled so "Svetlana" can't be read as "who paid".
+            Recipient is the big text; customer appears only on gift orders. */}
+        <div>
+          <div className="flex items-baseline gap-2">
+            <span className="text-[10px] font-bold uppercase tracking-wide text-ios-tertiary shrink-0">
+              {t.recipient}
+            </span>
+            <h3 className="text-base font-semibold text-ios-label truncate">{recipient}</h3>
           </div>
-        )}
+          {showBuyer && (
+            <div className="flex items-baseline gap-2 mt-0.5">
+              <span className="text-[10px] font-semibold uppercase tracking-wide text-ios-tertiary shrink-0">
+                {t.customer}
+              </span>
+              <span className="text-xs text-ios-tertiary truncate">{customerName}</span>
+            </div>
+          )}
+        </div>
 
-        {/* Owner's instructions to the driver */}
+        {/* Owner's instructions — promoted above address because it's the
+            single most important message on the card when present. */}
         {driverInstr && (
-          <div className="bg-orange-50 border-l-4 border-orange-400 rounded-lg px-3 py-1.5">
+          <div className="bg-orange-50 border-l-4 border-orange-500 rounded-lg px-3 py-2">
             <p className="text-[10px] font-bold uppercase tracking-wide text-orange-700 mb-0.5">
               ⚠ {t.driverInstructions}
             </p>
-            <p className="text-xs text-ios-label leading-snug whitespace-pre-wrap line-clamp-2">
+            <p className="text-sm text-ios-label leading-snug whitespace-pre-wrap">
               {driverInstr}
             </p>
           </div>
         )}
 
+        {/* Where — address then three-way navigation */}
+        {address && (
+          <div className={`${divider} space-y-2`}>
+            <p className="flex items-start gap-1.5 text-sm text-ios-label">
+              <span className="shrink-0 mt-0.5">📍</span>
+              <span className="line-clamp-2">{address}</span>
+            </p>
+            <NavButtons address={address} />
+          </div>
+        )}
+
+        {/* Who to call — two labelled pills side by side so the driver
+            picks the right contact fast. */}
+        {(customerPhone || recipientPhone) && (
+          <div className={`${divider}`}>
+            <p className="text-[10px] font-bold uppercase tracking-wide text-ios-tertiary mb-2">
+              📞 {t.phone}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {recipientPhone && (
+                <CallButton
+                  phone={recipientPhone}
+                  label={t.recipient}
+                  icon="📞"
+                  className="flex-1 justify-center"
+                />
+              )}
+              {customerPhone && customerPhone !== recipientPhone && (
+                <CallButton
+                  phone={customerPhone}
+                  label={t.customer}
+                  icon="📞"
+                  className="flex-1 justify-center"
+                  variant="subtle"
+                />
+              )}
+            </div>
+          </div>
+        )}
+
         {/* Delivered timestamp */}
-        <div className="flex items-center gap-3 text-xs text-ios-tertiary">
-          {isDone && deliveredAt && (
-            <span className="text-emerald-600 font-medium">
-              ✓ {new Date(deliveredAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-            </span>
-          )}
-          {isDone && deliveryResult && deliveryResult !== 'Success' && (
-            <span className="text-orange-500 font-medium">{deliveryResult}</span>
-          )}
-        </div>
+        {(isDone && (deliveredAt || deliveryResult)) && (
+          <div className="flex items-center gap-3 text-xs">
+            {deliveredAt && (
+              <span className="text-emerald-600 font-medium">
+                ✓ {new Date(deliveredAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+              </span>
+            )}
+            {deliveryResult && deliveryResult !== 'Success' && (
+              <span className="text-orange-500 font-medium">{deliveryResult}</span>
+            )}
+          </div>
+        )}
 
         {/* Explicit "Details" button — makes the expand action discoverable
             even when call/nav buttons occupy most of the card. */}
@@ -143,12 +189,12 @@ export default function DeliveryCard({ delivery, onTap, onStatusChange, onProble
 
         {/* Action button */}
         {!dimmed && (isPending || isOut) && (
-          <div className="pt-1">
+          <div>
             {isPending && (
               <button
                 onClick={e => { e.stopPropagation(); handleStatusChange('Out for Delivery'); }}
-                className="w-full h-10 rounded-xl bg-sky-600 text-white text-sm font-semibold
-                           flex items-center justify-center gap-1.5 active:opacity-80 active-scale"
+                className="w-full h-11 rounded-xl bg-sky-600 text-white text-sm font-semibold
+                           flex items-center justify-center gap-1.5 active:opacity-80 active-scale shadow-sm"
               >
                 🚗 {t.startDelivery}
               </button>
@@ -160,15 +206,15 @@ export default function DeliveryCard({ delivery, onTap, onStatusChange, onProble
                     e.stopPropagation();
                     if (window.confirm(t.confirmDelivered)) handleStatusChange('Delivered');
                   }}
-                  className="flex-1 h-10 rounded-xl bg-emerald-600 text-white text-sm font-semibold
-                             flex items-center justify-center gap-1.5 active:opacity-80 active-scale"
+                  className="flex-1 h-11 rounded-xl bg-emerald-600 text-white text-sm font-semibold
+                             flex items-center justify-center gap-1.5 active:opacity-80 active-scale shadow-sm"
                 >
                   ✓ {t.markDelivered}
                 </button>
                 <button
                   onClick={e => { e.stopPropagation(); onProblem?.(); }}
-                  className="h-10 px-3 rounded-xl bg-orange-500 text-white text-sm font-semibold
-                             flex items-center justify-center active:opacity-80 active-scale"
+                  className="h-11 px-4 rounded-xl bg-orange-500 text-white text-sm font-semibold
+                             flex items-center justify-center active:opacity-80 active-scale shadow-sm"
                 >
                   ⚠
                 </button>

--- a/apps/delivery/src/components/DeliverySheet.jsx
+++ b/apps/delivery/src/components/DeliverySheet.jsx
@@ -60,10 +60,31 @@ export default function DeliverySheet({ delivery, onClose, onStatusChange, onPro
 
         <div className="px-5 pb-8 space-y-4">
           {/* Header */}
-          <div className="flex items-center justify-between">
-            <h2 className="text-lg font-bold text-ios-label">{recipient}</h2>
-            <button onClick={onClose} className="text-ios-tertiary text-sm font-medium">{t.close}</button>
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-[10px] font-bold uppercase tracking-wide text-ios-tertiary">{t.recipient}</p>
+              <h2 className="text-lg font-bold text-ios-label truncate">{recipient}</h2>
+              {customerName && customerName !== recipient && (
+                <p className="text-xs text-ios-tertiary mt-0.5">
+                  <span className="font-semibold uppercase tracking-wide">{t.customer}:</span> {customerName}
+                </p>
+              )}
+            </div>
+            <button onClick={onClose} className="text-ios-tertiary text-sm font-medium shrink-0">{t.close}</button>
           </div>
+
+          {/* Owner's instructions — promoted to the top, above the info card,
+              because it's the single most important message when present. */}
+          {driverInstr && (
+            <div className="bg-orange-50 border-l-4 border-orange-500 rounded-xl px-4 py-3">
+              <p className="text-[10px] font-bold uppercase tracking-wide text-orange-700 mb-1">
+                ⚠ {t.driverInstructions}
+              </p>
+              <p className="text-sm text-ios-label whitespace-pre-wrap leading-relaxed">
+                {driverInstr}
+              </p>
+            </div>
+          )}
 
           {/* Info rows */}
           <div className="ios-card divide-y divide-gray-100 overflow-hidden">
@@ -142,16 +163,6 @@ export default function DeliverySheet({ delivery, onClose, onStatusChange, onPro
               {paymentStatus === 'Partial' && (
                 <span className="text-xs font-semibold px-3 py-1 rounded-full bg-amber-100 text-amber-700">{t.partialBadge}</span>
               )}
-            </div>
-          )}
-
-          {/* Owner's instructions to the driver (read-only) */}
-          {driverInstr && (
-            <div>
-              <p className="ios-label">{t.driverInstructions}</p>
-              <div className="ios-card px-4 py-3 border border-orange-200 bg-orange-50/50">
-                <p className="text-sm text-ios-label whitespace-pre-wrap">⚠ {driverInstr}</p>
-              </div>
             </div>
           )}
 

--- a/packages/shared/components/CallButton.jsx
+++ b/packages/shared/components/CallButton.jsx
@@ -14,7 +14,7 @@ export default function CallButton({
   const href = telHref(phone);
   if (!href) return null;
 
-  const base = 'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-sm font-semibold active-scale whitespace-nowrap';
+  const base = 'inline-flex items-center justify-center gap-1.5 px-3.5 py-2 rounded-xl text-sm font-semibold active-scale whitespace-nowrap';
   const styles = variant === 'subtle'
     ? 'bg-ios-green/10 text-ios-green'
     : 'bg-ios-green text-white';

--- a/packages/shared/components/NavButtons.jsx
+++ b/packages/shared/components/NavButtons.jsx
@@ -3,10 +3,14 @@ import { googleMapsUrl, wazeUrl, appleMapsUrl } from '../utils/navigation.js';
 // Three-up nav strip: Google Maps, Waze, Apple Maps.
 // Renders nothing when the address is empty so the driver card
 // doesn't show dead buttons for pickup-only orders.
+//
+// Colors match each app's brand (blue / cyan / near-black) with white
+// text — high contrast so a driver glancing at the phone in bright
+// daylight still sees three clear, distinct tap targets.
 export default function NavButtons({ address, className = '' }) {
   if (!address) return null;
   const stop = e => e.stopPropagation();
-  const base = 'flex-1 text-center px-3 py-2 rounded-xl text-xs font-semibold active-scale';
+  const base = 'flex-1 text-center px-3 py-2.5 rounded-xl text-sm font-semibold active-scale shadow-sm';
 
   return (
     <div className={`flex gap-2 ${className}`}>
@@ -15,7 +19,7 @@ export default function NavButtons({ address, className = '' }) {
         href={googleMapsUrl(address)}
         target="_blank"
         rel="noopener noreferrer"
-        className={`${base} bg-blue-50 text-blue-700`}
+        className={`${base} bg-blue-600 text-white`}
       >
         Google
       </a>
@@ -24,7 +28,7 @@ export default function NavButtons({ address, className = '' }) {
         href={wazeUrl(address)}
         target="_blank"
         rel="noopener noreferrer"
-        className={`${base} bg-cyan-50 text-cyan-700`}
+        className={`${base} bg-cyan-500 text-white`}
       >
         Waze
       </a>
@@ -33,7 +37,7 @@ export default function NavButtons({ address, className = '' }) {
         href={appleMapsUrl(address)}
         target="_blank"
         rel="noopener noreferrer"
-        className={`${base} bg-gray-100 text-gray-800`}
+        className={`${base} bg-gray-900 text-white`}
       >
         Apple
       </a>


### PR DESCRIPTION
The old card had three problems that made it hard to scan at a glance:
1. The recipient name had no label — readers couldn't tell whether "Svetlana" was the person paying or the person receiving. With gift orders (common) this is dangerous: call the wrong person, ruin the surprise.
2. The owner's driver instructions sat below the address and call strip, so they could be missed entirely on a fast scroll.
3. The Google/Waze/Apple nav strip used -50 backgrounds (bg-blue-50 etc.) and read as disabled — especially Apple on light gray.

New layout priorities, top to bottom:
- Status (payment / time)
- Who, labelled: "Recipient: Svetlana", "Customer: <name>" only when the buyer differs from the recipient (gift order).
- Owner's driver instructions — promoted above the address so it's the first actionable line after "who".
- Where: address + three-map strip in their own section, separated by a divider.
- Who to call: two labelled pills ("Recipient" / "Customer") side by side, each full-half-width so one-handed thumb-reach is easy.
- Thin dividers between sections so each block reads as one unit.

Nav buttons now use each app's brand color with white text:
- Google  → bg-blue-600
- Waze    → bg-cyan-500
- Apple   → bg-gray-900
Plus py-2.5 and a small shadow so they read as primary actions, not
disabled tiles.

CallButton grew slightly (px-3.5 py-2, rounded-xl) — a driver carrying flowers needs a bigger tap target than the old px-2.5 py-1 pill.

DeliverySheet mirrored the same changes: recipient/customer labels in the header, driver instructions promoted to the top of the sheet.

https://claude.ai/code/session_011xC3kbqd9iHaJdw4b64k15