### PR TITLE
feat: owner-only hard-delete for orders (dashboard + florist app)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,61 @@ AIRTABLE_PREMADE_BOUQUET_LINES_TABLE=tbl...  # Premade Bouquet Lines table ID
 
 ---
 
+## 2026-04-21 — Owner can hard-delete orders (dashboard + florist app)
+
+The owner now has a hard-delete action separate from Cancel. Cancel
+keeps the record around for audit (useful for business-reason
+cancellations); Delete makes the order disappear entirely — intended
+for test orders, accidental duplicates, and webhook noise from Wix
+that never should have turned into a record in the first place.
+
+### Backend
+- `services/orderService.js` — new `deleteOrder(orderId)` cascades:
+  returns stock for non-terminal orders (same rule as cancel, so a
+  deleted "holding" order doesn't leave a ghost deduction), then
+  deletes all order lines, the linked delivery, and finally the order
+  itself. Terminal orders (Delivered / Picked Up / Cancelled) skip the
+  stock return since stock was already consumed or returned.
+- `routes/orders.js` — new `DELETE /api/orders/:id`, owner-only (403
+  for other roles), broadcasts `order_deleted` over SSE so other open
+  clients refresh.
+
+### Dashboard (`apps/dashboard/src/components/OrderDetailPanel.jsx`)
+- Red outlined "🗑 Delete order" button next to the existing Cancel
+  button, with a two-step inline confirm. On delete, toast includes
+  any returned stock summary and `onUpdate()` refreshes the list —
+  which closes the panel since the order is gone.
+
+### Florist app
+- `components/OrderCard.jsx` — owner-only "Danger zone" block at the
+  bottom of the expanded card with the same two-step confirm. Parent
+  `OrderListPage` removes the card on success via new `onOrderDeleted`
+  callback.
+- `pages/OrderDetailPage.jsx` — owner-only delete block at the bottom;
+  on success navigates back to `/orders`.
+
+### Translations
+- EN + RU in both florist and dashboard: `deleteOrder`,
+  `deleteOrderConfirm`, `deleteOrderConfirmYes`, `orderDeleted`.
+
+### Why it matters
+- Cancel and Delete now mean different things. Cancel = "this order
+  was a real order that fell through" (keep for stats, revenue
+  tracking, refund audit). Delete = "this order should never have
+  existed" (wipe so reports stay clean).
+- Stock-return logic is reused so a non-terminal delete unwinds the
+  reservation, matching what the owner would expect from cancel.
+
+### What to watch for
+- This is a hard-delete. Once an order is deleted, there is no undo —
+  only the Airtable record's revision history (kept for a few weeks
+  on the current Airtable plan).
+- The route is owner-role only. If the florist logs in and sees the
+  delete button, the UI hides it (`isOwner` gate), but the backend
+  would also reject it with 403 — so no downgrade risk.
+
+---
+
 ## 2026-04-21 — Role-specific owner notes, customer call button, driver nav options
 
 The owner needed to direct the florist and the driver with separate

--- a/apps/dashboard/src/components/OrderDetailPanel.jsx
+++ b/apps/dashboard/src/components/OrderDetailPanel.jsx
@@ -46,6 +46,7 @@ export default function OrderDetailPanel({ orderId, onUpdate }) {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving]   = useState(false);
   const [confirmCancel, setConfirmCancel] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const [editingBouquet, setEditingBouquet] = useState(false);
   const [editLines, setEditLines] = useState([]);
   const [removedLines, setRemovedLines] = useState([]);
@@ -179,6 +180,26 @@ export default function OrderDetailPanel({ orderId, onUpdate }) {
       showToast(t.orderUpdated);
     } catch (err) {
       showToast(err.response?.data?.error || t.error, 'error');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    setSaving(true);
+    try {
+      const res = await client.delete(`/orders/${orderId}`);
+      const returned = res.data.returnedItems || [];
+      if (returned.length > 0) {
+        const summary = returned.map(r => `${r.flowerName}: +${r.quantityReturned}`).join(', ');
+        showToast(`${t.orderDeleted || 'Order deleted'}. ${t.stockReturned || 'Returned'}: ${summary}`, 'success');
+      } else {
+        showToast(t.orderDeleted || 'Order deleted', 'success');
+      }
+      if (onUpdate) onUpdate();
+    } catch (err) {
+      showToast(err.response?.data?.error || t.error, 'error');
+      setConfirmDelete(false);
     } finally {
       setSaving(false);
     }
@@ -1053,6 +1074,39 @@ export default function OrderDetailPanel({ orderId, onUpdate }) {
               </div>
             )}
           </>
