### PR TITLE
perf(dashboard): halve silent-poll rate on 3 tabs

### DIFF
--- a/apps/dashboard/src/components/DayToDayTab.jsx
+++ b/apps/dashboard/src/components/DayToDayTab.jsx
@@ -152,10 +152,12 @@ export default function DayToDayTab({ onNavigate }) {
   useEffect(() => {
     fetchData();
 
-    // Silent poll every 60s — updates data without disrupting UI
+    // Silent poll every 120s — updates data without disrupting UI.
+    // Low cadence because visibility-change refresh + SSE cover active use;
+    // this interval is just a safety net to catch anything missed.
     const interval = setInterval(() => {
       if (!document.hidden) fetchData(true);
-    }, 60000);
+    }, 120000);
 
     function handleVisibility() {
       if (!document.hidden) fetchData(true);

--- a/apps/dashboard/src/components/OrdersTab.jsx
+++ b/apps/dashboard/src/components/OrdersTab.jsx
@@ -140,7 +140,7 @@ export default function OrdersTab({ initialFilter, onNavigate }) {
   useEffect(() => {
     initialLoaded.current = false;
     fetchOrders();
-    const interval = setInterval(() => { if (!document.hidden) fetchOrders(true); }, 30000);
+    const interval = setInterval(() => { if (!document.hidden) fetchOrders(true); }, 60000);
     function onVisible() { if (!document.hidden) fetchOrders(true); }
     document.addEventListener('visibilitychange', onVisible);
     return () => { clearInterval(interval); document.removeEventListener('visibilitychange', onVisible); };

--- a/apps/dashboard/src/components/StockTab.jsx
+++ b/apps/dashboard/src/components/StockTab.jsx
@@ -97,7 +97,7 @@ export default function StockTab({ initialFilter, onNavigate }) {
   useEffect(() => {
     stockLoaded.current = false;
     fetchStock();
-    const interval = setInterval(() => { if (!document.hidden) fetchStock(true); }, 60000);
+    const interval = setInterval(() => { if (!document.hidden) fetchStock(true); }, 120000);
     function onVisible() { if (!document.hidden) fetchStock(true); }
     document.addEventListener('visibilitychange', onVisible);
     return () => { clearInterval(interval); document.removeEventListener('visibilitychange', onVisible); };


### PR DESCRIPTION
## Summary
- Doubles the background polling interval on three dashboard tabs: **Today** (60s→120s), **Orders** (30s→60s), **Stock** (60s→120s).
- Cuts Airtable load from an idle dashboard tab by ~50%, easing pressure on the 5 req/sec rate limit when the owner + florists are active simultaneously.
- Florist `OrderListPage` is intentionally **unchanged** at 30s — frontline order intake needs tight freshness.

## Why
The owner reported the dashboard and florist apps becoming slow. A diagnostic pass found the dominant waste isn't Airtable query speed, but polling cadence: the `/dashboard` endpoint alone fans out to 9 Airtable queries, and OrdersTab/StockTab each add their own polls. With visibility-change refresh and SSE broadcasts already wired, the intervals are effectively a safety net — not the primary freshness signal — so doubling them doesn't change the UX.

This is the lowest-risk, migration-independent perf win. Deeper architectural fixes (SSE subscription for orders/stock, HTTP caching headers, dashboard query consolidation) are deferred until the planned Airtable → PostgreSQL migration, since some of those queries will be rewritten anyway.

## Test plan
- [ ] Dashboard opens and `DayToDayTab` still loads its 9-query fan-out correctly
- [ ] OrdersTab list refreshes when you switch away + back (visibility-change path still fires)
- [ ] StockTab inline adjustments still settle after the next refresh
- [ ] Network inspector shows reduced request frequency (once every 60s / 120s respectively) when tab is idle in foreground
- [ ] No console errors on HMR or cold reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)