### PR TITLE
feat(wix): fetch actual payment method + admin reprocess endpoint

### DIFF
--- a/backend/src/routes/webhook.js
+++ b/backend/src/routes/webhook.js
@@ -133,4 +133,65 @@ router.get('/wix-order/:id', authenticate, authorize('admin'), async (req, res) 
   return res.status(502).json({ error: 'All Wix endpoints failed', attempts });
 });
 
+// POST /api/webhook/wix-order/:id/reprocess — admin-only. Deletes the
+// existing App Order (+ its lines and delivery record) for the given Wix
+// Order ID, then re-runs processWixOrder so the new parser populates every
+// field from canonical Wix data. Use this when Wix won't re-fire a webhook
+// and you need to correct orders that came in under an older buggy parser.
+//
+// Scope: safe on blank/broken orders because there's nothing to lose.
+// DO NOT run on orders the florist has composed or edited manually —
+// delete+recreate wipes local edits.
+router.post('/wix-order/:id/reprocess', authenticate, authorize('admin'), async (req, res) => {
+  const wixOrderId = req.params.id;
+  try {
+    // 1. Find the App Order row by Wix Order ID.
+    const matches = await db.list(TABLES.ORDERS, {
+      filterByFormula: `{Wix Order ID} = '${wixOrderId}'`,
+      maxRecords: 1,
+    });
+    if (matches.length === 0) {
+      return res.status(404).json({ error: `No App Order found with Wix Order ID ${wixOrderId}.` });
+    }
+    const existing = matches[0];
+    const lineIds = existing['Order Lines'] || [];
+    const deliveryIds = existing['Deliveries'] || [];
+
+    // 2. Delete linked order lines and delivery records first so nothing
+    //    orphans. Swallow per-record failures — the main goal is the
+    //    App Order itself.
+    for (const lineId of lineIds) {
+      await db.deleteRecord(TABLES.ORDER_LINES, lineId).catch(err => {
+        console.warn(`[REPROCESS] delete line ${lineId}:`, err.message);
+      });
+    }
+    for (const delId of deliveryIds) {
+      await db.deleteRecord(TABLES.DELIVERIES, delId).catch(err => {
+        console.warn(`[REPROCESS] delete delivery ${delId}:`, err.message);
+      });
+    }
+
+    // 3. Delete the App Order.
+    await db.deleteRecord(TABLES.ORDERS, existing.id);
+
+    // 4. Re-run the canonical pipeline with a synthetic webhook payload —
+    //    processWixOrder's dedup will miss (record just deleted) and fall
+    //    through to the Wix API fetch + fresh create.
+    await processWixOrder({ id: wixOrderId });
+
+    // 5. Return the newly created App Order so the UI can refresh.
+    const created = await db.list(TABLES.ORDERS, {
+      filterByFormula: `{Wix Order ID} = '${wixOrderId}'`,
+      maxRecords: 1,
+    });
+    return res.json({
+      deleted: { orderId: existing.id, lineCount: lineIds.length, deliveryCount: deliveryIds.length },
+      created: created[0] || null,
+    });
+  } catch (err) {
+    console.error('[REPROCESS] failed:', err);
+    return res.status(500).json({ error: err.message || 'Reprocess failed.' });
+  }
+});
+
 export default router;

--- a/backend/src/services/wix.js
+++ b/backend/src/services/wix.js
@@ -53,6 +53,48 @@ async function fetchWixOrderById(orderId) {
   }
 }
 
