### PR TITLE
fix(stock): stop double-counting committed orders when qty is already negative

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ These bug patterns have been found and fixed. Follow these rules to avoid reintr
 4. **Feature gates** — check that conditional rendering (`isDelivery &&`, `!isTerminal &&`, `isOwner &&`) doesn't accidentally exclude valid use cases. Example: unpaid warnings should show for ALL order types, not just pickup.
 5. **Silent catch blocks** — every `catch` should either show a toast with the backend error message or log meaningfully. Never `catch(() => {})`.
 6. **PO lines need identity** — every PO line must have either a Stock Item link or a Flower Name. Validate on creation, not during evaluation.
+7. **Stock / Committed double-count** — `Current Quantity` is decremented immediately when an order is created (`orderService.js` → `atomicStockAdjust`). `GET /stock/committed` separately sums all pending order-line demand. The two overlap: the SAME order affects both. Never inline `qty - committed` when `qty` might be negative — use `getEffectiveStock(qty, committed)` from `packages/shared/utils/stockMath.js`. Any stock-math change must be audited on BOTH `apps/florist/src/components/StockItem.jsx` AND `apps/dashboard/src/components/StockTab.jsx`.
 
 ## Key Files
 - `BACKLOG.md` — feature tracking, open items, known issues

--- a/apps/florist/src/components/StockItem.jsx
+++ b/apps/florist/src/components/StockItem.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import client from '../api/client.js';
 import t from '../translations.js';
