### PR TITLE
fix: sort delivery time slots chronologically

### DIFF
--- a/apps/dashboard/src/hooks/useConfigLists.js
+++ b/apps/dashboard/src/hooks/useConfigLists.js
@@ -37,6 +37,15 @@ export default function useConfigLists() {
       };
       if (merged.categories) merged.categories = [...merged.categories].sort((a, b) => a.localeCompare(b));
       if (merged.suppliers) merged.suppliers = [...merged.suppliers].sort((a, b) => a.localeCompare(b));
+      // Time slots sorted by start time so the picker renders chronologically
+      // regardless of the order they were added in Airtable settings.
+      if (merged.timeSlots) {
+        merged.timeSlots = [...merged.timeSlots].sort((a, b) => {
+          const [ah, am] = (a.split('-')[0] || '').split(':').map(Number);
+          const [bh, bm] = (b.split('-')[0] || '').split(':').map(Number);
+          return (ah * 60 + (am || 0)) - (bh * 60 + (bm || 0));
+        });
+      }
       cached = merged;
       setLists(cached);
     });

--- a/apps/florist/src/hooks/useConfigLists.js
+++ b/apps/florist/src/hooks/useConfigLists.js
@@ -45,6 +45,16 @@ export default function useConfigLists() {
       };
       if (merged.categories) merged.categories = [...merged.categories].sort((a, b) => a.localeCompare(b));
       if (merged.suppliers) merged.suppliers = [...merged.suppliers].sort((a, b) => a.localeCompare(b));
+      // Time slots must sort by start time, not lexicographically — "08:00-10:00"
+      // still sorts right as plain string, but explicit parse is safer if a slot
+      // like "9:00-11:00" (no leading zero) is ever entered.
+      if (merged.timeSlots) {
+        merged.timeSlots = [...merged.timeSlots].sort((a, b) => {
+          const [ah, am] = (a.split('-')[0] || '').split(':').map(Number);
+          const [bh, bm] = (b.split('-')[0] || '').split(':').map(Number);
+          return (ah * 60 + (am || 0)) - (bh * 60 + (bm || 0));
+        });
+      }
       cached = merged;
       setLists(cached);
     });


### PR DESCRIPTION
## Summary
Time slots stored in Airtable settings were rendered in insertion order. Adding \"08:00-10:00\" or \"18:00-20:00\" after the original slots put them at the end of the pill row instead of in chronological sequence.

## Root cause
5 call sites render \`timeSlots\` directly without going through the existing \`getAvailableSlots\` helper (which sorts). Fixing each call site would be 5 changes.

## Fix
Sort in both \`useConfigLists\` hooks (florist + dashboard) when merging config — same pattern already used for categories + suppliers. All 5 direct consumers get pre-sorted slots with no code changes needed downstream.

## Test plan
- [ ] Open any order in edit mode → Delivery time pills render chronologically (08-10, 10-12, 12-14, 14-16, 16-18, 18-20)
- [ ] Works on dashboard OrderDetailPanel + DeliverySection
- [ ] Works on florist OrderCard + OrderCardExpanded + OrderDetailPage
- [ ] Sort is stable after adding a new slot in Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)