+        )}
+
+        {/* Delete — hard-remove the order from Airtable. Distinct from
+            Cancel: Cancel keeps the record for audit; Delete makes it
+            disappear. Use for test orders / duplicates / webhook noise. */}
+        {!confirmDelete ? (
+          <button
+            onClick={() => setConfirmDelete(true)}
+            className="px-4 py-2 rounded-xl border border-ios-red/40 text-ios-red text-sm font-medium hover:bg-ios-red/5"
+          >
+            🗑 {t.deleteOrder || 'Delete order'}
+          </button>
+        ) : (
+          <div className="space-y-2">
+            <span className="text-xs text-ios-red font-semibold block">
+              {t.deleteOrderConfirm || 'Delete this order permanently? This cannot be undone.'}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={handleDelete}
+                disabled={saving}
+                className="px-3 py-1.5 rounded-lg bg-ios-red text-white text-xs font-semibold disabled:opacity-50"
+              >
+                🗑 {t.deleteOrderConfirmYes || 'Delete permanently'}
+              </button>
+              <button
+                onClick={() => setConfirmDelete(false)}
+                className="px-3 py-1.5 rounded-lg bg-gray-100 text-xs"
+              >
+                {t.cancel}
+              </button>
+            </div>
+          </div>
         )}
       </div>
       <DissolvePremadesDialog

--- a/apps/dashboard/src/translations.js
+++ b/apps/dashboard/src/translations.js
@@ -826,6 +826,12 @@ const en = {
   callRecipient:                'Call recipient',
   customer:                     'Customer',
   recipient:                    'Recipient',
+
+  // Owner-only hard-delete
+  deleteOrder:                  'Delete order',
+  deleteOrderConfirm:           'Delete this order permanently? Lines and delivery will also be removed. This cannot be undone.',
+  deleteOrderConfirmYes:        'Delete permanently',
+  orderDeleted:                 'Order deleted',
 };
 
 const ru = {
@@ -1653,6 +1659,12 @@ const ru = {
   callRecipient:                'Позвонить получателю',
   customer:                     'Клиент',
   recipient:                    'Получатель',
+
+  // Owner-only hard-delete
+  deleteOrder:                  'Удалить заказ',
+  deleteOrderConfirm:           'Удалить этот заказ навсегда? Позиции и доставка также будут удалены. Это действие нельзя отменить.',
+  deleteOrderConfirmYes:        'Удалить навсегда',
+  orderDeleted:                 'Заказ удалён',
 };
 
 // ── Proxy-based dynamic translation ──

--- a/apps/florist/src/components/OrderCard.jsx
+++ b/apps/florist/src/components/OrderCard.jsx
@@ -75,13 +75,14 @@ function Row({ label, value }) {
   );
 }
 
