### PR TITLE
Customer detail: dropdowns, missing fields, email/phone validation

### DIFF
--- a/apps/dashboard/src/components/CustomerDetailView.jsx
+++ b/apps/dashboard/src/components/CustomerDetailView.jsx
@@ -5,6 +5,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import client from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
+import useConfigLists from '../hooks/useConfigLists.js';
 import t from '../translations.js';
 import InlineEdit from './InlineEdit.jsx';
 import CustomerHeader from './CustomerHeader.jsx';
@@ -12,6 +13,16 @@ import CustomerTimeline from './CustomerTimeline.jsx';
 import KeyPersonChips from './KeyPersonChips.jsx';
 
 const SEGMENT_OPTIONS = ['', 'New', 'Constant', 'Rare', 'DO NOT CONTACT'];
+const LANGUAGE_OPTIONS = ['', 'RU', 'UK', 'PL', 'EN', 'TR'];
+// Matches the pill options in Step1Customer.jsx — keep in sync if the set changes.
+const SEX_BIZ_OPTIONS = ['', 'Female', 'Male', 'Business'];
+
+// Permissive validators: empty is valid (clearing the field); otherwise must match.
+// Phone accepts digits, spaces, +, (), -; at least 5 chars so "1" isn't accepted.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_RE = /^[\d\s+()\-]{5,}$/;
+const validateEmail = v => (!v || EMAIL_RE.test(v)) ? null : t.invalidEmail;
+const validatePhone = v => (!v || PHONE_RE.test(v)) ? null : t.invalidPhone;
 
 export default function CustomerDetailView({ customerId, onUpdate, onNavigate }) {
   const [cust, setCust]       = useState(null);
@@ -69,7 +80,7 @@ export default function CustomerDetailView({ customerId, onUpdate, onNavigate })
 
       <StatStrip orders={orders} />
 
-      <ProfileGrid cust={cust} onPatch={patchField} />
+      <ProfileGrid cust={cust} onPatch={patchField} onInvalid={msg => showToast(msg, 'error')} />
 
       <KeyPersonChips cust={cust} onPatch={patchField} />
 
@@ -173,7 +184,32 @@ function StatCard({ value, label }) {
   );
 }
 
