### PR TITLE
fix(stock): show deactivated stock in bouquet picker (includeInactive flag)

### DIFF
--- a/apps/dashboard/src/components/NewOrderTab.jsx
+++ b/apps/dashboard/src/components/NewOrderTab.jsx
@@ -33,7 +33,7 @@ export default function NewOrderTab({ onNavigate, initialFilter }) {
   const [premadeBouquets, setPremadeBouquets] = useState([]);
 
   useEffect(() => {
-    client.get('/stock?includeEmpty=true').then(r => setStock(r.data)).catch(console.error);
+    client.get('/stock?includeEmpty=true&includeInactive=true').then(r => setStock(r.data)).catch(console.error);
     client.get('/premade-bouquets').then(r => setPremadeBouquets(r.data || [])).catch(() => {});
   }, []);
 
@@ -185,7 +185,7 @@ export default function NewOrderTab({ onNavigate, initialFilter }) {
       setForm(emptyForm);
       setStep(0);
       // Refresh stock to reflect deductions (negative stock)
-      client.get('/stock?includeEmpty=true').then(r => setStock(r.data)).catch(console.error);
+      client.get('/stock?includeEmpty=true&includeInactive=true').then(r => setStock(r.data)).catch(console.error);
       // Navigate to orders tab to see the new order
       onNavigate?.({ tab: 'orders' });
     } catch (err) {
@@ -258,7 +258,7 @@ export default function NewOrderTab({ onNavigate, initialFilter }) {
             orderLines={form.orderLines}
             priceOverride={form.priceOverride}
             stock={stock}
-            onStockRefresh={() => client.get('/stock?includeEmpty=true').then(r => setStock(r.data))}
+            onStockRefresh={() => client.get('/stock?includeEmpty=true&includeInactive=true').then(r => setStock(r.data))}
             onChange={updateForm}
             onLinesChange={updateLines}
             requiredBy={form.deliveryDate}

--- a/apps/dashboard/src/components/OrderDetailPanel.jsx
+++ b/apps/dashboard/src/components/OrderDetailPanel.jsx
@@ -161,7 +161,7 @@ export default function OrderDetailPanel({ orderId, onUpdate, onNavigate }) {
       // includeEmpty=true so the picker can reselect negative-stock items
       // (they represent unfulfilled demand rolling into the next PO).
       const [stockRes, premadeRes] = await Promise.all([
-        client.get('/stock?includeEmpty=true'),
+        client.get('/stock?includeEmpty=true&includeInactive=true'),
         client.get('/stock/premade-committed').catch(() => ({ data: {} })),
       ]);
       setStockItems(stockRes.data);
@@ -551,7 +551,7 @@ export default function OrderDetailPanel({ orderId, onUpdate, onNavigate }) {
                   if (stockItems.length === 0) {
                     // includeEmpty=true so negative-stock (unfulfilled demand)
                     // flowers appear in the picker — prevents duplicate Stock rows.
-                    client.get('/stock?includeEmpty=true').then(r => setStockItems(r.data)).catch(() => {});
+                    client.get('/stock?includeEmpty=true&includeInactive=true').then(r => setStockItems(r.data)).catch(() => {});
                   }
                   client.get('/stock/pending-po').then(r => setPendingPO(r.data)).catch(() => {});
                   client.get('/stock/premade-committed').then(r => setPremadeMap(r.data || {})).catch(() => setPremadeMap({}));

--- a/apps/dashboard/src/components/PremadeBouquetCreateModal.jsx
+++ b/apps/dashboard/src/components/PremadeBouquetCreateModal.jsx
@@ -26,7 +26,7 @@ export default function PremadeBouquetCreateModal({ onClose, onCreated }) {
   const [stock, setStock] = useState([]);
 
   useEffect(() => {
-    client.get('/stock?includeEmpty=true').then(r => setStock(r.data)).catch(console.error);
+    client.get('/stock?includeEmpty=true&includeInactive=true').then(r => setStock(r.data)).catch(console.error);
   }, []);
 
   function updateForm(patch) {
@@ -122,7 +122,7 @@ export default function PremadeBouquetCreateModal({ onClose, onCreated }) {
             stock={stock}
             /* Physical compose flow — no pending-PO stems allowed. */
             onlyPhysicallyAvailable
-            onStockRefresh={() => client.get('/stock?includeEmpty=true').then(r => setStock(r.data))}
+            onStockRefresh={() => client.get('/stock?includeEmpty=true&includeInactive=true').then(r => setStock(r.data))}
             onChange={updateForm}
             onLinesChange={updateLines}
             requiredBy={null}

--- a/apps/florist/src/components/OrderCard.jsx
+++ b/apps/florist/src/components/OrderCard.jsx
@@ -250,7 +250,7 @@ export default function OrderCard({ order, onOrderUpdated, onOrderDeleted, isOwn
     }
     try {
       const [stockRes, premadeRes] = await Promise.all([
-        client.get('/stock?includeEmpty=true'),
+        client.get('/stock?includeEmpty=true&includeInactive=true'),
         client.get('/stock/premade-committed').catch(() => ({ data: {} })),
       ]);
       setStockItems(stockRes.data);
@@ -417,7 +417,7 @@ export default function OrderCard({ order, onOrderUpdated, onOrderDeleted, isOwn
                         // demand for next PO) are selectable — otherwise the user
                         // retypes the name and creates a duplicate Stock row.
                         if (stockItems.length === 0) {
-                          client.get('/stock?includeEmpty=true').then(r => setStockItems(r.data)).catch(() => {
+                          client.get('/stock?includeEmpty=true&includeInactive=true').then(r => setStockItems(r.data)).catch(() => {
                             showToast(t.loadError || 'Failed to load stock', 'error');
                           });
                         }

--- a/apps/florist/src/pages/NewOrderPage.jsx
+++ b/apps/florist/src/pages/NewOrderPage.jsx
@@ -41,7 +41,7 @@ export default function NewOrderPage() {
   const [premadeBouquets, setPremadeBouquets] = useState([]);
 
   useEffect(() => {
-    client.get('/stock?includeEmpty=true')
+    client.get('/stock?includeEmpty=true&includeInactive=true')
       .then(r => { setStock(r.data); setStockError(false); })
       .catch(err => {
         console.error('Failed to load stock:', err);
@@ -357,7 +357,7 @@ export default function NewOrderPage() {
             </span>
             <button
               onClick={() => {
-                client.get('/stock?includeEmpty=true')
+                client.get('/stock?includeEmpty=true&includeInactive=true')
                   .then(r => { setStock(r.data); setStockError(false); })
                   .catch(() => showToast(t.stockLoadError || 'Still unable to load stock', 'error'));
               }}
@@ -401,7 +401,7 @@ export default function NewOrderPage() {
             priceOverride={form.priceOverride}
             stock={stock}
             isOwner={isOwner}
-            onStockRefresh={() => client.get('/stock?includeEmpty=true').then(r => { setStock(r.data); setStockError(false); }).catch(() => { setStockError(true); showToast(t.stockLoadError, 'error'); })}
+            onStockRefresh={() => client.get('/stock?includeEmpty=true&includeInactive=true').then(r => { setStock(r.data); setStockError(false); }).catch(() => { setStockError(true); showToast(t.stockLoadError, 'error'); })}
             onChange={updateForm}
             onLinesChange={updateLines}
             requiredBy={form.deliveryDate || form.requiredBy}

--- a/apps/florist/src/pages/OrderDetailPage.jsx
+++ b/apps/florist/src/pages/OrderDetailPage.jsx
@@ -322,7 +322,7 @@ export default function OrderDetailPage() {
                         if (stockItems.length === 0) {
                           // includeEmpty=true so negative-stock flowers are
                           // selectable in the picker (matches new-order wizard).
-                          client.get('/stock?includeEmpty=true').then(r => setStockItems(r.data)).catch(() => {});
+                          client.get('/stock?includeEmpty=true&includeInactive=true').then(r => setStockItems(r.data)).catch(() => {});
                         }
                       }}
                       className="text-xs text-brand-600 font-medium px-1"

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -17,18 +17,28 @@ const STOCK_PATCH_ALLOWED = [
   'Last Restocked',
 ];
 
-// GET /api/stock?category=Roses&includeEmpty=true
-// By default hides items with qty=0 (old depleted batches). Pass includeEmpty=true to see all.
+// GET /api/stock?category=Roses&includeEmpty=true&includeInactive=true
+// Defaults hide qty=0 (old depleted batches) and Active=false rows.
+//  - includeEmpty=true   → also return rows with qty ≤ 0 (e.g. negative stock
+//                          already owed to customers)
+//  - includeInactive=true → also return rows that have been manually deactivated
+//                          in Airtable (the bouquet picker needs this so it can
+//                          surface stale-but-still-demanded records and prevent
+//                          duplicate-row creation when the owner re-types a name)
 router.get('/', async (req, res, next) => {
   try {
-    const { category, includeEmpty } = req.query;
-    const filters = ['{Active} = TRUE()'];
+    const { category, includeEmpty, includeInactive } = req.query;
+    const filters = [];
 
+    if (includeInactive !== 'true') filters.push('{Active} = TRUE()');
     if (includeEmpty !== 'true') filters.push('{Current Quantity} > 0');
     if (category) filters.push(`{Category} = '${sanitizeFormulaValue(category)}'`);
 
     const stock = await db.list(TABLES.STOCK, {
-      filterByFormula: `AND(${filters.join(', ')})`,
+      // When no filters are active we must pass an empty string — Airtable
+      // rejects `AND()` with zero clauses. This only happens if the caller
+      // opts into both includeEmpty and includeInactive.
+      filterByFormula: filters.length ? `AND(${filters.join(', ')})` : '',
       sort: [
         { field: 'Category', direction: 'asc' },
         { field: 'Display Name', direction: 'asc' },

--- a/packages/shared/hooks/useOrderEditing.js
+++ b/packages/shared/hooks/useOrderEditing.js
@@ -48,7 +48,7 @@ export default function useOrderEditing({ orderId, apiClient, showToast, t }) {
     setNewFlowerForm(null);
     setEditingBouquet(true);
     if (stockItems.length === 0) {
-      apiClient.get('/stock?includeEmpty=true').then(r => setStockItems(r.data)).catch(() => {});
+      apiClient.get('/stock?includeEmpty=true&includeInactive=true').then(r => setStockItems(r.data)).catch(() => {});
     }
     apiClient.get('/stock/pending-po').then(r => setPendingPO(r.data)).catch(() => {});
     apiClient.get('/stock/premade-committed').then(r => setPremadeMap(r.data || {})).catch(() => setPremadeMap({}));
@@ -267,7 +267,7 @@ export default function useOrderEditing({ orderId, apiClient, showToast, t }) {
     // sees the post-dissolve reality.
     try {
       const [stockRes, premadeRes] = await Promise.all([
-        apiClient.get('/stock?includeEmpty=true'),
+        apiClient.get('/stock?includeEmpty=true&includeInactive=true'),
         apiClient.get('/stock/premade-committed').catch(() => ({ data: {} })),
       ]);
       setStockItems(stockRes.data);


### PR DESCRIPTION
## Root cause (finally)
Backend \`GET /stock\` has **always** hard-filtered \`{Active} = TRUE()\`, regardless of \`includeEmpty\`. The Oxypetalum blue row at -10 had been manually deactivated in Airtable at some point. No amount of frontend filter relaxation could surface it.

## Fix

**Backend:** new \`?includeInactive=true\` param. When set, the Active filter is dropped.

**Frontend:** every bouquet-picker flow now passes both flags:
| File | Flow |
|---|---|
| florist/pages/NewOrderPage.jsx | New-order wizard (3 fetches) |
| florist/components/OrderCard.jsx | Edit bouquet from order list |
| florist/pages/OrderDetailPage.jsx | Edit bouquet full-page |
| dashboard/components/NewOrderTab.jsx | New-order wizard (3 fetches) |
| dashboard/components/OrderDetailPanel.jsx | Edit bouquet side panel |
| dashboard/components/PremadeBouquetCreateModal.jsx | Premade creator |
| packages/shared/hooks/useOrderEditing.js | Shared editing hook (2 fetches) |

**Intentionally NOT changed:** \`StockTab\` and \`ProductsTab\` — stock management pages; deactivated rows should stay hidden there so the owner can use the Active checkbox as a \"hide from my view\" toggle without them resurfacing.

## Test plan
- [ ] Open an existing order, tap Edit bouquet, search \"oxy\" → Oxypetalum blue (-10) now appears
- [ ] Create a new order, bouquet step, search \"oxy\" → same record appears
- [ ] Stock panel unchanged: \"All\" filter still shows only active rows
- [ ] Tapping the -10 row in the picker increments the cart; no duplicate Stock row created

🤖 Generated with [Claude Code](https://claude.com/claude-code)