-export default function OrderCard({ order, onOrderUpdated, isOwner }) {
+export default function OrderCard({ order, onOrderUpdated, onOrderDeleted, isOwner }) {
   const { paymentMethods: payMethods, timeSlots, drivers } = useConfigLists();
   const { showToast } = useToast();
   const [expanded, setExpanded]   = useState(false);
   const [detail, setDetail]       = useState(null);
   const [loading, setLoading]     = useState(false);
   const [saving, setSaving]       = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const [editingBouquet, setEditingBouquet] = useState(false);
   const [editLines, setEditLines] = useState([]);
   const [removedLines, setRemovedLines] = useState([]);
@@ -122,6 +123,25 @@ export default function OrderCard({ order, onOrderUpdated, isOwner }) {
         .catch(() => showToast(t.loadError, 'error'))
         .finally(() => setLoading(false));
     }
+  }
+
+  async function handleDelete() {
+    setSaving(true);
+    try {
+      const res = await client.delete(`/orders/${order.id}`);
+      const returned = res.data.returnedItems || [];
+      const summary = returned.length > 0
+        ? returned.map(r => `${r.flowerName}: +${r.quantityReturned}`).join(', ')
+        : '';
+      showToast(`${t.orderDeleted || 'Order deleted'}${summary ? '. ' + summary : ''}`, 'success');
+      onOrderDeleted?.(order.id);
+    } catch (err) {
+      showToast(err.response?.data?.error || t.updateError, 'error');
+      setConfirmDelete(false);
+      setSaving(false);
+    }
+    // Note: on success the parent unmounts this card, so we don't
+    // clear saving — the component is about to disappear anyway.
   }
 
   async function patch(fields) {
@@ -1063,6 +1083,47 @@ export default function OrderCard({ order, onOrderUpdated, isOwner }) {
                 )}
               </div>
             </>
+          )}
+
+          {/* ── Danger zone — hard-delete the order (owner only). Distinct
+              from Cancel: Cancel keeps the record for audit, Delete makes
+              it disappear. Intended for test / duplicate / webhook-noise
+              orders. Two-tap confirm so a fat-fingered swipe can't wipe
+              a real order. */}
+          {isOwner && !editingBouquet && (
+            <div className="pt-3 border-t border-dashed border-gray-200 dark:border-gray-700">
+              {!confirmDelete ? (
+                <button
+                  onClick={(e) => { e.stopPropagation(); setConfirmDelete(true); }}
+                  disabled={saving}
+                  className="w-full py-2 rounded-xl border border-ios-red/40 text-ios-red text-sm font-medium active-scale disabled:opacity-40"
+                >
+                  🗑 {t.deleteOrder || 'Delete order'}
+                </button>
+              ) : (
+                <div className="space-y-2">
+                  <p className="text-xs text-ios-red font-semibold text-center">
+                    {t.deleteOrderConfirm || 'Delete this order permanently? This cannot be undone.'}
+                  </p>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={(e) => { e.stopPropagation(); handleDelete(); }}
+                      disabled={saving}
+                      className="flex-1 py-2 rounded-xl bg-ios-red text-white text-sm font-semibold active-scale disabled:opacity-50"
+                    >
+                      🗑 {t.deleteOrderConfirmYes || 'Delete permanently'}
+                    </button>
+                    <button
+                      onClick={(e) => { e.stopPropagation(); setConfirmDelete(false); }}
+                      disabled={saving}
+                      className="flex-1 py-2 rounded-xl bg-gray-100 dark:bg-gray-700 text-ios-label text-sm font-medium active-scale"
+                    >
+                      {t.cancel}
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
           )}
 
           {/* Collapse button */}

--- a/apps/florist/src/pages/OrderDetailPage.jsx
+++ b/apps/florist/src/pages/OrderDetailPage.jsx
@@ -153,6 +153,7 @@ export default function OrderDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError]     = useState(false);
   const [saving, setSaving]   = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
   const [editingBouquet, setEditingBouquet] = useState(false);
   const [editLines, setEditLines] = useState([]);
   const [removedLines, setRemovedLines] = useState([]);
@@ -184,6 +185,23 @@ export default function OrderDetailPage() {
       const msg = err.response?.data?.error || 'Failed to update order.';
       showToast(msg, 'error');
     } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete() {
+    setSaving(true);
+    try {
+      const res = await client.delete(`/orders/${id}`);
+      const returned = res.data.returnedItems || [];
+      const summary = returned.length > 0
+        ? returned.map(r => `${r.flowerName}: +${r.quantityReturned}`).join(', ')
+        : '';
+      showToast(`${t.orderDeleted || 'Order deleted'}${summary ? '. ' + summary : ''}`, 'success');
+      navigate('/orders');
+    } catch (err) {
+      showToast(err.response?.data?.error || t.updateError || 'Failed to delete order.', 'error');
+      setConfirmDelete(false);
       setSaving(false);
     }
   }
@@ -627,6 +645,43 @@ export default function OrderDetailPage() {
                 </div>
               )}
             </div>
