### PR TITLE
Customer navigation: order→customer link + no-reload edits

### DIFF
--- a/apps/dashboard/src/components/CustomerDetailView.jsx
+++ b/apps/dashboard/src/components/CustomerDetailView.jsx
@@ -24,7 +24,10 @@ const PHONE_RE = /^[\d\s+()\-]{5,}$/;
 const validateEmail = v => (!v || EMAIL_RE.test(v)) ? null : t.invalidEmail;
 const validatePhone = v => (!v || PHONE_RE.test(v)) ? null : t.invalidPhone;
 
-export default function CustomerDetailView({ customerId, onUpdate, onNavigate }) {
+// `onLocalPatch(id, updates)` lets the parent CRM list merge the changed fields
+// into its in-memory row without a full re-fetch — avoids the 3-second skeleton
+// reload of 1094 customers every time a single field changes.
+export default function CustomerDetailView({ customerId, onLocalPatch, onNavigate }) {
   const [cust, setCust]       = useState(null);
   const [orders, setOrders]   = useState([]);
   const [loading, setLoading] = useState(true);
@@ -56,7 +59,9 @@ export default function CustomerDetailView({ customerId, onUpdate, onNavigate })
     try {
       await client.patch(`/customers/${customerId}`, { [field]: value });
       setCust(prev => ({ ...prev, [field]: value }));
-      onUpdate?.();
+      // Update just this customer in the parent list instead of triggering a
+      // full re-fetch. Server and client state converge without a visible reload.
+      onLocalPatch?.(customerId, { [field]: value });
     } catch (err) {
       showToast(err.response?.data?.error || t.error, 'error');
     }

--- a/apps/dashboard/src/components/CustomerDrawer.jsx
+++ b/apps/dashboard/src/components/CustomerDrawer.jsx
@@ -11,7 +11,7 @@
 import { useEffect } from 'react';
 import CustomerDetailView from './CustomerDetailView.jsx';
 
-export default function CustomerDrawer({ customerId, onUpdate, onNavigate, onClose }) {
+export default function CustomerDrawer({ customerId, onLocalPatch, onNavigate, onClose }) {
   useEffect(() => {
     function onKey(e) { if (e.key === 'Escape') onClose(); }
     document.addEventListener('keydown', onKey);
@@ -34,7 +34,7 @@ export default function CustomerDrawer({ customerId, onUpdate, onNavigate, onClo
         </button>
         <CustomerDetailView
           customerId={customerId}
-          onUpdate={onUpdate}
+          onLocalPatch={onLocalPatch}
           onNavigate={onNavigate}
         />
       </div>

--- a/apps/dashboard/src/components/CustomersTab.jsx
+++ b/apps/dashboard/src/components/CustomersTab.jsx
@@ -29,13 +29,23 @@ export default function CustomersTab({ initialFilter, onNavigate }) {
   const [customers, setCustomers] = useState([]);
   const [loading, setLoading]     = useState(false);
   const [insights, setInsights]   = useState(null);
-  const [selectedId, setSelected] = useState(null);
+  // `selectedId` can be seeded from a cross-tab navigation (e.g. clicking the
+  // customer link on an Order expanded view) so landing here already opens the
+  // right record — no extra click needed.
+  const [selectedId, setSelected] = useState(f.selectedId || null);
   const [search, setSearch]       = useState(f.search || '');
   const [filters, setFilters]     = useState(() => {
     try { return deserializeFilters(localStorage.getItem(FILTERS_KEY)); }
     catch { return { ...EMPTY_FILTERS }; }
   });
   const { showToast } = useToast();
+
+  // Merges changed fields into the one customer row, instead of re-fetching
+  // the whole 1094-row list. Called by CustomerDetailView after a PATCH succeeds.
+  // Without this, every inline field edit triggered ~3s of skeleton + list reload.
+  const patchCustomerLocal = useCallback((id, updates) => {
+    setCustomers(prev => prev.map(c => c.id === id ? { ...c, ...updates } : c));
+  }, []);
 
   // Fetch all customers once (backend returns full 1094 enriched with _agg)
   const fetchCustomers = useCallback(async () => {
@@ -199,7 +209,7 @@ export default function CustomersTab({ initialFilter, onNavigate }) {
             {selectedCustomer ? (
               <CustomerDetailView
                 customerId={selectedCustomer.id}
-                onUpdate={fetchCustomers}
+                onLocalPatch={patchCustomerLocal}
                 onNavigate={onNavigate}
               />
             ) : (
@@ -216,7 +226,7 @@ export default function CustomersTab({ initialFilter, onNavigate }) {
            handles the detail view. */}
       <CustomerDrawer
         customerId={selectedCustomer?.id || null}
-        onUpdate={fetchCustomers}
+        onLocalPatch={patchCustomerLocal}
         onNavigate={onNavigate}
         onClose={() => setSelected(null)}
       />

--- a/apps/dashboard/src/components/OrderDetailPanel.jsx
+++ b/apps/dashboard/src/components/OrderDetailPanel.jsx
@@ -36,7 +36,7 @@ const DELIVERY_TYPES = [
   { value: 'Pickup',   label: '🏪 ' + t.pickup },
 ];
 
-export default function OrderDetailPanel({ orderId, onUpdate }) {
+export default function OrderDetailPanel({ orderId, onUpdate, onNavigate }) {
   const { paymentMethods: pmList, orderSources: srcList, timeSlots, targetMarkup } = useConfigLists();
   const PAYMENT_METHODS = pmList.map(v => ({ value: v, label: v }));
   const SOURCES = srcList.map(v => ({ value: v, label: v }));
@@ -271,8 +271,39 @@ export default function OrderDetailPanel({ orderId, onUpdate }) {
   const hasP1 = p1Amount > 0 && p1Method;
   const remainingAfterP1 = effectivePrice - p1Amount;
 
+  // First linked customer ID — the owner-facing "click to open CRM profile" target.
+  // Orders may technically link to multiple customers in Airtable but the
+  // convention in this base is one primary customer per order, so we use [0].
+  const customerId = o.Customer?.[0];
+  const customerDisplayName = o['Customer Name'] || o['Customer Nickname'] || '';
+
   return (
     <div className="border-t border-gray-100 px-4 py-4 bg-gray-50/70 space-y-5">
+      {/* Customer — clickable link that jumps to the Customers tab with this
+           customer pre-selected. Keeps the owner from having to search by name
+           after opening an order (a frequent pain point during busy days). */}
+      {customerDisplayName && (
+        <Section label={t.customer}>
+          {customerId && onNavigate ? (
+            <button
+              type="button"
+              onClick={() => onNavigate({ tab: 'customers', filter: { selectedId: customerId } })}
+              className="text-sm font-medium text-ios-blue hover:underline flex items-center gap-1.5"
+              title={t.openInCustomersTab}
+            >
+              <span aria-hidden="true">👤</span>
+              <span>{customerDisplayName}</span>
+              {o['Customer Nickname'] && o['Customer Nickname'] !== customerDisplayName && (
+                <span className="text-ios-tertiary font-normal">({o['Customer Nickname']})</span>
+              )}
+              <span className="text-ios-tertiary" aria-hidden="true">›</span>
+            </button>
+          ) : (
+            <span className="text-sm font-medium text-ios-label">{customerDisplayName}</span>
+          )}
+        </Section>
+      )}
+
       {/* Status */}
       <Section label={t.status}>
         <Pills

--- a/apps/dashboard/src/components/OrdersTab.jsx
+++ b/apps/dashboard/src/components/OrdersTab.jsx
@@ -599,6 +599,7 @@ export default function OrdersTab({ initialFilter, onNavigate }) {
               <OrderDetailPanel
                 orderId={order.id}
                 onUpdate={fetchOrders}
+                onNavigate={onNavigate}
               />
             )}
           </div>

--- a/apps/dashboard/src/translations.js
+++ b/apps/dashboard/src/translations.js
@@ -727,6 +727,7 @@ const en = {
   moreFields:               'More fields',
   invalidEmail:             'Invalid email address',
   invalidPhone:             'Invalid phone number',
+  openInCustomersTab:       'Open in Customers tab',
 
   // Florist Hours (Financial tab + Settings)
   floristHours:             'Florist hours',
@@ -1562,6 +1563,7 @@ const ru = {
   moreFields:               'Ещё поля',
   invalidEmail:             'Неверный формат email',
   invalidPhone:             'Неверный формат телефона',
+  openInCustomersTab:       'Открыть в клиентах',
 
   // Florist Hours (Financial tab + Settings)
   floristHours:             'Часы флористов',


### PR DESCRIPTION
## Summary
Two CRM UX fixes that the owner hits every day:

1. **Order → Customer deep link** — Clicking the customer name in an expanded order now jumps straight to the Customers tab with that record pre-selected. No more switching tabs and searching by name.
2. **No more full-page reload on customer field edits** — Editing any field on a customer used to re-fetch all 1094 rows and show a skeleton for ~3 seconds. Now the change merges into the parent list in-memory after the PATCH succeeds. Feels instant.

## Why
- The owner routinely needs to cross-reference an order against the customer's history / preferences. The round-trip was: open order → note customer name → switch to Customers tab → search → click. That's four interactions for one intent. Now it's one click.
- The skeleton reload made inline editing feel broken. Typing, committing, and watching the whole list blank out 1094 times a day was actively painful. The optimistic merge keeps server and client in sync without the visible churn.

## Files changed
| File | Change |
|---|---|
| `CustomersTab.jsx` | Seeds `selectedId` from `initialFilter.selectedId` (enables the deep link landing); adds `patchCustomerLocal(id, updates)` that merges into the in-memory list; passes that function to `CustomerDetailView` and `CustomerDrawer` instead of `onUpdate` (which triggered the full refetch) |
| `CustomerDetailView.jsx`, `CustomerDrawer.jsx` | Renamed outer prop from `onUpdate` to `onLocalPatch` (distinct from the inner field-level `onPatch(field, value)` signature already used by ProfileGrid / KeyPersonChips / NotesSection) |
| `OrderDetailPanel.jsx` | Accepts `onNavigate` prop; renders a clickable customer section near the top (blue link, 👤 icon, › chevron). Falls back to plain text if no `onNavigate` — keeps the component decoupled |
| `OrdersTab.jsx` | Forwards `onNavigate` through to `OrderDetailPanel` |
| `translations.js` | Adds `openInCustomersTab` (EN: "Open in Customers tab" / RU: "Открыть в клиентах") for the link's tooltip |

## How it connects
- Uses the existing `navigateTo({ tab, filter })` plumbing — just adds a new `filter.selectedId` field that `CustomersTab` reads once on mount (remount forced by `filterKey` increment in `DashboardPage`)
- `onLocalPatch` uses `setCustomers(prev => prev.map(...))` — standard React immutable-update pattern, no stale-state risks

## What to watch for
- If the owner edits a customer's field and the list is sorted by that field (e.g. sorted by Name, user edits Name), the row stays in its old position until next full list refresh. Minor visual artifact; not a correctness issue. Can be addressed later with a smart re-sort if it becomes annoying
- The order→customer link assumes one primary customer per order (`order.Customer?.[0]`). Airtable's link-to-record field technically supports multiple but this base uses one. Matches existing conventions in `orders.js:157` and elsewhere

## Test plan
- [ ] Open Dashboard → Orders → expand any order → confirm a blue "👤 Customer Name ›" button appears near the top
- [ ] Click the button → lands on Customers tab with that customer's detail panel already open
- [ ] In Customers tab, edit any field (Name, Segment dropdown, Language dropdown, etc.) → confirm the list does NOT blank out and reappear. The detail pane updates immediately, the list row reflects the change
- [ ] On a narrow viewport (<1280px) the drawer variant still works (CustomerDrawer receives the same `onLocalPatch` prop)