### PR TITLE
fix(edit-bouquet): hide qty=0 rows from picker (keep negatives)

### DIFF
--- a/apps/dashboard/src/components/OrderDetailPanel.jsx
+++ b/apps/dashboard/src/components/OrderDetailPanel.jsx
@@ -663,7 +663,13 @@ export default function OrderDetailPanel({ orderId, onUpdate, onNavigate }) {
                       .filter(s => {
                         const name = (s['Display Name'] || '').toLowerCase();
                         const qty = Number(s['Current Quantity']) || 0;
+                        const poQty = pendingPO[s.id]?.ordered || 0;
                         if (qty <= 0 && /\(\d{1,2}\.\w{3,4}\.?\)$/.test(s['Display Name'] || '')) return false;
+                        // Hide exactly-zero base rows with no pending PO — those
+                        // are clutter (duplicates, stale records). Negative stock
+                        // stays (implicit demand); qty=0 with a pending PO stays
+                        // (stems arriving soon). Parity with Step2Bouquet.
+                        if (qty === 0 && poQty === 0) return false;
                         if (editLines.some(l => l.stockItemId === s.id)) return false;
                         if (flowerSearch) return name.includes(flowerSearch.toLowerCase());
                         return true;

--- a/apps/florist/src/components/OrderCard.jsx
+++ b/apps/florist/src/components/OrderCard.jsx
@@ -492,14 +492,18 @@ export default function OrderCard({ order, onOrderUpdated, onOrderDeleted, isOwn
                             className="w-full text-sm border border-gray-200 rounded-lg px-3 py-2 outline-none"
                             autoFocus />
                           <div className="max-h-36 overflow-y-auto divide-y divide-gray-50">
-                            {/* Stock results — only items with qty > 0 */}
+                            {/* Stock results — positive OR negative qty; hide empties */}
                             {flowerSearch.length >= 1 && stockItems
                               .filter(s => {
                                 const name = (s['Display Name'] || '').toLowerCase();
                                 const q = flowerSearch.toLowerCase();
                                 const qty = Number(s['Current Quantity']) || 0;
-                                // Hide depleted dated batches
+                                // Hide depleted dated batches (e.g. "Rose (14.Mar.)")
                                 if (qty <= 0 && /\(\d{1,2}\.\w{3,4}\.?\)$/.test(s['Display Name'] || '')) return false;
+                                // Hide exactly-zero base rows — they're clutter
+                                // (duplicate records from earlier manual entries, etc.).
+                                // Negative stock stays: it's implicit demand for the next PO.
+                                if (qty === 0) return false;
                                 return name.includes(q) && !editLines.some(l => l.stockItemId === s.id);
                               })
                               .slice(0, 6)

--- a/apps/florist/src/pages/OrderDetailPage.jsx
+++ b/apps/florist/src/pages/OrderDetailPage.jsx
@@ -366,6 +366,9 @@ export default function OrderDetailPage() {
                               const name = (s['Display Name'] || '').toLowerCase();
                               const qty = Number(s['Current Quantity']) || 0;
                               if (qty <= 0 && /\(\d{1,2}\.\w{3,4}\.?\)$/.test(s['Display Name'] || '')) return false;
+                              // Hide exactly-zero base rows — keep negatives visible
+                              // (they're unfulfilled demand for the next PO).
+                              if (qty === 0) return false;
                               if (editLines.some(l => l.stockItemId === s.id)) return false;
                               if (flowerSearch) return name.includes(flowerSearch.toLowerCase());
                               return true;


### PR DESCRIPTION
## Summary
Follow-up to #122. Opening \`includeEmpty=true\` exposed every qty=0 active row — including duplicate \"Oxypetalum blue\" records from earlier manual-entry incidents.

Tightens the downstream filter to match Step2Bouquet:
- \`qty > 0\` → show
- \`qty < 0\` → show (implicit demand for next PO)
- \`qty === 0 && pending PO > 0\` → show (dashboard only — stems arriving)
- \`qty === 0 && no PO\` → **hide** (clutter: duplicate / stale records)

Florist OrderCard + OrderDetailPage don't fetch /stock/pending-po, so they use the simpler \`qty === 0 → hide\`. Dashboard OrderDetailPanel keeps the full condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)