+
+            {/* Danger zone — owner only. Two-tap delete. */}
+            {isOwner && (
+              <div className="pt-4 border-t border-dashed border-gray-200">
+                {!confirmDelete ? (
+                  <button
+                    onClick={() => setConfirmDelete(true)}
+                    disabled={saving}
+                    className="w-full py-2.5 rounded-xl border border-ios-red/40 text-ios-red text-sm font-medium active-scale disabled:opacity-40"
+                  >
+                    🗑 {t.deleteOrder || 'Delete order'}
+                  </button>
+                ) : (
+                  <div className="space-y-2">
+                    <p className="text-xs text-ios-red font-semibold text-center">
+                      {t.deleteOrderConfirm || 'Delete this order permanently? This cannot be undone.'}
+                    </p>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={handleDelete}
+                        disabled={saving}
+                        className="flex-1 py-2.5 rounded-xl bg-ios-red text-white text-sm font-semibold active-scale disabled:opacity-50"
+                      >
+                        🗑 {t.deleteOrderConfirmYes || 'Delete permanently'}
+                      </button>
+                      <button
+                        onClick={() => setConfirmDelete(false)}
+                        disabled={saving}
+                        className="flex-1 py-2.5 rounded-xl bg-gray-100 text-ios-label text-sm font-medium active-scale"
+                      >
+                        {t.cancel}
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
           </>
         )}
       </div>

--- a/apps/florist/src/pages/OrderListPage.jsx
+++ b/apps/florist/src/pages/OrderListPage.jsx
@@ -512,6 +512,9 @@ export default function OrderListPage() {
                 onOrderUpdated={(id, patch) => {
                   setOrders(prev => prev.map(o => o.id === id ? { ...o, ...patch } : o));
                 }}
+                onOrderDeleted={(id) => {
+                  setOrders(prev => prev.filter(o => o.id !== id));
+                }}
               />
             ))}
           </div>