-import { stockBaseName, renderDateTag, LOSS_REASONS, reasonLabel } from '@flower-studio/shared';
+import { stockBaseName, renderDateTag, LOSS_REASONS, reasonLabel, getEffectiveStock, hasStockShortfall } from '@flower-studio/shared';
 import fmtDate from '../utils/formatDate.js';
 
 /**
@@ -20,8 +20,11 @@ export default function StockItem({ item, editMode, onAdjust, onWriteOff, onPatc
   const dead      = item['Dead/Unsold Stems'] || 0;
   const threshold = item['Reorder Threshold'] || 5;
   const committed = committedData?.committed || 0;
-  const effective = qty - committed;
-  const hasShortfall = committed > 0 && effective < 0;
+  // Use the shared helper — inline `qty - committed` was double-counting when
+  // qty is already negative (the negative already reflects the same orders).
+  // See packages/shared/utils/stockMath.js + root CLAUDE.md pitfall #7.
+  const effective = getEffectiveStock(qty, committed);
+  const hasShortfall = hasStockShortfall(qty, committed);
   const isLow     = qty > 0 && qty <= threshold;
   const isOut     = qty <= 0;
   // Premade reservations — stems physically locked into a premade bouquet.

--- a/backend/src/__tests__/customerRepo.test.js
+++ b/backend/src/__tests__/customerRepo.test.js
@@ -1,0 +1,316 @@
+// customerRepo tests — pin the persistence-boundary behaviour so swapping
+// the underlying store (Airtable → Postgres) can't quietly change the API
+// the routes depend on.
+//
+// These are unit tests: airtable.js and batchQuery.js are mocked. No real
+// network calls. What we assert:
+//   - Field-name aliases applied on read AND write
+//   - PATCH allowlist rejects unknown fields silently
+//   - Empty-allowed-fields update throws { statusCode: 400 }
+//   - listOrders normalizes both legacy + app into one schema sorted desc
+//   - getAggregateMap caches for 60s and recomputes after TTL
+//   - computedSegment hint matches the order-count thresholds
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../config/airtable.js', () => ({
+  default: {},
+  TABLES: {
+    CUSTOMERS: 'tblCustomers',
+    ORDERS: 'tblOrders',
+    LEGACY_ORDERS: 'tblLegacyOrders',
+  },
+}));
+
+vi.mock('../services/airtable.js', () => ({
+  list: vi.fn(),
+  getById: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+}));
+
+vi.mock('../utils/batchQuery.js', () => ({
+  listByIds: vi.fn(),
+}));
+
+import * as db from '../services/airtable.js';
+import { listByIds } from '../utils/batchQuery.js';
+import * as customerRepo from '../repos/customerRepo.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  customerRepo._resetAggregateCache();
+});
+
+describe('customerRepo.list', () => {
+  it('returns customers with response aliases applied', async () => {
+    db.list.mockImplementation((table) => {
+      if (table === 'tblCustomers') {
+        return Promise.resolve([
+          { id: 'recC1', Name: 'Alice', 'Segment (client)': 'Rare', 'Key person 1 (Name + Contact details)': 'Bob' },
+        ]);
+      }
+      // Aggregate computation fetches legacy + app + customers; return empty
+      return Promise.resolve([]);
+    });
+
+    const customers = await customerRepo.list();
+
+    expect(customers).toHaveLength(1);
+    // Alias reads through to the real field under the hood
+    expect(customers[0].Segment).toBe('Rare');
+    expect(customers[0]['Key person 1']).toBe('Bob');
+    // Empty _agg when the customer has no orders
+    expect(customers[0]._agg).toEqual({ lastOrderDate: null, orderCount: 0, totalSpend: 0 });
+  });
+
+  it('applies server-side OR-SEARCH when search query is provided', async () => {
+    db.list.mockResolvedValue([]);
+    await customerRepo.list({ search: 'Alice' });
+
+    const customersCall = db.list.mock.calls.find(([table]) => table === 'tblCustomers');
+    expect(customersCall[1].filterByFormula).toContain('SEARCH');
+    expect(customersCall[1].filterByFormula).toContain('Alice');
+  });
+
+  it('skips aggregate computation when withAggregates=false', async () => {
+    db.list.mockResolvedValue([{ id: 'recC1', Name: 'Alice' }]);
+    const customers = await customerRepo.list({ withAggregates: false });
+
+    expect(customers[0]).not.toHaveProperty('_agg');
+    // Only one db.list call (customers) — not three (legacy + app + customers for agg).
+    expect(db.list).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('customerRepo.getById', () => {
+  it('returns customer with aliases + computedSegment for 10+ orders', async () => {
+    db.getById.mockResolvedValue({
+      id: 'recC1',
+      Name: 'Alice',
+      'Segment (client)': 'Constant',
+      'App Order Count': 12,
+    });
+
+    const c = await customerRepo.getById('recC1');
+
+    expect(c.Segment).toBe('Constant');
+    expect(c.computedSegment).toBe('Constant');
+  });
+
+  it('computedSegment = Rare for 2-9 orders', async () => {
+    db.getById.mockResolvedValue({ id: 'recC1', 'App Order Count': 3 });
+    const c = await customerRepo.getById('recC1');
+    expect(c.computedSegment).toBe('Rare');
+  });
+
+  it('computedSegment = New for 1 order', async () => {
+    db.getById.mockResolvedValue({ id: 'recC1', 'App Order Count': 1 });
+    const c = await customerRepo.getById('recC1');
+    expect(c.computedSegment).toBe('New');
+  });
+
+  it('computedSegment = null for 0 orders', async () => {
+    db.getById.mockResolvedValue({ id: 'recC1', 'App Order Count': 0 });
+    const c = await customerRepo.getById('recC1');
+    expect(c.computedSegment).toBeNull();
+  });
+});
+
+describe('customerRepo.create', () => {
+  it('remaps aliases to real field names before writing', async () => {
+    db.create.mockResolvedValue({ id: 'recC1', Name: 'Alice', 'Segment (client)': 'Rare' });
+
+    await customerRepo.create({ Name: 'Alice', Segment: 'Rare', 'Key person 1': 'Bob' });
+
+    expect(db.create).toHaveBeenCalledWith(
+      'tblCustomers',
+      expect.objectContaining({
+        Name: 'Alice',
+        'Segment (client)': 'Rare',
+        'Key person 1 (Name + Contact details)': 'Bob',
+      }),
+    );
+    // Original alias keys should NOT make it to Airtable.
+    const createdFields = db.create.mock.calls[0][1];
+    expect(createdFields).not.toHaveProperty('Segment');
+    expect(createdFields).not.toHaveProperty('Key person 1');
+  });
+
+  it('drops keys not in the PATCH allowlist', async () => {
+    db.create.mockResolvedValue({ id: 'recC1', Name: 'Alice' });
+
+    await customerRepo.create({
+      Name: 'Alice',
+      BogusField: 'should be stripped',
+      'App Order Count': 99,  // computed field, not in allowlist
+    });
+
+    const createdFields = db.create.mock.calls[0][1];
+    expect(createdFields).toHaveProperty('Name', 'Alice');
+    expect(createdFields).not.toHaveProperty('BogusField');
+    expect(createdFields).not.toHaveProperty('App Order Count');
+  });
+});
+
+describe('customerRepo.update', () => {
+  it('remaps aliases + runs allowlist', async () => {
+    db.update.mockResolvedValue({ id: 'recC1', 'Segment (client)': 'Constant' });
+
+    await customerRepo.update('recC1', { Segment: 'Constant', BogusField: 'x' });
+
+    expect(db.update).toHaveBeenCalledWith(
+      'tblCustomers',
+      'recC1',
+      { 'Segment (client)': 'Constant' },
+    );
+  });
+
+  it('throws statusCode 400 when no allowed fields survive', async () => {
+    await expect(
+      customerRepo.update('recC1', { BogusField: 'x', AnotherBogus: 'y' }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    // And didn't hit the DB.
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('applies response aliases to the updated record', async () => {
+    db.update.mockResolvedValue({
+      id: 'recC1',
+      'Segment (client)': 'Constant',
+      'Key person 1 (Name + Contact details)': 'Carol',
+    });
+
+    const c = await customerRepo.update('recC1', { Segment: 'Constant' });
+
+    expect(c.Segment).toBe('Constant');
+    expect(c['Key person 1']).toBe('Carol');
+  });
+});
+
+describe('customerRepo.listOrders', () => {
+  it('merges legacy + app and sorts date-desc; nulls sink to bottom', async () => {
+    db.getById.mockResolvedValue({
+      id: 'recC1',
+      'Orders (list)': ['recL1', 'recL2'],
+      'App Orders': ['recA1'],
+    });
+    listByIds.mockImplementation((table) => {
+      if (table === 'tblLegacyOrders') {
+        return Promise.resolve([
+          {
+            id: 'recL1',
+            'Oder Number': '202304-WS-Bouquets-15Apr-1',
+            'Flowers+Details of order': 'Roses',
+            'Order Reason': 'Birthday',
+            'Price (with Delivery)': 150,
+          },
+          {
+            id: 'recL2',
+            // No Oder Number, no dates — sinks to bottom.
+            'Flowers+Details of order': 'Tulips',
+          },
+        ]);
+      }
+      if (table === 'tblOrders') {
+        return Promise.resolve([
+          {
+            id: 'recA1',
+            'Order Date': '2026-03-20',
+            'Customer Request': 'Pink roses',
+            'Price Override': 300,
+            Status: 'Delivered',
+          },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const merged = await customerRepo.listOrders('recC1');
+
+    expect(merged).toHaveLength(3);
+    // App order is 2026-03-20, legacy parsed is 2023-04-15, null is last.
+    expect(merged[0].source).toBe('app');
+    expect(merged[0].date).toBe('2026-03-20');
+    expect(merged[0].amount).toBe(300);
+    expect(merged[0].link).toBe('/orders/recA1');
+
+    expect(merged[1].source).toBe('legacy');
+    expect(merged[1].date).toBe('2023-04-15'); // parsed from the Oder Number
+    expect(merged[1].description).toContain('Roses');
+    expect(merged[1].description).toContain('Birthday');
+    expect(merged[1].amount).toBe(150);
+
+    // Null-date legacy entry is last.
+    expect(merged[2].date).toBeNull();
+  });
+
+  it('returns empty array when the customer has no linked orders', async () => {
+    db.getById.mockResolvedValue({ id: 'recC1', 'Orders (list)': [], 'App Orders': [] });
+    listByIds.mockResolvedValue([]);
+
+    const merged = await customerRepo.listOrders('recC1');
+    expect(merged).toEqual([]);
+  });
+});
+
+describe('customerRepo.getAggregateMap — caching', () => {
+  it('caches the result and returns the same object on the second call', async () => {
+    db.list.mockImplementation((table) => {
+      if (table === 'tblLegacyOrders') return Promise.resolve([]);
+      if (table === 'tblOrders') return Promise.resolve([]);
+      if (table === 'tblCustomers') return Promise.resolve([]);
+      return Promise.resolve([]);
+    });
+
+    const first = await customerRepo.getAggregateMap();
+    const second = await customerRepo.getAggregateMap();
+
+    expect(first).toBe(second); // same reference — cache hit
+    // Three fetches for the first call (legacy + app + customers), none for the second.
+    expect(db.list).toHaveBeenCalledTimes(3);
+  });
+
+  it('recomputes after cache reset', async () => {
+    db.list.mockResolvedValue([]);
+
+    await customerRepo.getAggregateMap();
+    customerRepo._resetAggregateCache();
+    await customerRepo.getAggregateMap();
+
+    // Six fetches total: three per computation.
+    expect(db.list).toHaveBeenCalledTimes(6);
+  });
+
+  it('aggregates legacy + app orders per customer', async () => {
+    db.list.mockImplementation((table) => {
+      if (table === 'tblLegacyOrders') {
+        return Promise.resolve([
+          { id: 'recL1', 'Order Delivery Date': '2025-12-01', 'Price (with Delivery)': 100 },
+        ]);
+      }
+      if (table === 'tblOrders') {
+        return Promise.resolve([
+          { id: 'recA1', 'Order Date': '2026-03-20', 'Price Override': 200 },
+        ]);
+      }
+      if (table === 'tblCustomers') {
+        return Promise.resolve([
+          { id: 'recC1', 'Orders (list)': ['recL1'], 'App Orders': ['recA1'] },
+          { id: 'recC2', 'Orders (list)': [], 'App Orders': [] }, // no orders — omitted from agg
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+
+    const agg = await customerRepo.getAggregateMap();
+
+    expect(agg.recC1).toEqual({
+      lastOrderDate: '2026-03-20',
+      orderCount: 2,
+      totalSpend: 300,
+    });
+    // Customers with 0 orders aren't in the map — list() defaults them downstream.
+    expect(agg.recC2).toBeUndefined();
+  });
+});

--- a/backend/src/repos/README.md
+++ b/backend/src/repos/README.md
@@ -1,0 +1,43 @@
+# Repository layer
+
+Thin interface between route handlers and persistence. Handlers call repo
+methods instead of `db.list()` / `db.getById()` directly.
+
+## Why
+
+This repo exists to enable the upcoming **Airtable → Postgres migration**
+without a big-bang rewrite. The pattern is Strangler Fig:
+
+1. Routes call `customerRepo.list()`, `customerRepo.update(...)`, etc. Today
+   those methods are thin wrappers around the existing `airtable.js` service.
+2. When we swap Postgres in, **only files in this directory change**. Route
+   handlers, service layers, and frontends stay identical.
+3. Migration happens per entity — customer first, then stock, then orders —
+   with a shadow-write period where both stores are written to verify parity
+   before cutting over.
+
+IE framing: supplier-agnostic receiving dock. Production lines don't care
+which vendor delivered the materials, only that they arrive in the
+expected shape.
+
+## What goes in here
+
+- **Field-name translation** (Airtable aliases ↔ domain names)
+- **PATCH allowlists** — so routes can't write arbitrary fields
+- **Cross-table joins** that are logically one entity's domain (e.g. a
+  customer's merged legacy + app order history)
+- **In-process caches** tied to a single entity (e.g. customer aggregates)
+
+## What does NOT go in here
+
+- Cross-entity analytics (customer insights that read orders AND customers
+  AND compute RFM) — those belong in a service.
+- HTTP concerns (req/res, status codes, error translation) — stay in routes.
+- Write cascades that span multiple domains (order → delivery status, stock
+  return on cancel) — those belong in `services/`.
+
+## Status
+
+- `customerRepo.js` — pilot, live on Airtable
+- `orderRepo.js` — TODO
+- `stockRepo.js` — TODO

--- a/backend/src/repos/customerRepo.js
+++ b/backend/src/repos/customerRepo.js
@@ -1,0 +1,337 @@
+// Customer repository — the persistence boundary for Customer records.
+//
+// Routes call these methods; this module owns all Airtable specifics
+// (field-name aliases, PATCH allowlist, formula quirks, cross-table joins
+// for order history, aggregate caching). When Postgres replaces Airtable,
+// only this file changes.
+
+import * as db from '../services/airtable.js';
+import { TABLES } from '../config/airtable.js';
+import { pickAllowed } from '../utils/fields.js';
+import { listByIds } from '../utils/batchQuery.js';
+import { sanitizeFormulaValue } from '../utils/sanitize.js';
+
+// ── Field-name translation ──
+// Airtable stores some fields under verbose names ("Segment (client)") but the
+// rest of the stack reads/writes short aliases ("Segment") for ergonomics.
+// Translate at the repo boundary so everything else stays clean.
+const CUSTOMERS_FIELD_ALIASES = {
+  'Segment':           'Segment (client)',
+  'Key person 1':      'Key person 1 (Name + Contact details)',
+  'Key person 2':      'Key person 2 (Name + Contact details)',
+  'Connected people':  'Connected people (TO SORT into Key 1 & Key 2 person)',
+};
+
+// PATCH allowlist uses REAL Airtable field names (not aliases).
+// Remap aliases → real names BEFORE pickAllowed runs.
+// Omitted fields that don't exist in the live Customers table:
+// "Notes / Preferences", "WhatsApp Contact", "Default Delivery Address".
+// Prior PATCHes to those silently no-op'd before the startup schema guard.
+const CUSTOMERS_PATCH_ALLOWED = [
+  'Name', 'Nickname', 'Phone', 'Email', 'Link', 'Language',
+  'Home address', 'Sex / Business', 'Segment (client)',
+  'Found us from',
+  'Connected people (TO SORT into Key 1 & Key 2 person)',
+  'Key person 1 (Name + Contact details)',
+  'Key person 2 (Name + Contact details)',
+  'Key person 1 (important DATE)', 'Key person 2 (important DATE)',
+  'Communication method', 'Order Source',
+];
+
+// Incoming body { Segment: 'Rare' } → { 'Segment (client)': 'Rare' } so the
+// write lands on the real field.
+function remapAliasesToReal(body) {
+  const out = { ...body };
+  for (const [alias, real] of Object.entries(CUSTOMERS_FIELD_ALIASES)) {
+    if (alias in out) {
+      out[real] = out[alias];
+      delete out[alias];
+    }
+  }
+  return out;
+}
+
+// Outgoing customer record: expose both the real field and the short alias
+// so callers can read c.Segment without caring about the Airtable name.
+function addResponseAliases(customer) {
+  for (const [alias, real] of Object.entries(CUSTOMERS_FIELD_ALIASES)) {
+    if (real in customer && !(alias in customer)) {
+      customer[alias] = customer[real];
+    }
+  }
+  return customer;
+}
+
+// ── Legacy order date resolution ──
+// Legacy Oder Numbers follow YYYYMM-<code>-<DD><Mmm>-<seq>,
+// e.g. "202304-WS-Bouquets-15Apr-1". On 2023-era records the dedicated date
+// fields are often empty, so the Oder Number IS the authoritative date.
+const LEGACY_ODER_DATE_RE = /^(\d{4})(\d{2})-.*-(\d{1,2})[A-Za-z]{3}-\d+$/;
+
+function parseLegacyOderDate(oderNumber) {
+  if (!oderNumber || typeof oderNumber !== 'string') return null;
+  const m = LEGACY_ODER_DATE_RE.exec(oderNumber);
+  if (!m) return null;
+  const [, year, month, day] = m;
+  return `${year}-${month}-${day.padStart(2, '0')}`;
+}
+
+function legacyOrderDate(o) {
+  return o['Order Delivery Date'] || o['Order date'] || parseLegacyOderDate(o['Oder Number']);
+}
+
+// ── Aggregate cache ──
+// GET /customers fires on every dashboard mount. Recomputing the full
+// legacy+app join each time would cost ~4 Airtable requests and ~2s.
+// Cache for 60s — stale-by-at-most-a-minute is fine for "last order date".
+const AGG_TTL_MS = 60 * 1000;
+let aggCache = { data: null, computedAt: 0 };
+
+// Exposed so tests can reset between runs.
+export function _resetAggregateCache() {
+  aggCache = { data: null, computedAt: 0 };
+}
+
+async function computeAggregateMap() {
+  // Trust the customer's linked-record fields (auto-populated by Airtable
+  // from nickname matches during owner entry) rather than re-deriving via
+  // text match. Orders (list) is a formula returning legacy-order IDs;
+  // App Orders is the native linked-record array.
+  //
+  // Note: 'Final Price' and 'Sell Total' are computed in code (see
+  // dashboard.js, orders.js) — they aren't stored Airtable fields in this
+  // base. For the aggregate spend we use Price Override as the best
+  // available approximation.
+  const [legacyOrders, appOrders, customers] = await Promise.all([
+    db.list(TABLES.LEGACY_ORDERS, {
+      fields: ['Oder Number', 'Order Delivery Date', 'Order date', 'Price (with Delivery)'],
+    }),
+    db.list(TABLES.ORDERS, {
+      fields: ['Order Date', 'Price Override'],
+    }),
+    db.list(TABLES.CUSTOMERS, {
+      fields: ['Orders (list)', 'App Orders'],
+    }),
+  ]);
+
+  const legacyById = Object.fromEntries(legacyOrders.map(o => [o.id, o]));
+  const appById = Object.fromEntries(appOrders.map(o => [o.id, o]));
+
+  const agg = {};
+  for (const c of customers) {
+    let lastOrderDate = null;
+    let orderCount = 0;
+    let totalSpend = 0;
+
+    for (const lid of (c['Orders (list)'] || [])) {
+      const o = legacyById[lid];
+      if (!o) continue;
+      const date = legacyOrderDate(o);
+      const amount = Number(o['Price (with Delivery)'] || 0);
+      orderCount += 1;
+      totalSpend += amount;
+      if (date && (!lastOrderDate || date > lastOrderDate)) lastOrderDate = date;
+    }
+    for (const aid of (c['App Orders'] || [])) {
+      const o = appById[aid];
+      if (!o) continue;
+      const date = o['Order Date'];
+      const amount = Number(o['Price Override'] || 0);
+      orderCount += 1;
+      totalSpend += amount;
+      if (date && (!lastOrderDate || date > lastOrderDate)) lastOrderDate = date;
+    }
+
+    if (orderCount > 0) agg[c.id] = { lastOrderDate, orderCount, totalSpend };
+  }
+
+  return agg;
+}
+
+// ── Public API ──
+
+/**
+ * Per-customer aggregate map { customerId → { lastOrderDate, orderCount, totalSpend } }.
+ * Joins legacy + app orders. Cached in-process for 60s.
+ */
+export async function getAggregateMap() {
+  if (aggCache.data && Date.now() - aggCache.computedAt < AGG_TTL_MS) {
+    return aggCache.data;
+  }
+  const data = await computeAggregateMap();
+  aggCache = { data, computedAt: Date.now() };
+  return data;
+}
+
+/**
+ * List customers.
+ *   - options.search: substring matched case-insensitively across
+ *     Name, Nickname, Phone, Link, Email (server-side OR of SEARCH()).
+ *   - options.withAggregates (default true): enrich each customer with
+ *     `_agg: { lastOrderDate, orderCount, totalSpend }`.
+ * Response aliases are always applied.
+ */
+export async function list({ search, withAggregates = true } = {}) {
+  const listOptions = { sort: [{ field: 'Name', direction: 'asc' }] };
+  if (search) {
+    const q = sanitizeFormulaValue(search);
+    listOptions.filterByFormula = `OR(
+      SEARCH(LOWER('${q}'), LOWER({Name})),
+      SEARCH(LOWER('${q}'), LOWER({Nickname})),
+      SEARCH('${q}', {Phone}),
+      SEARCH(LOWER('${q}'), LOWER({Link})),
+      SEARCH(LOWER('${q}'), LOWER({Email}))
+    )`;
+  }
+
+  const [customers, aggMap] = await Promise.all([
+    db.list(TABLES.CUSTOMERS, listOptions),
+    withAggregates ? getAggregateMap() : Promise.resolve({}),
+  ]);
+
+  const emptyAgg = { lastOrderDate: null, orderCount: 0, totalSpend: 0 };
+  for (const c of customers) {
+    addResponseAliases(c);
+    if (withAggregates) {
+      c._agg = aggMap[c.id] || emptyAgg;
+    }
+  }
+  return customers;
+}
+
+/**
+ * Fetch a single customer by Airtable record ID.
+ * Returns with response aliases + computedSegment (read-only hint based on
+ * order count — not written to Airtable).
+ */
+export async function getById(id) {
+  const customer = await db.getById(TABLES.CUSTOMERS, id);
+  addResponseAliases(customer);
+  const count = customer['App Order Count'] || 0;
+  customer.computedSegment =
+    count >= 10 ? 'Constant' :
+    count >= 2  ? 'Rare' :
+    count >= 1  ? 'New' : null;
+  return customer;
+}
+
+/**
+ * Create a new customer. Field aliases are remapped, then the payload runs
+ * through the PATCH allowlist so unknown / unsafe keys are rejected silently.
+ * Response carries aliases applied.
+ */
+export async function create(fields) {
+  const remapped = remapAliasesToReal(fields);
+  const safeFields = pickAllowed(remapped, CUSTOMERS_PATCH_ALLOWED);
+  const customer = await db.create(TABLES.CUSTOMERS, safeFields);
+  addResponseAliases(customer);
+  return customer;
+}
+
+/**
+ * Update an existing customer. Same alias + allowlist pipeline as create.
+ * Throws { statusCode: 400 } if no allowed fields survive filtering — the
+ * caller (route) surfaces that as a 400 error to the HTTP client.
+ */
+export async function update(id, fields) {
+  const remapped = remapAliasesToReal(fields);
+  const safeFields = pickAllowed(remapped, CUSTOMERS_PATCH_ALLOWED);
+  if (Object.keys(safeFields).length === 0) {
+    const err = new Error('No valid fields to update.');
+    err.statusCode = 400;
+    throw err;
+  }
+  const customer = await db.update(TABLES.CUSTOMERS, id, safeFields);
+  addResponseAliases(customer);
+  return customer;
+}
+
+/**
+ * Merged legacy + app order history for one customer, sorted date-desc.
+ * Each entry is normalized to:
+ *   { id, source: 'legacy'|'app', date, description, amount, status, link, lines, raw }
+ *
+ * Legacy orders link via the customer's `Orders (list)` formula field (which
+ * returns linked record IDs). App orders link via `App Orders`. Both are
+ * fetched in parallel via `listByIds` (chunked OR-of-RECORD_ID).
+ */
+export async function listOrders(customerId) {
+  const customer = await db.getById(TABLES.CUSTOMERS, customerId);
+  const legacyIds = customer['Orders (list)'] || [];
+  const appIds = customer['App Orders'] || [];
+
+  const [legacyOrders, appOrders] = await Promise.all([
+    listByIds(TABLES.LEGACY_ORDERS, legacyIds, {
+      // 'Oder Number' is misspelled in the live base (sic). If the owner ever
+      // renames it to 'Order Number', add that here — the normalizer already
+      // checks both via ||.
+      fields: [
+        'Oder Number',
+        'Flowers+Details of order',
+        'Order Reason',
+        'Order Delivery Date',
+        'Order date',
+        'Price (with Delivery)',
+      ],
+    }),
+    listByIds(TABLES.ORDERS, appIds, {
+      // Bouquet Summary / Final Price / Sell Total are computed in code, not
+      // stored Airtable fields. Timeline uses Price Override as a lower-bound
+      // amount and falls back to Customer Request for the description.
+      fields: [
+        'Order Date', 'Customer Request',
+        'Price Override', 'Status', 'Order Lines',
+      ],
+    }),
+  ]);
+
+  const normalizedLegacy = legacyOrders.map(o => ({
+    id: o.id,
+    source: 'legacy',
+    date: legacyOrderDate(o),
+    description: [
+      o['Oder Number'],
+      o['Flowers+Details of order'],
+      o['Order Reason'],
+    ].filter(Boolean).join(' — '),
+    // 0 means "price not recorded" on pre-app records. The frontend can check
+    // raw['Price (with Delivery)'] if it needs to distinguish 0 zł from missing.
+    amount: Number(o['Price (with Delivery)'] || 0),
+    status: null,
+    link: null,
+    lines: null,
+    raw: o,
+  }));
+
+  const normalizedApp = appOrders.map(o => ({
+    id: o.id,
+    source: 'app',
+    date: o['Order Date'] || null,
+    description: o['Customer Request'] || '',
+    amount: Number(o['Price Override'] || 0),
+    status: o.Status || null,
+    link: `/orders/${o.id}`,
+    lines: o['Order Lines'] || null,
+    raw: o,
+  }));
+
+  return [...normalizedLegacy, ...normalizedApp].sort((a, b) => {
+    if (!a.date && !b.date) return 0;
+    if (!a.date) return 1;
+    if (!b.date) return -1;
+    return b.date.localeCompare(a.date);
+  });
+}
+
+// ── Internal exports for tests ──
+// Not part of the public API, but pinned here so tests can import them without
+// duplicating the constants. If the repo is later split into impl + interface,
+// these move with the impl.
+export const _internal = {
+  CUSTOMERS_FIELD_ALIASES,
+  CUSTOMERS_PATCH_ALLOWED,
+  remapAliasesToReal,
+  addResponseAliases,
+  parseLegacyOderDate,
+  legacyOrderDate,
+};

