### PR TITLE
fix(florist): show negative-stock flowers in bouquet picker

### DIFF
--- a/apps/florist/src/components/steps/Step2Bouquet.jsx
+++ b/apps/florist/src/components/steps/Step2Bouquet.jsx
@@ -281,10 +281,17 @@ export default function Step2Bouquet({
       result = result.filter(s => (Number(s['Current Quantity']) || 0) > 0);
     } else if (!showOutOfStock) {
       // #39: Filter to show only in-stock items by default,
-      // but always show items with pending PO quantities (they're coming)
-      result = result.filter(s =>
-        (Number(s['Current Quantity']) || 0) > 0 || (pendingPO[s.id]?.ordered || 0) > 0
-      );
+      // but always show items with pending PO quantities (they're coming).
+      // 2026-04: also keep items at NEGATIVE stock — they're implicit demand
+      // for the next PO, so the owner should be able to select them when a new
+      // order needs more of the same flower. Typing the name manually was
+      // producing duplicate Stock rows (especially after the Lot Size field
+      // was added). Only qty === 0 with no pending PO is hidden by default.
+      result = result.filter(s => {
+        const qty = Number(s['Current Quantity']) || 0;
+        const onOrder = pendingPO[s.id]?.ordered || 0;
+        return qty !== 0 || onOrder > 0;
+      });
     }
     const q = flowerQuery.toLowerCase().trim();
     if (!q) return result;
@@ -535,7 +542,14 @@ export default function Step2Bouquet({
                       {isOwner && <span> · {(Number(s['Current Cost Price']) || 0).toFixed(0)} zł {t.costPrice}</span>}
                       <span> · {qty} pcs</span>
                       {low && !out && <span className="text-ios-orange"> · low</span>}
-                      {out && !poQty && <span className="text-amber-600 font-medium"> · {t.outOfStock || 'out'}</span>}
+                      {/* qty < 0 → will roll into next PO; label it clearly so the
+                          owner knows she's adding to pre-existing demand, not a bug. */}
+                      {qty < 0 && !poQty && (
+                        <span className="text-orange-600 font-medium"> · {t.addsToNextPO || 'next PO'}</span>
+                      )}
+                      {qty === 0 && !poQty && (
+                        <span className="text-amber-600 font-medium"> · {t.outOfStock || 'out'}</span>
+                      )}
                       {poQty > 0 && <span className="text-blue-600 font-medium"> · +{poQty} {poDateLabel ? `→ ${poDateLabel}` : (t.onOrder || 'on order')}</span>}
                     </div>
                   </div>

--- a/apps/florist/src/translations.js
+++ b/apps/florist/src/translations.js
@@ -251,6 +251,7 @@ const en = {
   negativeStockWarning:  'Some items went below zero stock. Create a purchase order?',
   outOfStock:            'Out of stock',
   onOrder:               'on order',
+  addsToNextPO:          'adds to next PO',
 
   // Stock evaluation
   stockEvaluation:       'Stock Evaluation',
@@ -858,6 +859,7 @@ const ru = {
   negativeStockWarning:  'Некоторые позиции ушли в минус. Создать заказ поставщику?',
   outOfStock:            'Нет в наличии',
   onOrder:               'в заказе',
+  addsToNextPO:          'в следующую закупку',
 
   // Stock evaluation
   stockEvaluation:       'Оценка цветов',


### PR DESCRIPTION
## Summary
Negative-stock flowers were hidden from the florist bouquet picker by default. The owner had to type the flower name manually, which (after the Lot Size field was added) created duplicate Stock rows — real case: two \"Oxypetalum\" rows at -10 and -5 for different orders.

Negative stock is implicit demand for the next PO. It should be selectable alongside pending-PO arrivals so the owner can deepen existing demand rather than spawn a duplicate row.

## Changes
- **Filter** (`Step2Bouquet.jsx:282`): default mode now keeps \`qty !== 0 || pendingPO.ordered > 0\`. Only \`qty === 0\` with no PO is hidden.
- **Row badge**: \`qty < 0 && !poQty\` now shows \"adds to next PO\" (orange) instead of generic \"out\".
- **Translations**: \`addsToNextPO\` / \`в следующую закупку\`.
- Dashboard Step2Bouquet already shows all stock (no gate), so no dashboard change needed.

## Test plan
- [ ] Create a new order as owner, search for a flower with known negative stock → appears in the list with \"-N pcs · adds to next PO\" badge
- [ ] Tap it → increments qty in the bouquet; does NOT spawn a new Stock row
- [ ] Existing pending-PO items still show with \"+N → date\" label (unchanged)
- [ ] Empty-stock flowers with no PO are still hidden (unchanged default)
- [ ] \"Show all\" toggle still reveals everything (unchanged)

## Not in this PR (follow-up)
- The two existing Oxypetalum duplicate Stock rows (−10 and −5) need data cleanup — either merge manually in Airtable or script it. This PR only prevents future duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)