+/**
+ * Fetch the human-readable payment method for a Wix order.
+ * The v3 Orders endpoint doesn't inline this; it lives on a separate
+ * transactions resource. Tries the v3 Orders transactions endpoint first,
+ * falls back to the Payments domain if the shape differs by site.
+ * Returns a best-guess method string (e.g. "CreditCard", "Stripe", "PayPal",
+ * "Cash") or null if nothing is found — callers keep the "Wix Online"
+ * placeholder in that case.
+ */
+export async function fetchWixPaymentMethod(orderId) {
+  if (!process.env.WIX_API_KEY || !process.env.WIX_SITE_ID) return null;
+  const endpoints = [
+    `${WIX_API_URL}/ecom/v1/orders/${encodeURIComponent(orderId)}/transactions`,
+    `${WIX_API_URL}/payments/v1/payments?orderId=${encodeURIComponent(orderId)}`,
+  ];
+  for (const url of endpoints) {
+    try {
+      const res = await fetch(url, { method: 'GET', headers: wixHeaders() });
+      if (!res.ok) continue;
+      const body = await res.json();
+      // Possible shapes across Wix API versions/domains:
+      //   { transactions: [{ payment: { paymentMethod }, ... }] }
+      //   { transactions: [{ paymentMethod, ... }] }
+      //   { payments: [{ paymentMethod, provider, ... }] }
+      //   [{ paymentMethod }]
+      const list = body.transactions || body.payments || (Array.isArray(body) ? body : []);
+      if (!Array.isArray(list) || list.length === 0) continue;
+      for (const item of list) {
+        const method = item.payment?.paymentMethod
+          || item.paymentMethod
+          || item.provider
+          || item.method
+          || item.gatewayName;
+        if (method) return String(method);
+      }
+    } catch (err) {
+      console.error(`[WIX-API] Payment method fetch failed at ${url}:`, err.message);
+    }
+  }
+  return null;
+}
+
 // Wix eCommerce v3 stores prices as { amount: "195.00", formattedAmount: ... }
 // where amount is a decimal STRING. Always parse defensively.
 function moneyAmount(m) {
@@ -225,10 +267,12 @@ export async function processWixOrder(payload) {
       || 0;
 
     // Payment method — v3 doesn't inline this on the order; it's on a separate
-    // transactions resource. Leave as a placeholder that the owner can edit
-    // once seen. Better than guessing wrong. (If you want this populated
-    // accurately, we'd add a second API call to /ecom/v1/orders/:id/transactions.)
-    const paymentMethodLabel = 'Wix Online';
+    // transactions resource. Fetch it directly; fall back to "Wix Online" if
+    // the site uses a provider we can't parse out of the response. Owner can
+    // add new payment methods to Settings whenever Wix reports a new one.
+    const paymentMethodFromWix = await fetchWixPaymentMethod(wixOrderId);
+    const paymentMethodLabel = paymentMethodFromWix || 'Wix Online';
+    if (paymentMethodFromWix) log('8b-PAY', `Payment method: ${paymentMethodFromWix}`);
 
     // 9. Delivery date — Wix may or may not set this, depending on shipping
     //    method configuration. Try a few known paths; fall back to today.


### PR DESCRIPTION
## Summary

Two follow-ups after the Wix parser rewrite (#114):

1. **Actual payment method from Wix.** New `fetchWixPaymentMethod(orderId)`
   helper hits `/ecom/v1/orders/:id/transactions` (falls back to
   `/payments/v1/payments`) and pulls the first recognised payment-method
   field (e.g. `CreditCard`, `Stripe`, `PayPal`, `Cash`). Used in
   `processWixOrder` to set the Payment Method on the App Order instead
   of the hard-coded `Wix Online`. Falls back to `Wix Online` if no
   endpoint responds with a field we recognise.

2. **Admin reprocess endpoint.** Owner said she can't re-fire webhooks
   from Wix, but we have ~3 blank orders that came in under the older
   buggy parser. `POST /api/webhook/wix-order/:id/reprocess`
   (admin-only) deletes the existing App Order + its lines + delivery
   record, then re-runs `processWixOrder` against canonical Wix data
   so every field is populated correctly.

## Safety

The reprocess endpoint is **delete + recreate**, so it wipes any manual
edits. That's fine for the 3 blank orders — nothing to lose. Do NOT
use it on orders where the florist has already composed the bouquet
or added notes. (I'll make this a proper `confirm=true` param if we
ever find ourselves wanting to reprocess touched orders.)

## Test plan

- [ ] Merge → Railway redeploys.
- [ ] Owner runs the fetch snippet below for each of the 3 blank Wix
      orders. Expected: each returns the deleted old record's summary
      and the newly created order record with all fields populated
      (product name, prices, address, payment method, delivery date).
- [ ] Next organic Wix order: Payment Method now reflects the actual
      provider rather than `Wix Online`.

### DevTools snippet (for reprocess)

```js
fetch('/api/webhook/wix-order/11b47468-c0b7-43d2-bab5-145ed93cb3ad/reprocess', {
  method: 'POST',
  headers: { 'X-Auth-PIN': prompt('Owner PIN') },
}).then(r => r.json()).then(d => console.log(JSON.stringify(d, null, 2)));
```

Repeat for the other two order IDs.

https://claude.ai/code/session_01FaX2UirZ6z1tM1n1fL2Ppy