--- a/backend/src/routes/customers.js
+++ b/backend/src/routes/customers.js
@@ -1,201 +1,43 @@
+// Thin HTTP controller for customer endpoints. All Airtable-specific logic
+// (field-name aliases, allowlists, aggregate caching, legacy/app order joins)
+// lives in customerRepo. Insights stays here because it's a cross-entity
+// computation that reads customers + orders and produces derived analytics —
+// not a single-entity persistence concern.
+//
+// When Airtable is swapped for Postgres, this file shouldn't need to change.
+
 import { Router } from 'express';
 import { authorize } from '../middleware/auth.js';
 import * as db from '../services/airtable.js';
 import { TABLES } from '../config/airtable.js';
-import { pickAllowed } from '../utils/fields.js';
-import { listByIds } from '../utils/batchQuery.js';
-import { sanitizeFormulaValue } from '../utils/sanitize.js';
+import * as customerRepo from '../repos/customerRepo.js';
 
 const router = Router();
 router.use(authorize('customers'));
 
-// Field-name aliases: the Airtable schema uses verbose names for a few fields,
-// but the frontend code reads/writes short aliases for ergonomics. We translate
-// at the API boundary so the rest of the stack stays simple.
-const CUSTOMERS_FIELD_ALIASES = {
-  'Segment':           'Segment (client)',
-  'Key person 1':      'Key person 1 (Name + Contact details)',
-  'Key person 2':      'Key person 2 (Name + Contact details)',
-  'Connected people':  'Connected people (TO SORT into Key 1 & Key 2 person)',
-};
-
-// PATCH allowlist uses REAL Airtable field names (not aliases).
-// Remap aliases → real names BEFORE pickAllowed runs (see remapAliasesToReal below).
-// Omitted vs old allowlist: "Notes / Preferences", "WhatsApp Contact", "Default
-// Delivery Address" — these don't exist in the live Customers table (caught by the
-// startup schema guard). Prior PATCHes to them silently no-op'd.
-const CUSTOMERS_PATCH_ALLOWED = [
-  'Name', 'Nickname', 'Phone', 'Email', 'Link', 'Language',
-  'Home address', 'Sex / Business', 'Segment (client)',
-  'Found us from',
-  'Connected people (TO SORT into Key 1 & Key 2 person)',
-  'Key person 1 (Name + Contact details)',
-  'Key person 2 (Name + Contact details)',
-  'Key person 1 (important DATE)', 'Key person 2 (important DATE)',
-  'Communication method', 'Order Source',
-];
-
-// For incoming request bodies: if the client sent { Segment: "Rare" },
-// translate to { "Segment (client)": "Rare" } so the write lands on the real field.
-function remapAliasesToReal(body) {
-  const out = { ...body };
-  for (const [alias, real] of Object.entries(CUSTOMERS_FIELD_ALIASES)) {
-    if (alias in out) {
-      out[real] = out[alias];
-      delete out[alias];
-    }
-  }
-  return out;
-}
-
-// For outgoing GET responses: expose both the real field and the short alias
-// so the frontend can read c.Segment without caring about the Airtable name.
-function addResponseAliases(customer) {
-  for (const [alias, real] of Object.entries(CUSTOMERS_FIELD_ALIASES)) {
-    if (real in customer && !(alias in customer)) {
-      customer[alias] = customer[real];
-    }
-  }
-  return customer;
-}
-
-// Legacy Oder Numbers follow the convention YYYYMM-<code>-<DD><Mmm>-<seq>,
-// e.g. "202304-WS-Bouquets-15Apr-1". On old records (2023 era) the dedicated
-// Order Delivery Date / Order date fields are often empty, so the Oder Number
-// IS the authoritative date. This parser returns an ISO YYYY-MM-DD string.
-// Returns null if the convention doesn't match (newer records use date fields).
-const LEGACY_ODER_DATE_RE = /^(\d{4})(\d{2})-.*-(\d{1,2})[A-Za-z]{3}-\d+$/;
-function parseLegacyOderDate(oderNumber) {
-  if (!oderNumber || typeof oderNumber !== 'string') return null;
-  const m = LEGACY_ODER_DATE_RE.exec(oderNumber);
-  if (!m) return null;
-  const [, year, month, day] = m;
-  return `${year}-${month}-${day.padStart(2, '0')}`;
-}
-
-function legacyOrderDate(o) {
-  return o['Order Delivery Date'] || o['Order date'] || parseLegacyOderDate(o['Oder Number']);
-}
-
-// 60-second in-process cache of customer-level aggregates (last order,
-// order count, total spend) computed over legacy + app orders combined.
-// Why cache: GET /customers fires on every dashboard mount; recomputing
-// the join each time would cost ~28 Airtable requests and ~6 seconds.
-const AGG_TTL_MS = 60 * 1000;
-let aggCache = { data: null, computedAt: 0 };
-
-async function getAggregateMap() {
-  if (aggCache.data && Date.now() - aggCache.computedAt < AGG_TTL_MS) {
-    return aggCache.data;
-  }
-
-  // We trust the customer's linked-record fields (auto-populated by Airtable
-  // from nickname matches during owner entry) rather than re-deriving via
-  // text match. Orders (list) is a formula returning legacy-order IDs;
-  // App Orders is the native linked-record array.
-  //
-  // Note: 'Final Price' and 'Sell Total' are computed in code (see dashboard.js,
-  // orders.js) — they aren't stored Airtable fields in this base. For the
-  // aggregate spend we use Price Override as the best available approximation.
-  const [legacyOrders, appOrders, customers] = await Promise.all([
-    db.list(TABLES.LEGACY_ORDERS, {
-      fields: ['Oder Number', 'Order Delivery Date', 'Order date', 'Price (with Delivery)'],
-    }),
-    db.list(TABLES.ORDERS, {
-      fields: ['Order Date', 'Price Override'],
-    }),
-    db.list(TABLES.CUSTOMERS, {
-      fields: ['Orders (list)', 'App Orders'],
-    }),
-  ]);
-
-  const legacyById = Object.fromEntries(legacyOrders.map(o => [o.id, o]));
-  const appById = Object.fromEntries(appOrders.map(o => [o.id, o]));
-
-  const agg = {};
-  for (const c of customers) {
-    let lastOrderDate = null;
-    let orderCount = 0;
-    let totalSpend = 0;
-
-    for (const lid of (c['Orders (list)'] || [])) {
-      const o = legacyById[lid];
-      if (!o) continue;
-      const date = legacyOrderDate(o);
-      const amount = Number(o['Price (with Delivery)'] || 0);
-      orderCount += 1;
-      totalSpend += amount;
-      if (date && (!lastOrderDate || date > lastOrderDate)) lastOrderDate = date;
-    }
-    for (const aid of (c['App Orders'] || [])) {
-      const o = appById[aid];
-      if (!o) continue;
-      const date = o['Order Date'];
-      const amount = Number(o['Price Override'] || 0);
-      orderCount += 1;
-      totalSpend += amount;
-      if (date && (!lastOrderDate || date > lastOrderDate)) lastOrderDate = date;
-    }
-
-    if (orderCount > 0) agg[c.id] = { lastOrderDate, orderCount, totalSpend };
-  }
-
-  aggCache = { data: agg, computedAt: Date.now() };
-  return agg;
-}
-
 // GET /api/customers