--- a/apps/florist/src/translations.js
+++ b/apps/florist/src/translations.js
@@ -542,6 +542,12 @@ const en = {
   customer:                     'Customer',
   recipient:                    'Recipient',
   details:                      'Details',
+
+  // Owner-only hard-delete
+  deleteOrder:                  'Delete order',
+  deleteOrderConfirm:           'Delete this order permanently? Lines and delivery will also be removed. This cannot be undone.',
+  deleteOrderConfirmYes:        'Delete permanently',
+  orderDeleted:                 'Order deleted',
 };
 
 const ru = {
@@ -1083,6 +1089,12 @@ const ru = {
   customer:                     'Клиент',
   recipient:                    'Получатель',
   details:                      'Подробнее',
+
+  // Owner-only hard-delete
+  deleteOrder:                  'Удалить заказ',
+  deleteOrderConfirm:           'Удалить этот заказ навсегда? Позиции и доставка также будут удалены. Это действие нельзя отменить.',
+  deleteOrderConfirmYes:        'Удалить навсегда',
+  orderDeleted:                 'Заказ удалён',
 };
 
 // ── Proxy-based dynamic translation ──

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -11,6 +11,7 @@ import {
   createOrder,
   transitionStatus,
   cancelWithStockReturn,
+  deleteOrder,
   editBouquetLines,
 } from '../services/orderService.js';
 import { broadcast } from '../services/notifications.js';
@@ -396,6 +397,30 @@ router.post('/:id/cancel-with-return', async (req, res, next) => {
   } catch (err) {
     if (err.statusCode === 400) {
       return res.status(400).json({ error: err.message });
+    }
+    next(err);
+  }
+});
+
+// DELETE /api/orders/:id — hard-delete the order, its lines, and linked
+// delivery. Owner-only. Stock is returned for non-terminal orders so a
+// deleted "holding" order doesn't leave a ghost deduction.
+//
+// Intended for the "this order shouldn't exist at all" case (test
+// orders, accidental duplicates, webhook noise). Cancellation is still
+// the right tool for business-reason cancellations that need an audit
+// trail.
+router.delete('/:id', async (req, res, next) => {
+  if (req.role !== 'owner') {
+    return res.status(403).json({ error: 'Only the owner can delete orders.' });
+  }
+  try {
+    const result = await deleteOrder(req.params.id);
+    broadcast({ type: 'order_deleted', orderId: req.params.id });
+    res.json(result);
+  } catch (err) {
+    if (err.statusCode) {
+      return res.status(err.statusCode).json({ error: err.message });
     }
     next(err);
   }

--- a/backend/src/services/orderService.js
+++ b/backend/src/services/orderService.js
@@ -357,6 +357,78 @@ export async function cancelWithStockReturn(orderId) {
 }
 
 /**
+ * Hard-delete an order and every record tied to it — lines and linked
+ * delivery — so nothing orphaned is left behind in Airtable.
+ *
+ * Stock return rule: the same rule as cancel. If the order is still
+ * "holding" stock (not Delivered / Picked Up / Cancelled), returning
+ * its lines' quantities is right — otherwise stock deducted at order
+ * creation would become a ghost deduction forever. Terminal orders
+ * either already consumed the stock (Delivered / Picked Up) or already
+ * returned it on cancel, so we skip the return in those cases.
+ *
+ * Ordering matters: we return stock FIRST (while we still have line
+ * data), then delete lines, then the delivery, then the order record
+ * itself. If anything fails mid-way we stop — leaves the order record
+ * present so the owner can retry, rather than a half-torn-down state.
+ *
+ * @param {string} orderId Airtable record ID
+ * @returns {{ deleted: true, orderId, returnedItems, deletedLineCount, deletedDeliveryCount }}
+ */
+export async function deleteOrder(orderId) {
+  const order = await db.getById(TABLES.ORDERS, orderId);
+  const currentStatus = order.Status || ORDER_STATUS.NEW;
+  const isTerminal = [
+    ORDER_STATUS.DELIVERED,
+    ORDER_STATUS.PICKED_UP,
+    ORDER_STATUS.CANCELLED,
+  ].includes(currentStatus);
+
+  const lineIds = order['Order Lines'] || [];
+  const deliveryIds = order['Deliveries'] || [];
+  const returnedItems = [];
+
+  // 1. Return stock for non-terminal orders.
+  if (!isTerminal && lineIds.length > 0) {
+    const lines = await listByIds(TABLES.ORDER_LINES, lineIds);
+    for (const line of lines) {
+      const stockId = line['Stock Item']?.[0];
+      const qty = Number(line.Quantity || 0);
+      if (stockId && qty > 0) {
+        const { newQty } = await db.atomicStockAdjust(stockId, qty);
+        returnedItems.push({
+          stockId,
+          flowerName: line['Flower Name'] || '?',
+          quantityReturned: qty,
+          newStockQty: newQty,
+        });
+      }
+    }
+  }
+
+  // 2. Delete order lines.
+  for (const lineId of lineIds) {
+    await db.deleteRecord(TABLES.ORDER_LINES, lineId);
+  }
+
+  // 3. Delete linked delivery records.
+  for (const deliveryId of deliveryIds) {
+    await db.deleteRecord(TABLES.DELIVERIES, deliveryId);
+  }
+
+  // 4. Delete the order record itself.
+  await db.deleteRecord(TABLES.ORDERS, orderId);
+
+  return {
+    deleted: true,
+    orderId,
+    returnedItems,
+    deletedLineCount: lineIds.length,
+    deletedDeliveryCount: deliveryIds.length,
+  };
+}
+
+/**
  * Edit bouquet lines — handle removals (return/writeoff), new lines, qty changes.
  * Auto-reverts status from Ready → New if owner edits.
  * @returns {{ updated: true, createdLines }}


### PR DESCRIPTION
Distinct from Cancel (which keeps the record for audit). Delete makes the order vanish from Airtable entirely — for test orders, accidental duplicates, and webhook noise that shouldn't have become records.

Backend:
- deleteOrder(orderId) in orderService.js cascades: return stock for non-terminal orders (same rule as cancel-with-return), then delete order lines → linked delivery → order. Terminal orders skip the stock return since stock was already consumed or already returned.
- DELETE /api/orders/:id, owner-only (403 otherwise), broadcasts order_deleted over SSE so other connected clients can refresh.

Dashboard — red outline "Delete order" button in OrderDetailPanel alongside Cancel, two-step inline confirm to prevent fat-finger mistakes. Toast includes any returned stock summary.

Florist app — same two-step pattern in:
- OrderCard.jsx expanded view (danger zone at the bottom). OrderListPage removes the card on success via new onOrderDeleted prop.
- OrderDetailPage.jsx (full-page view). Navigates back to /orders on success.

Both frontends gate the button with isOwner; the dashboard is owner-only by construction so no explicit gate there.

Translations in EN and RU on both apps: deleteOrder, deleteOrderConfirm, deleteOrderConfirmYes, orderDeleted.

CHANGELOG.md documents the feature + the "no undo beyond Airtable revision history" gotcha.

Backend tests: 64/65 pass (1 pre-existing analyticsService failure unrelated to this change).

https://claude.ai/code/session_011xC3kbqd9iHaJdw4b64k15