-function ProfileGrid({ cust, onPatch }) {
+function ProfileGrid({ cust, onPatch, onInvalid }) {
+  const { orderSources } = useConfigLists();
+
+  // Airtable occasionally returns single-element arrays for fields that were
+  // linked records at some point in the past — coerce to scalar before using.
+  const commCurrent   = scalar(cust['Communication method']);
+  const sourceCurrent = scalar(cust['Order Source']);
+
+  // Preserve the currently stored value even if the owner later removed it
+  // from Settings — otherwise the select would silently jump to another option.
+  const commOptions = useMemo(
+    () => dedupe(['', ...orderSources, commCurrent]),
+    [orderSources, commCurrent]
+  );
+  const sourceOptions = useMemo(
+    () => dedupe(['', ...orderSources, sourceCurrent]),
+    [orderSources, sourceCurrent]
+  );
+
+  const sexBizLabels = {
+    '':         '—',
+    'Female':   t.female,
+    'Male':     t.male,
+    'Business': t.business,
+  };
+
   return (
     <div className="grid grid-cols-2 lg:grid-cols-3 gap-3">
       <Field label={t.name}>
@@ -183,36 +219,105 @@ function ProfileGrid({ cust, onPatch }) {
         <InlineEdit value={cust.Nickname || ''} onSave={v => onPatch('Nickname', v || null)} />
       </Field>
       <Field label={t.phone}>
-        <InlineEdit value={cust.Phone || ''} onSave={v => onPatch('Phone', v || null)} />
+        <InlineEdit
+          value={cust.Phone || ''}
+          type="tel"
+          onSave={v => onPatch('Phone', v || null)}
+          validate={validatePhone}
+          onValidationError={onInvalid}
+        />
       </Field>
       <Field label={t.email}>
-        <InlineEdit value={cust.Email || ''} onSave={v => onPatch('Email', v || null)} />
+        <InlineEdit
+          value={cust.Email || ''}
+          type="email"
+          onSave={v => onPatch('Email', v || null)}
+          validate={validateEmail}
+          onValidationError={onInvalid}
+        />
       </Field>
       <Field label={t.instagram}>
         <InlineEdit value={cust.Link || ''} onSave={v => onPatch('Link', v || null)} />
       </Field>
       <Field label={t.segment}>
-        <select
-          value={cust.Segment || ''}
-          onChange={e => onPatch('Segment', e.target.value || null)}
-          className="text-sm field-input w-full"
-        >
-          {SEGMENT_OPTIONS.map(s => (
-            <option key={s || 'none'} value={s}>{s || '—'}</option>
-          ))}
-        </select>
+        <SelectField
+          value={cust.Segment}
+          onChange={v => onPatch('Segment', v || null)}
+          options={SEGMENT_OPTIONS.map(s => ({ value: s, label: s || '—' }))}
+        />
       </Field>
       <Field label={t.homeAddress}>
         <InlineEdit value={cust['Home address'] || ''} onSave={v => onPatch('Home address', v || null)} />
       </Field>
       <Field label={t.language}>
-        <InlineEdit value={cust.Language || ''} onSave={v => onPatch('Language', v || null)} />
+        <SelectField
+          value={cust.Language}
+          onChange={v => onPatch('Language', v || null)}
+          options={LANGUAGE_OPTIONS.map(l => ({ value: l, label: l || '—' }))}
+        />
+      </Field>
+      <Field label={t.sex}>
+        <SelectField
+          value={cust['Sex / Business']}
+          onChange={v => onPatch('Sex / Business', v || null)}
+          options={SEX_BIZ_OPTIONS.map(s => ({ value: s, label: sexBizLabels[s] || s }))}
+        />
+      </Field>
+      <Field label={t.communicationMethod}>
+        <SelectField
+          value={commCurrent}
+          onChange={v => onPatch('Communication method', v || null)}
+          options={commOptions.map(s => ({ value: s, label: s || '—' }))}
+        />
+      </Field>
+      <Field label={t.orderSource}>
+        <SelectField
+          value={sourceCurrent}
+          onChange={v => onPatch('Order Source', v || null)}
+          options={sourceOptions.map(s => ({ value: s, label: s || '—' }))}
+        />
       </Field>
       <Field label={t.foundUsFrom}>
         <InlineEdit value={cust['Found us from'] || ''} onSave={v => onPatch('Found us from', v || null)} />
       </Field>
     </div>
   );
+}
+
+// Controlled <select> wrapper. Coerces value to a scalar string so React
+// never sees an array (which triggers a "must be scalar" warning).
+function SelectField({ value, onChange, options }) {
+  return (
+    <select
+      value={scalar(value)}
+      onChange={e => onChange(e.target.value)}
+      className="text-sm field-input w-full"
+    >
+      {options.map(o => (
+        <option key={o.value || 'none'} value={o.value}>{o.label}</option>
+      ))}
+    </select>
+  );
+}
+
+function dedupe(arr) {
+  const seen = new Set();
+  const out  = [];
+  for (const v of arr) {
+    const k = v == null ? '' : v;
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push(k);
+  }
+  return out;
+}
+
+// Coerce Airtable's mixed scalar/array returns into a single string for
+// controlled <select> elements. Empty arrays and nullish values become ''.
+function scalar(v) {
+  if (v == null) return '';
+  if (Array.isArray(v)) return v[0] == null ? '' : String(v[0]);
+  return String(v);
 }
 
 function Field({ label, children }) {

--- a/apps/dashboard/src/components/InlineEdit.jsx
+++ b/apps/dashboard/src/components/InlineEdit.jsx
@@ -1,9 +1,14 @@
 // InlineEdit — click text to edit, blur/enter to save.
 // Like a paper form field: shows the current value, click to write over it.
+// Optional `validate(draft)` returns an error string to block the save;
+// the invalid draft is discarded and `onValidationError(msg)` is notified.
 
 import { useState, useEffect } from 'react';
 
-export default function InlineEdit({ value, onSave, type = 'text', placeholder, multiline, disabled }) {
+export default function InlineEdit({
+  value, onSave, type = 'text', placeholder, multiline, disabled,
+  validate, onValidationError,
+}) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft]     = useState(value);
 
@@ -11,8 +16,18 @@ export default function InlineEdit({ value, onSave, type = 'text', placeholder, 
   useEffect(() => { setDraft(value); }, [value]);
 
   function commit() {
+    if (draft === value) { setEditing(false); return; }
+    if (validate) {
+      const err = validate(draft);
+      if (err) {
+        onValidationError?.(err);
+        setDraft(value);        // revert so the bad value doesn't persist in the input
+        setEditing(false);
+        return;
+      }
+    }
     setEditing(false);
-    if (draft !== value) onSave(draft);
+    onSave(draft);
   }
 
   if (!editing) {

--- a/apps/dashboard/src/translations.js
+++ b/apps/dashboard/src/translations.js
@@ -725,6 +725,8 @@ const en = {
   male:                     'Male',
   business:                 'Business',
   moreFields:               'More fields',
+  invalidEmail:             'Invalid email address',
+  invalidPhone:             'Invalid phone number',
 
   // Florist Hours (Financial tab + Settings)
   floristHours:             'Florist hours',
@@ -1558,6 +1560,8 @@ const ru = {
   male:                     'Мужчина',
   business:                 'Бизнес',
   moreFields:               'Ещё поля',
+  invalidEmail:             'Неверный формат email',
+  invalidPhone:             'Неверный формат телефона',
 
   // Florist Hours (Financial tab + Settings)
   floristHours:             'Часы флористов',


### PR DESCRIPTION
## Summary
- Replaces free-text inputs with dropdowns for **Language** and **Segment** in the Customer detail view, and adds three previously-missing editable fields — **Sex / Business**, **Communication method**, and **Order Source** — wired to the backend's existing `CUSTOMERS_PATCH_ALLOWED` allowlist
- Adds format validation for **Email** and **Phone** via a new optional `validate`/`onValidationError` contract on `InlineEdit`; invalid entries surface a Russian toast and the draft reverts, so bad data can never reach Airtable
- Hardens the `<select>` wrapper against Airtable's occasional single-element-array returns (`['Male']` where `'Male'` is expected) — this was also silently triggering a React "must be scalar" warning before

## Why
The owner previously had to type Language / Sex / Communication method as free text in the new-order wizard but couldn't edit them at all from the customer detail pane, which meant every typo (`Russian`, `ru`, `RUS`) became a permanent data quality hole. The [filter bar](apps/dashboard/src/utils/customerFilters.js) already segmented on these fields, so the mismatch was visible in every funnel count. No backend change was needed — the allowlist already accepted these fields; the UI was just ignoring them.

Communication method and Order Source pull their options from `useConfigLists().orderSources`, so the list stays owner-managed via Settings → Order sources. Pre-existing values that aren't in the current config are preserved as an extra option, so historical data is never silently overwritten.

## Files changed
| File | Change |
|---|---|
| `apps/dashboard/src/components/InlineEdit.jsx` | Adds `validate` + `onValidationError` props; blocks invalid commits, reverts draft, notifies parent |
| `apps/dashboard/src/components/CustomerDetailView.jsx` | Converts Language to dropdown; adds Sex/Business, Communication method, Order Source as dropdowns; wires email/phone validation; `scalar()` helper for defensive array coercion |
| `apps/dashboard/src/translations.js` | Adds `invalidEmail` / `invalidPhone` in EN + RU |

## Parity note
Customer edit is dashboard-only — the florist app has no equivalent detail page (only `Step1Customer` creation). If the owner ever needs in-depth edits from her phone, a new florist component would need to mirror this grid. Not in scope today.

## Test plan
- [ ] Open Dashboard → Customers → click any customer
- [ ] Confirm new dropdowns render: Language, Sex/Business (Тип), Communication method (Способ связи), Order Source (Источник заказа)
- [ ] Pick a new value from any dropdown → confirm it persists on refresh
- [ ] Click the Email field, enter `not-an-email`, press Enter → confirm toast "Неверный формат email" appears and the field reverts
- [ ] Click the Phone field, enter `abc`, press Enter → confirm toast "Неверный формат телефона" appears and the field reverts
- [ ] Inspect a customer that already had `Communication method = "Insta"` (a value NOT in current config) → confirm that value is still selected and appears as an option
- [ ] Check browser console → no React "must be scalar" warnings, no component crashes