-// Without ?search: returns ALL customers (~1094 rows), each enriched with
-// _agg: { lastOrderDate, orderCount, totalSpend } computed over legacy + app.
-// With ?search=X: applies the old server-side OR(SEARCH()) filter across
-// Name/Nickname/Phone/Link/Email so the legacy Customer tab's search input
-// keeps working until the v2.0 frontend lands with client-side universal search.
+// Without ?search: all customers (~1094 rows), each enriched with
+// _agg: { lastOrderDate, orderCount, totalSpend }.
+// With ?search=X: OR-of-SEARCH across Name/Nickname/Phone/Link/Email so the
+// legacy Customer tab's server-side search keeps working.
 router.get('/', async (req, res, next) => {
   try {
-    const { search } = req.query;
-
-    const listOptions = { sort: [{ field: 'Name', direction: 'asc' }] };
-    if (search) {
-      const q = sanitizeFormulaValue(search);
-      listOptions.filterByFormula = `OR(
-        SEARCH(LOWER('${q}'), LOWER({Name})),
-        SEARCH(LOWER('${q}'), LOWER({Nickname})),
-        SEARCH('${q}', {Phone}),
-        SEARCH(LOWER('${q}'), LOWER({Link})),
-        SEARCH(LOWER('${q}'), LOWER({Email}))
-      )`;
-    }
-
-    const [customers, aggMap] = await Promise.all([
-      db.list(TABLES.CUSTOMERS, listOptions),
-      getAggregateMap(),
-    ]);
-
-    for (const c of customers) {
-      addResponseAliases(c);
-      c._agg = aggMap[c.id] || { lastOrderDate: null, orderCount: 0, totalSpend: 0 };
-    }
-
+    const customers = await customerRepo.list({ search: req.query.search });
     res.json(customers);
   } catch (err) {
     next(err);
   }
 });
 
