### PR TITLE
feat(wix): admin endpoint to fetch Wix order by ID (parser debug)

### DIFF
--- a/backend/src/routes/webhook.js
+++ b/backend/src/routes/webhook.js
@@ -92,4 +92,45 @@ router.get('/log', authenticate, authorize('admin'), async (req, res, next) => {
   }
 });
 
+// GET /api/webhook/wix-order/:id — admin-only passthrough to Wix's eCommerce
+// API. Fetches an order by ID so we can see the exact payload shape Wix
+// sends, without needing to intercept a live webhook. Used to debug orders
+// that came in before diagnostic logging was deployed.
+// Tries the eCommerce v3 Orders endpoint first, then falls back to the older
+// Stores v2 Orders endpoint. Returns whichever responds 200.
+router.get('/wix-order/:id', authenticate, authorize('admin'), async (req, res) => {
+  const apiKey = process.env.WIX_API_KEY;
+  const siteId = process.env.WIX_SITE_ID;
+  if (!apiKey || !siteId) {
+    return res.status(500).json({ error: 'Wix API credentials not configured.' });
+  }
+  const headers = {
+    Authorization: apiKey,
+    'wix-site-id': siteId,
+    'Content-Type': 'application/json',
+  };
+  const endpoints = [
+    `https://www.wixapis.com/ecom/v1/orders/${encodeURIComponent(req.params.id)}`,
+    `https://www.wixapis.com/stores/v2/orders/${encodeURIComponent(req.params.id)}`,
+  ];
+  const attempts = [];
+  for (const url of endpoints) {
+    try {
+      const r = await fetch(url, { method: 'GET', headers });
+      const text = await r.text();
+      attempts.push({ url, status: r.status, ok: r.ok });
+      if (r.ok) {
+        try {
+          return res.json({ source: url, order: JSON.parse(text) });
+        } catch {
+          return res.json({ source: url, raw: text });
+        }
+      }
+    } catch (err) {
+      attempts.push({ url, error: err.message });
+    }
+  }
+  return res.status(502).json({ error: 'All Wix endpoints failed', attempts });
+});
+
 export default router;


### PR DESCRIPTION
## Summary

Adds an admin-only endpoint `GET /api/webhook/wix-order/:id` that pulls a
Wix order directly from Wix's eCommerce API using the existing
`WIX_API_KEY` + `WIX_SITE_ID` env vars (already configured for product
sync).

## Why

Owner can't re-send failing webhooks from Wix, and two orders already came
in with empty fields before the `[WIX-RAW]` logging was deployed. Without a
fresh webhook there's no way to see the raw payload shape. This endpoint
bypasses the webhook path entirely — fetches the order from Wix directly,
returns its JSON, which is what we need to fix the parser.

## Usage

Owner hits the endpoint with an admin PIN. Two options:

**From a browser signed in to the dashboard** (PIN already in axios
`X-Auth-PIN` header, reuses the existing session) — open DevTools console
and run:

```js
fetch('/api/webhook/wix-order/11b47468-c0b7-43d2-bab5-145ed93cb3ad', {
  headers: { 'X-Auth-PIN': 'YOUR_OWNER_PIN' },
}).then(r => r.json()).then(d => console.log(JSON.stringify(d, null, 2)));
```

**Or curl from a terminal:**

```
curl -H "X-Auth-PIN: YOUR_PIN" \
  https://blossom-backend.railway.app/api/webhook/wix-order/11b47468-c0b7-43d2-bab5-145ed93cb3ad
```

Copy the JSON response, paste it back in chat. I'll fix the parser from
the actual shape.

## Test plan

- [ ] Merge + wait for Railway redeploy (~30s).
- [ ] Owner calls the endpoint for order `11b47468-c0b7-43d2-bab5-145ed93cb3ad`.
- [ ] Owner pastes the JSON response.
- [ ] I rewrite wix.js line-item / price / address / payment-method
      extraction paths to match the real shape, then remove the debug
      endpoint and the [WIX-RAW] console log in a follow-up.

https://claude.ai/code/session_01FaX2UirZ6z1tM1n1fL2Ppy