### PR TITLE
feat(wix): harden reprocess endpoint + customer match + delivery date fallback

### DIFF
--- a/backend/src/routes/webhook.js
+++ b/backend/src/routes/webhook.js
@@ -4,6 +4,7 @@ import { processWixOrder } from '../services/wix.js';
 import { authenticate, authorize } from '../middleware/auth.js';
 import * as db from '../services/airtable.js';
 import { TABLES } from '../config/airtable.js';
+import { listByIds } from '../utils/batchQuery.js';
 
 const router = Router();
 
@@ -139,11 +140,14 @@ router.get('/wix-order/:id', authenticate, authorize('admin'), async (req, res) 
 // field from canonical Wix data. Use this when Wix won't re-fire a webhook
 // and you need to correct orders that came in under an older buggy parser.
 //
-// Scope: safe on blank/broken orders because there's nothing to lose.
-// DO NOT run on orders the florist has composed or edited manually —
-// delete+recreate wipes local edits.
+// SAFETY GATE: refuses to touch orders that look composed or edited —
+// any Order Line with a Stock Item link OR any Status other than 'New'.
+// Responds 409 with the reasons so the caller can see why it refused.
+// If you *really* need to reprocess a composed order (accepting data loss),
+// pass ?force=true.
 router.post('/wix-order/:id/reprocess', authenticate, authorize('admin'), async (req, res) => {
   const wixOrderId = req.params.id;
+  const force = req.query.force === 'true' || req.query.force === '1';
   try {
     // 1. Find the App Order row by Wix Order ID.
     const matches = await db.list(TABLES.ORDERS, {
@@ -156,6 +160,35 @@ router.post('/wix-order/:id/reprocess', authenticate, authorize('admin'), async 
     const existing = matches[0];
     const lineIds = existing['Order Lines'] || [];
     const deliveryIds = existing['Deliveries'] || [];
+
+    // 1b. SAFETY CHECK — refuse to delete anything that looks composed or
+    //     touched. Two independent signals: status beyond 'New', or any line
+    //     with a Stock Item link (Wix lines never get stock-linked by the
+    //     parser, so presence of a link means the florist added real flowers).
+    if (!force) {
+      const reasons = [];
+      if (existing.Status && existing.Status !== 'New') {
+        reasons.push(`Status is "${existing.Status}" (not 'New').`);
+      }
+      if (lineIds.length > 0) {
+        const lineRecords = await listByIds(TABLES.ORDER_LINES, lineIds, {
+          fields: ['Stock Item', 'Flower Name', 'Quantity'],
+        });
+        const composed = lineRecords.filter(l => Array.isArray(l['Stock Item']) && l['Stock Item'].length > 0);
+        if (composed.length > 0) {
+          const names = composed.map(l => `${l.Quantity || '?'}× ${l['Flower Name'] || '?'}`).join(', ');
+          reasons.push(`${composed.length} line(s) have Stock Item links (composed bouquet): ${names}.`);
+        }
+      }
+      if (reasons.length > 0) {
+        return res.status(409).json({
+          error: 'Reprocess refused — order appears composed or edited.',
+          reasons,
+          hint: 'Pass ?force=true if you truly want to delete and recreate (accepts data loss).',
+          appOrderId: existing['App Order ID'] || existing.id,
+        });
+      }
+    }
 
     // 2. Delete linked order lines and delivery records first so nothing
     //    orphans. Swallow per-record failures — the main goal is the
@@ -187,6 +220,7 @@ router.post('/wix-order/:id/reprocess', authenticate, authorize('admin'), async 
     return res.json({
       deleted: { orderId: existing.id, lineCount: lineIds.length, deliveryCount: deliveryIds.length },
       created: created[0] || null,
+      forced: force,
     });
   } catch (err) {
     console.error('[REPROCESS] failed:', err);

--- a/backend/src/services/wix.js
+++ b/backend/src/services/wix.js
@@ -192,6 +192,14 @@ export async function processWixOrder(payload) {
     log('4-CUSTOMER', `Name: ${customerName}, Email: ${customerEmail}, Phone: ${customerPhone}`);
 
     // 5. Match or create customer
+    // Customer matching — three passes, strongest to weakest:
+    //   1. Phone (normalised) OR email exact
+    //   2. Exact full name (firstName + lastName, case-insensitive)
+    //   3. No match → create
+    // Name-matching is a fallback because Wix often only gives us an email
+    // that may not be on the existing customer record. Duplicates from this
+    // path are possible (two different people with the same name) but less
+    // damaging than the silent duplication we saw when phone/email miss.
     let customerId = null;
     if (customerPhone || customerEmail) {
       const searchFilters = [];
@@ -208,7 +216,32 @@ export async function processWixOrder(payload) {
       });
       if (matches.length > 0) {
         customerId = matches[0].id;
-        log('5-MATCH', `Found existing customer: ${matches[0].Name || matches[0].id}`);
+        log('5-MATCH', `Found existing customer by phone/email: ${matches[0].Name || matches[0].id}`);
+      }
+    }
+    // Pass 2: name fallback. Only run if we actually have a composed
+    // first+last name — avoid matching on 'Wix Customer' or a bare first
+    // name, which could merge unrelated records.
+    if (!customerId && firstName && lastName) {
+      const fullName = `${firstName} ${lastName}`.trim();
+      const nameMatches = await db.list(TABLES.CUSTOMERS, {
+        filterByFormula: `LOWER({Name}) = LOWER('${sanitizeFormulaValue(fullName)}')`,
+        maxRecords: 1,
+      });
+      if (nameMatches.length > 0) {
+        customerId = nameMatches[0].id;
+        log('5-MATCH', `Found existing customer by name: ${nameMatches[0].Name || nameMatches[0].id}`);
+        // Patch email/phone onto the matched record if we have new data Wix
+        // provided and the existing fields are empty — so the next order
+        // matches on the stronger signal.
+        const patch = {};
+        if (customerEmail && !nameMatches[0].Email) patch.Email = customerEmail;
+        if (customerPhone && !nameMatches[0].Phone) patch.Phone = customerPhone;
+        if (Object.keys(patch).length > 0) {
+          db.update(TABLES.CUSTOMERS, customerId, patch).catch(err => {
+            console.error('[WIX] Customer enrich failed:', err.message);
+          });
+        }
       }
     }
     if (!customerId) {
@@ -274,8 +307,11 @@ export async function processWixOrder(payload) {
     const paymentMethodLabel = paymentMethodFromWix || 'Wix Online';
     if (paymentMethodFromWix) log('8b-PAY', `Payment method: ${paymentMethodFromWix}`);
 
-    // 9. Delivery date — Wix may or may not set this, depending on shipping
-    //    method configuration. Try a few known paths; fall back to today.
+    // 9. Delivery date — Wix sends this only when the storefront offers a
+    //    picker. If empty, leave it null so the dashboard's orphan-date
+    //    banner surfaces the order for the owner to set the real date.
+    //    Previously we fell back to "today", which silently mis-dated any
+    //    order reprocessed after the fact.
     const deliveryDate = shipping.deliveryTime?.rangeStartTime
       || shipping.deliveryTime?.deliveryDate
       || shipping.shipmentDetails?.deliveryDate
@@ -284,9 +320,7 @@ export async function processWixOrder(payload) {
       || wixOrder.fulfillments?.[0]?.expectedDeliveryDate
       || null;
     // Normalise to YYYY-MM-DD. Wix may send ISO timestamp or date-only string.
-    const deliveryDateIso = deliveryDate
-      ? String(deliveryDate).slice(0, 10)
-      : new Date().toISOString().split('T')[0];
+    const deliveryDateIso = deliveryDate ? String(deliveryDate).slice(0, 10) : null;
 
     // 10. Create the App Order. Wix is delivery-only today — hard-code the type.
     //     Price Override carries the total the buyer paid (flowers + shipping)


### PR DESCRIPTION
## Summary

Three hardenings triggered by today's incident where `reprocess` silently
deleted a composed Wix order (Klym Semenov) and its florist-added bouquet,
with nothing in Airtable trash to restore from.

## Changes

### 1. `POST /webhook/wix-order/:id/reprocess` refuses composed orders

Before reprocess deletes anything it now checks:

- Any `Order Line` with a `Stock Item` link → the florist composed real
  flowers from stock, not just the text-only Wix line the parser created.
- `Status ≠ 'New'` → order has been advanced beyond initial creation.

If either signal fires, the endpoint returns **409 Conflict** with the
reasons listed, e.g.:

```json
{
  "error": "Reprocess refused — order appears composed or edited.",
  "reasons": [
    "Status is \"Ready\" (not 'New').",
    "2 line(s) have Stock Item links (composed bouquet): 10× Rose White, 3× Lisianthus."
  ],
  "hint": "Pass ?force=true if you truly want to delete and recreate (accepts data loss).",
  "appOrderId": "202604-027"
}
```

`?force=true` bypass still exists for the edge case where the operator
truly wants to accept data loss.

### 2. `processWixOrder` — name-based customer match fallback

Three passes, strongest to weakest:
1. Phone (normalised) OR email exact.
2. Exact full-name (case-insensitive) — only if we have `firstName` AND
   `lastName` (avoids collapsing unrelated `'Wix Customer'` rows).
3. Create new.

On name match we opportunistically patch missing email/phone onto the
existing customer so the next order matches on the stronger signal and
we don't rebuild the problem.

This stops the silent duplicate-customer split we saw: Wix only gave us
`klimjsdev@gmail.com`, the existing Klym Semenov record didn't have that
email, old code created a second customer, and the new order landed on
the orphan duplicate.

### 3. Null `Required By` when Wix has no delivery date

Old behaviour: fell back to `new Date().toISOString().split('T')[0]` (today)
if `shippingInfo.deliveryTime` was absent. That silently mis-dated any
order reprocessed after the fact — the owner saw "delivery today" on an
order placed 5 days ago.

New: leave null. The orphan-date banner we already ship surfaces the row
so the owner sets the real date manually.

## Test plan

- [ ] CI green.
- [ ] Merge.
- [ ] Call `POST /webhook/wix-order/<any-composed-order-ID>/reprocess` →
      expect 409 with reasons, zero records deleted.
- [ ] Call with `?force=true` → proceeds as before (for the edge case).
- [ ] Place a Wix order with a name that matches an existing customer but
      a fresh email → expect the order to land on the existing customer,
      not a new one.
- [ ] Place a Wix order without a delivery date selected → expect the
      order to land with `Required By` null and show in the orphan-date
      banner.

## Incident recap

Earlier today the reprocess endpoint (PR #115) was used to clean up blank
Wix orders. One of the targets was no longer blank — the florist had
composed a real bouquet on it after the bad initial parse. Endpoint
deleted it without warning, Airtable trash is empty on this plan, and
the composed bouquet is unrecoverable. This PR closes the hole.

https://claude.ai/code/session_01FaX2UirZ6z1tM1n1fL2Ppy