-// GET /api/customers/insights — segment distribution, churn risk, top spenders
+// GET /api/customers/insights — segment distribution, churn risk, top spenders.
 // Must be defined BEFORE /:id to avoid route collision.
+// Kept in the route because it joins customers + orders + computes RFM —
+// that's analytics, not a single-entity persistence operation.
 router.get('/insights', async (req, res, next) => {
   try {
-    // Fetch all customers — don't filter by field names since some fields
-    // may not exist yet in the dev base (e.g. Segment, App Order Count)
-    const customers = await db.list(TABLES.CUSTOMERS, {
-      sort: [{ field: 'Name', direction: 'asc' }],
-    });
+    const customers = await customerRepo.list({ withAggregates: false });
 
-    // Normalize aliases so c.Segment etc. are populated from the real Airtable field.
-    for (const c of customers) addResponseAliases(c);
-
-    // Segment distribution
+    // Segment distribution (uses the alias the repo already applied)
     const segments = {};
     for (const c of customers) {
       const seg = c.Segment || 'Unassigned';
@@ -248,23 +90,19 @@ router.get('/insights', async (req, res, next) => {
       .sort((a, b) => (b['App Total Spend'] || 0) - (a['App Total Spend'] || 0))
       .slice(0, 20);
 
-    // Total revenue at risk from churning customers
     const totalRevenueAtRisk = churnRisk.reduce((sum, c) => sum + (c['App Total Spend'] || 0), 0);
 
-    // Top 10 customers by total spend
     const topCustomers = customers
       .filter(c => (c['App Total Spend'] || 0) > 0)
       .sort((a, b) => (b['App Total Spend'] || 0) - (a['App Total Spend'] || 0))
       .slice(0, 10);
 
-    // Revenue per segment — how much each segment contributes
     const segmentRevenue = {};
     for (const c of customers) {
       const seg = c.Segment || 'Unassigned';
       segmentRevenue[seg] = (segmentRevenue[seg] || 0) + (c['App Total Spend'] || 0);
     }
 
-    // Acquisition source distribution — where customers come from
     const acquisitionBySource = {};
     for (const c of customers) {
       const src = c['Communication method'] || c.Source || 'Unknown';
@@ -281,7 +119,6 @@ router.get('/insights', async (req, res, next) => {
         const sorted = [...values].sort((a, b) => a - b);
         const len = sorted.length;
         return values.map(v => {
-          // Handle edge case: all same values → everyone gets score 3
           if (sorted[0] === sorted[len - 1]) return 3;
           const rank = sorted.filter(s => s <= v).length / len;
           const score = Math.ceil(rank * 5) || 1;
@@ -289,7 +126,6 @@ router.get('/insights', async (req, res, next) => {
         });
       }
 
-      // Calculate raw values
       const recencyValues = scoredCustomers.map(c => {
         const lastDate = lastOrderByCustomer[c.id];
         return lastDate ? (now - new Date(lastDate).getTime()) / 86400000 : 999;
@@ -297,11 +133,10 @@ router.get('/insights', async (req, res, next) => {
       const frequencyValues = scoredCustomers.map(c => c['App Order Count'] || 0);
       const monetaryValues = scoredCustomers.map(c => c['App Total Spend'] || 0);
 
-      const rScores = quintileScore(recencyValues, true);  // fewer days ago = higher score
+      const rScores = quintileScore(recencyValues, true);
       const fScores = quintileScore(frequencyValues, false);
       const mScores = quintileScore(monetaryValues, false);
 
-      // Map RFM scores to human-readable labels
       function rfmLabel(r, f, m) {
         if (r >= 4 && f >= 4 && m >= 4) return 'Champions';
         if (f >= 4 || (r >= 3 && f >= 3 && m >= 3)) return 'Loyal';
@@ -330,8 +165,8 @@ router.get('/insights', async (req, res, next) => {
       rfmData = { summary: rfmSummary, revenue: rfmRevenue, byCustomer: rfmByCustomer };
     }
 
-    // Auto-compute segment based on order count (doesn't overwrite manual segments like "DO NOT CONTACT").
-    // Like an automatic quality classification gate: the label is computed from metrics, not from manual input.
+    // Auto-compute segment based on order count — read-only hint for the UI,
+    // doesn't overwrite manual segments like "DO NOT CONTACT".
     for (const c of customers) {
       const count = c['App Order Count'] || 0;
       c.computedSegment = count >= 10 ? 'Constant' : count >= 2 ? 'Rare' : count >= 1 ? 'New' : null;
@@ -352,85 +187,10 @@ router.get('/insights', async (req, res, next) => {
   }
 });
 
-// GET /api/customers/:id/orders — merged legacy + app order history for one customer.
-// Legacy orders (pre-app era, 2023-11 → 2026-03) link via the customer's Orders/Orders 2/Orders 3
-// linked-record arrays. App orders link via App Orders linked array.
-// Response is sorted date-desc and normalized to one schema the UI timeline can render directly.
+// GET /api/customers/:id/orders — merged legacy + app order history.
 router.get('/:id/orders', async (req, res, next) => {
   try {
-    const customer = await db.getById(TABLES.CUSTOMERS, req.params.id);
-
-    // Orders (list) is a formula that returns legacy-order record IDs —
-    // the authoritative linkage (auto-populated by Airtable when the owner
-    // types a matching Nickname on a legacy order).
-    const legacyIds = customer['Orders (list)'] || [];
-    const appIds = customer['App Orders'] || [];
-
-    const [legacyOrders, appOrders] = await Promise.all([
-      listByIds(TABLES.LEGACY_ORDERS, legacyIds, {
-        // 'Oder Number' is misspelled in the live base (sic). If the owner ever
-        // renames it to 'Order Number', add it here too — the normalizer below
-        // already checks both names via ||.
-        fields: [
-          'Oder Number',
-          'Flowers+Details of order',
-          'Order Reason',
-          'Order Delivery Date',
-          'Order date',
-          'Price (with Delivery)',
-        ],
-      }),
-      listByIds(TABLES.ORDERS, appIds, {
-        // Bouquet Summary / Final Price / Sell Total are computed in code, not
-        // Airtable fields in this base. Timeline shows Price Override as a
-        // lower-bound amount and description falls back to Customer Request.
-        fields: [
-          'Order Date', 'Customer Request',
-          'Price Override', 'Status', 'Order Lines',
-        ],
-      }),
-    ]);
-
-    const normalizedLegacy = legacyOrders.map(o => ({
-      id: o.id,
-      source: 'legacy',
-      // Falls back to parsing the Oder Number string when dedicated date
-      // fields are empty (common on pre-2024 records).
-      date: legacyOrderDate(o),
-      description: [
-        o['Oder Number'],
-        o['Flowers+Details of order'],
-        o['Order Reason'],
-      ].filter(Boolean).join(' — '),
-      // 0 means "price not recorded" on pre-app records — the frontend
-      // should check raw['Price (with Delivery)'] to distinguish from 0 zł.
-      amount: Number(o['Price (with Delivery)'] || 0),
-      status: null,
-      link: null,
-      lines: null,
-      raw: o,
-    }));
-
-    const normalizedApp = appOrders.map(o => ({
-      id: o.id,
-      source: 'app',
-      date: o['Order Date'] || null,
-      description: o['Customer Request'] || '',
-      amount: Number(o['Price Override'] || 0),
-      status: o.Status || null,
-      link: `/orders/${o.id}`,
-      lines: o['Order Lines'] || null,
-      raw: o,
-    }));
-
-    // Sort date-desc; null dates (data quality holes) sink to the bottom.
-    const merged = [...normalizedLegacy, ...normalizedApp].sort((a, b) => {
-      if (!a.date && !b.date) return 0;
-      if (!a.date) return 1;
-      if (!b.date) return -1;
-      return b.date.localeCompare(a.date);
-    });
-
+    const merged = await customerRepo.listOrders(req.params.id);
     res.json(merged);
   } catch (err) {
     next(err);
@@ -440,11 +200,7 @@ router.get('/:id/orders', async (req, res, next) => {
 // GET /api/customers/:id
 router.get('/:id', async (req, res, next) => {
   try {
-    const customer = await db.getById(TABLES.CUSTOMERS, req.params.id);
-    addResponseAliases(customer);
-    // Auto-compute segment from order count (read-only suggestion, not written to Airtable)
-    const count = customer['App Order Count'] || 0;
-    customer.computedSegment = count >= 10 ? 'Constant' : count >= 2 ? 'Rare' : count >= 1 ? 'New' : null;
+    const customer = await customerRepo.getById(req.params.id);
     res.json(customer);
   } catch (err) {
     next(err);
@@ -461,11 +217,7 @@ router.post('/', async (req, res, next) => {
     if (Phone && typeof Phone !== 'string') {
       return res.status(400).json({ error: 'Phone must be a string if provided.' });
     }
-
-    const remapped = remapAliasesToReal(req.body);
-    const safeFields = pickAllowed(remapped, CUSTOMERS_PATCH_ALLOWED);
-    const customer = await db.create(TABLES.CUSTOMERS, safeFields);
-    addResponseAliases(customer);
+    const customer = await customerRepo.create(req.body);
     res.status(201).json(customer);
   } catch (err) {
     next(err);
@@ -475,15 +227,14 @@ router.post('/', async (req, res, next) => {
 // PATCH /api/customers/:id
 router.patch('/:id', async (req, res, next) => {
   try {
-    const remapped = remapAliasesToReal(req.body);
-    const safeFields = pickAllowed(remapped, CUSTOMERS_PATCH_ALLOWED);
-    if (Object.keys(safeFields).length === 0) {
-      return res.status(400).json({ error: 'No valid fields to update.' });
-    }
-    const customer = await db.update(TABLES.CUSTOMERS, req.params.id, safeFields);
-    addResponseAliases(customer);
+    const customer = await customerRepo.update(req.params.id, req.body);
     res.json(customer);
   } catch (err) {
+    // The repo throws { statusCode: 400 } when no allowed fields survive.
+    // Surface that with the right HTTP status instead of a generic 500.
+    if (err.statusCode === 400) {
+      return res.status(400).json({ error: err.message });
+    }
     next(err);
   }
 });

--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -42,3 +42,4 @@ export {
   REASON_COLORS,
   reasonBadgeClass,
 } from './utils/lossReasons.js';
+export { getEffectiveStock, hasStockShortfall } from './utils/stockMath.js';

--- a/packages/shared/test/stockMath.test.js
+++ b/packages/shared/test/stockMath.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { getEffectiveStock, hasStockShortfall } from '../utils/stockMath.js';
+
+describe('getEffectiveStock', () => {
+  it('subtracts committed when qty is positive', () => {
+    expect(getEffectiveStock(10, 3)).toBe(7);
+  });
+
+  it('returns qty unchanged when qty is already negative (NO double count)', () => {
+    // Regression for the 2026-04-22 bug: stock was -2 and committed was 2
+    // from the same order → old code showed -4 (double-counted).
+    expect(getEffectiveStock(-2, 2)).toBe(-2);
+    expect(getEffectiveStock(-11, 11)).toBe(-11);
+  });
+
+  it('returns 0 when qty is 0 with no committed', () => {
+    expect(getEffectiveStock(0, 0)).toBe(0);
+  });
+
+  it('returns negative committed when qty is 0 with pending orders', () => {
+    // qty=0 is not yet negative, so the pending orders ARE additional demand.
+    expect(getEffectiveStock(0, 5)).toBe(-5);
+  });
+
+  it('coerces non-numeric input safely', () => {
+    expect(getEffectiveStock(null, null)).toBe(0);
+    expect(getEffectiveStock(undefined, undefined)).toBe(0);
+    expect(getEffectiveStock('10', '3')).toBe(7);
+  });
+
+  it('treats negative committed as zero (defensive)', () => {
+    expect(getEffectiveStock(10, -5)).toBe(10);
+  });
+});
+
+describe('hasStockShortfall', () => {
+  it('flags true when stock is already negative', () => {
+    expect(hasStockShortfall(-1, 0)).toBe(true);
+    expect(hasStockShortfall(-1, 5)).toBe(true);
+  });
+
+  it('flags true when pending orders exceed available positive stock', () => {
+    expect(hasStockShortfall(5, 10)).toBe(true);
+  });
+
+  it('flags false when stock covers pending orders', () => {
+    expect(hasStockShortfall(10, 5)).toBe(false);
+    expect(hasStockShortfall(10, 10)).toBe(false);
+  });
+
+  it('flags false when no committed and positive stock', () => {
+    expect(hasStockShortfall(10, 0)).toBe(false);
+    expect(hasStockShortfall(0, 0)).toBe(false);
+  });
+});

--- a/packages/shared/utils/stockMath.js
+++ b/packages/shared/utils/stockMath.js
@@ -1,0 +1,51 @@
+// Stock math — the single source of truth for how Current Quantity and
+// Committed combine. Exists because the two numbers measure overlapping
+// events and naive subtraction produces a double-count bug (see
+// "Known Pitfalls" in root CLAUDE.md, entry #7).
+//
+// Background:
+//   - Current Quantity on a Stock record is decremented IMMEDIATELY when an
+//     order is created (in orderService.js via atomicStockAdjust). So if
+//     stock was 0 and an order for 2 stems comes in, Current Quantity = -2.
+//   - GET /api/stock/committed sums all non-terminal future-dated order
+//     lines grouped by Stock Item — it does NOT care whether those lines
+//     have already been deducted. It's a raw demand signal.
+//   - These two are therefore in OVERLAPPING measurement frames. If you do
+//     `qty - committed` when qty is already negative, you count the same
+//     order twice (−2 − 2 = −4 when the true shortfall is just −2).
+//
+// Rule used below (matches the 2026-04-16 dashboard fix, commit 9e7b470):
+//   - qty >= 0: `committed` represents real pending deductions; subtract.
+//               Result is "what's still available after pending orders".
+//   - qty <  0: the negative ALREADY reflects all current deductions; the
+//               committed number is redundant for this flower. Return qty.
+//
+// If you ever need "future shortfall beyond current negatives", that is a
+// different calculation and should NOT be derived via subtraction here.
+
+/**
+ * Compute effective stock after accounting for committed (pending) orders.
+ * Do NOT inline `qty - committed` anywhere — always call this helper.
+ *
+ * @param {number} qty        Current Quantity from the Stock record
+ * @param {number} committed  Sum of pending-order demand for this stock item
+ * @returns {number} effective stock (may be negative if orders exceed supply)
+ */
+export function getEffectiveStock(qty, committed) {
+  const q = Number(qty) || 0;
+  const c = Math.max(0, Number(committed) || 0);
+  if (q >= 0) return q - c;
+  return q;
+}
+
+/**
+ * True when there IS a shortfall the owner needs to act on.
+ * - committed > 0 AND effective < 0 → someone's waiting on stems we don't have
+ * - qty < 0                         → we're already short (negative = IOU)
+ */
+export function hasStockShortfall(qty, committed) {
+  const q = Number(qty) || 0;
+  const c = Math.max(0, Number(committed) || 0);
+  if (q < 0) return true;
+  return c > 0 && q - c < 0;
+}


### PR DESCRIPTION
## Summary
\`Current Quantity\` decrements immediately on order create. \`/stock/committed\` separately sums pending-order demand. Same order is in BOTH numbers. StockItem's \`effective = qty - committed\` was double-counting → Hydrangea Pink at -2 with committed 2 showed \"-4\".

The 2026-04-16 commit 9e7b470 fixed this on the dashboard but not on the florist StockItem.

## Fix

**New shared helper** \`packages/shared/utils/stockMath.js\`:
\`\`\`js
getEffectiveStock(qty, committed)    // qty >= 0 → qty - committed; qty < 0 → qty
hasStockShortfall(qty, committed)    // any time we owe stems
\`\`\`

**Updated** \`apps/florist/src/components/StockItem.jsx\` to use the helper. No more inline \`qty - committed\`.

**10 Vitest cases** covering positive / negative / zero qty, mixed input, defensive coercion.

**Root CLAUDE.md** gains \"Known Pitfalls\" entry #7 documenting the two-measurement-frame conflict and mandating the helper.

## Test plan
- [x] All 61 shared tests pass (45 existing + 16 new — 10 stockMath, others from earlier PRs)
- [ ] Hydrangea Pink at -2 with 1 order for 2 stems: now shows Effective = -2 (was -4)
- [ ] Peony Pink at -11 with 1 order for 11 stems: now shows Effective = -11 (was -22)
- [ ] Positive stock still shows \`qty - committed\` normally (e.g. 10 available, 3 pending → effective 7)

## Prevention going forward
1. **Inline \`qty - committed\` banned** — always use \`getEffectiveStock()\`
2. **Cross-app parity rule** extended: stock math changes must hit both dashboard and florist
3. **Helper has tests** — regression on the formula is caught at CI

## Follow-ups (not in this PR)
- The \"Trace\" view for Hydrangea Pink also shows inconsistent history — sum of events was +7 but stock is -2. That's a **separate** bug, likely wrong batch aggregation or stale Current Quantity. Needs its own investigation.
- Consider filtering \`/stock/committed\` server-side to only include deferred (not-yet-deducted) orders, which would make \"committed\" a clean future-demand signal. Deferred to future refactor.
- Periodic reconciliation script (weekly): walk Purchase + Order + StockLoss tables, compute expected Current Quantity, flag mismatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)