### PR TITLE
chore(wix): unconditional [WIX-RAW] payload log to Railway

### DIFF
--- a/backend/src/services/webhookLog.js
+++ b/backend/src/services/webhookLog.js
@@ -12,7 +12,7 @@ import { TABLES } from '../config/airtable.js';
  * @param {string} [errorMessage] - error details if failed
  * @param {object} [rawPayload] - full webhook payload for debugging
  */
-export async function logWebhookEvent({ status, wixOrderId, appOrderId, errorMessage }) {
+export async function logWebhookEvent({ status, wixOrderId, appOrderId, errorMessage, rawPayload }) {
   try {
     if (!TABLES.WEBHOOK_LOG) {
       console.warn('[WEBHOOK_LOG] Table ID not configured — skipping log');
@@ -33,6 +33,10 @@ export async function logWebhookEvent({ status, wixOrderId, appOrderId, errorMes
     if (errorMessage) {
       fields['Error'] = errorMessage.slice(0, 1000);
     }
+    // rawPayload intentionally not persisted here — Airtable's Error short-
+    // text field caps at ~1000 chars and Wix payloads are 10-30 KB. The
+    // payload is dumped to Railway logs via console.log in wix.js instead.
+    void rawPayload;
 
     await db.create(TABLES.WEBHOOK_LOG, fields);
   } catch (err) {

--- a/backend/src/services/wix.js
+++ b/backend/src/services/wix.js
@@ -25,16 +25,14 @@ import { DELIVERY_STATUS } from '../constants/statuses.js';
 export async function processWixOrder(payload) {
   const log = (step, msg) => console.log(`[WIX] ${step}: ${msg}`);
 
-  // Temporary diagnostic: if DEBUG_WIX_PAYLOAD=1, dump the full raw payload
-  // to Railway logs so we can see the exact field shape Wix is sending. Turn
-  // on for 24h after the next failing order, then off again. Remove this
-  // block once the parser is confirmed to handle every shape correctly.
-  if (process.env.DEBUG_WIX_PAYLOAD === '1') {
-    try {
-      console.log('[WIX-DIAGNOSTIC-PAYLOAD]', JSON.stringify(payload));
-    } catch (jsonErr) {
-      console.log('[WIX-DIAGNOSTIC-PAYLOAD] (could not stringify)', jsonErr.message);
-    }
+  // Always dump the raw payload to Railway logs on every Wix webhook until
+  // the parser is rewritten to handle every payload shape Wix sends. Grep
+  // Railway logs for [WIX-RAW] to retrieve. Remove this block (and the
+  // rawPayload param on logWebhookEvent) once the parser is confirmed good.
+  try {
+    console.log('[WIX-RAW]', JSON.stringify(payload));
+  } catch (jsonErr) {
+    console.log('[WIX-RAW] (could not stringify)', jsonErr.message);
   }
 
   try {


### PR DESCRIPTION
## Summary

Owner set `DEBUG_WIX_PAYLOAD=1` on Railway, backend restarted, a new Wix
order came in (#f16884eb…), and still no diagnostic line in logs — either
the env var didn't propagate or the `=== '1'` check was too strict.

This PR removes the gate: `wix.js` now unconditionally logs the raw payload
with a `[WIX-RAW]` tag on every incoming Wix webhook. Owner just needs to:
1. Grep Railway logs for `[WIX-RAW]` after the next order.
2. Paste the JSON blob back.

Then I'll rewrite the line-item / price / address / payment-method extraction
paths to match the real shape, and remove this logging in a follow-up.

## Why not write to Airtable instead

I looked at it. The existing `Webhook Log` table's `Error` short-text field
caps at ~1 KB; Wix payloads are 10–30 KB. Adding a new long-text column
would require a schema change on the Airtable side. Railway logs are the
path of least friction for a temporary diagnostic.

## Test plan

- [ ] Merge.
- [ ] Wait for next Wix order (or re-send the failing one from Wix dashboard).
- [ ] Open Railway logs, filter for `[WIX-RAW]`, copy the JSON.
- [ ] Paste into the chat for parser rewrite.

https://claude.ai/code/session_01FaX2UirZ6z1tM1n1fL2Ppy