### PR TITLE
feat(florist): phase A cleanup — nav trim, Wix Pull/Push, stock ops grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,72 @@ AIRTABLE_PREMADE_BOUQUET_LINES_TABLE=tbl...  # Premade Bouquet Lines table ID
 
 ---
 
+## 2026-04-22 — Florist app cleanup (Phase A): nav trim + Shopping→Stock + Wix tab polish
+
+Owner feedback made clear the florist app had accumulated UX debt: Catalog
+tab didn't match its Wix content, Pull/Push sync wasn't discoverable
+(single ambiguous refresh icon), Stock-adjacent workflows were scattered
+across bottom nav + burger + inline buttons, and the burger had dead
+entries. First PR of a three-part cleanup.
+
+### Navigation
+- **`components/BottomNav.jsx`** — Owner bottom nav trimmed from 5 to 4
+  tabs (Shopping removed; folded into Stock page). Burger menu dropped
+  Day Summary (unused), Purchase Orders + Waste Log (reachable from Stock
+  now). Florist burger dropped Waste Log (same reason). The narrow-viewport
+  collapse logic was removed since both roles now fit 4 tabs comfortably;
+  Phase B will reintroduce it when the Customers tab becomes the 5th.
+
+### Wix tab (was "Catalog")
+- **`translations.js`** — `tabCatalog` renamed "Catalog"→"Wix" (EN) /
+  "Каталог"→"Wix" (RU). Route `/catalog/bouquets` unchanged.
+- **`pages/BouquetsPage.jsx`** — the single `RefreshCw` icon in the
+  header is replaced by two explicit labeled buttons: blue
+  `⬇ Pull` (bg-blue-50) and emerald `⬆ Push` (bg-emerald-50). Both
+  always visible, backed by the existing `POST /products/pull` and
+  `POST /products/push` endpoints — no backend changes.
+- **`components/bouquets/PushBar.jsx`** — converted from a prominent
+  brand-colored CTA button to a passive `role="status"` banner. Push is
+  now one trigger (the header button); PushBar is a pure "N changes
+  pending" indicator when scrolled. Still shows a "Syncing…" spinner
+  while a push is in flight.
+- **Translations** — new short keys `pullShort` ("Pull"/"Загрузить") and
+  `pushShort` ("Push"/"Отправить") for the header buttons — the full
+  "Pull from Wix" / "Отправить в Wix" strings were too long to fit
+  alongside the title on narrow phones.
+
+### Stock page
+- **`pages/StockPanelPage.jsx`** — the three stacked full-width buttons
+  (Purchase Orders, Waste Log, Receive Stock) are replaced for the owner
+  with a compact 2×2 Operations tile grid: Purchase Orders · Active
+  Shopping · Stock Evaluation · Waste Log. A new inline `OpsTile`
+  sub-component renders each tile (icon-over-label, 80px tall, rounded
+  2xl). Florist still sees only the red Waste Log button (PO + Shopping
+  are owner-only flows).
+
+### Why it matters
+- **Discoverability.** The old refresh icon on the Wix tab gave no signal
+  that sync was bidirectional. With two labeled buttons, the mental model
+  "I can push changes to Wix from here" forms immediately.
+- **Fewer buttons, more breathing room.** Stock page went from 3 stacked
+  CTAs to a tidy 2×2 grid (same footprint, less visual noise).
+- **Silent misconfigs now surface.** A missing `WIX_API_KEY` on Railway
+  used to hide behind the ambiguous refresh icon — next pull/push tap
+  now shows the backend error as a toast.
+
+### What to watch for
+- `/shopping-support` and `/day-summary` routes stay live (nothing
+  deleted) — direct URL access still works even though the nav entries
+  are gone. If owner confirms Day Summary truly isn't used, the page can
+  be deleted in a follow-up.
+- `runPush()` is idempotent — tapping Push on a clean catalog is a
+  no-op on the Wix side. No confirmation dialog needed.
+- Phase B (next PR) wires a new **Customers** tab into the 4th owner
+  nav slot and adds it to the florist burger; Phase C wires
+  order-card customer names to navigate there.
+
+---
+
 ## 2026-04-21 — Owner can hard-delete orders (dashboard + florist app)
 
 The owner now has a hard-delete action separate from Cancel. Cancel

--- a/apps/florist/src/components/BottomNav.jsx
+++ b/apps/florist/src/components/BottomNav.jsx
@@ -1,45 +1,27 @@
 // BottomNav — fixed tab bar at the bottom of every authenticated screen.
-// Owner sees 5 tabs (Orders · Stock · Catalog · Shopping · More); florists see
-// 4 (Orders · Stock · Hours · More). On very narrow viewports (< 360 px) the
-// owner's Shopping tab collapses into More so we always keep 4 primary tabs
-// within comfortable touch reach.
+// Owner sees 4 tabs (Orders · Stock · Wix · More); florists see 4 too
+// (Orders · Stock · Hours · More). Shopping was folded into the Stock tab
+// Operations row in 2026-04. Phase B will add a Customers tab in the 4th slot
+// for the owner; florist picks up Customers via the More burger menu.
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
   ClipboardList,
   Package,
   Flower2,
-  ShoppingCart,
   Clock,
   Menu as MenuIcon,
   Sun,
   Moon,
   RefreshCw,
   LogOut,
-  BarChart3,
   ClipboardCheck,
-  Trash2,
   HelpCircle,
-  Truck,
 } from 'lucide-react';
 import { useAuth } from '../context/AuthContext.jsx';
 import { useTheme } from '../context/ThemeContext.jsx';
 import t from '../translations.js';
-
-// Track current viewport width so the owner's Shopping tab can gracefully
-// fall into the More menu on iPhone SE 1st-gen (320 px) style devices.
-function useNarrowViewport(threshold = 360) {
-  const [narrow, setNarrow] = useState(() =>
-    typeof window !== 'undefined' ? window.innerWidth < threshold : false
-  );
-  useEffect(() => {
-    function onResize() { setNarrow(window.innerWidth < threshold); }
-    window.addEventListener('resize', onResize);
-    return () => window.removeEventListener('resize', onResize);
-  }, [threshold]);
-  return narrow;
-}
 
 export default function BottomNav() {
   const navigate = useNavigate();
@@ -48,29 +30,23 @@ export default function BottomNav() {
   const { dark, toggle: toggleDark } = useTheme();
   const [moreOpen, setMoreOpen] = useState(false);
   const isOwner = role === 'owner';
-  const narrow = useNarrowViewport(360);
 
-  // Primary tabs depend on role (and, for the owner on very narrow devices,
-  // on viewport width — Shopping moves into More when the bar would be cramped).
-  let tabs;
-  if (isOwner) {
-    const ownerTabs = [
-      { key: 'orders',   Icon: ClipboardList, label: t.tabOrders,   path: '/orders' },
-      { key: 'stock',    Icon: Package,       label: t.tabStock,    path: '/stock' },
-      { key: 'catalog',  Icon: Flower2,       label: t.tabCatalog,  path: '/catalog/bouquets' },
-      { key: 'shopping', Icon: ShoppingCart,  label: t.tabShopping, path: '/shopping-support' },
-    ];
-    tabs = narrow
-      ? [...ownerTabs.slice(0, 3), { key: 'more', Icon: MenuIcon, label: t.tabMore, path: null }]
-      : [...ownerTabs, { key: 'more', Icon: MenuIcon, label: t.tabMore, path: null }];
-  } else {
-    tabs = [
-      { key: 'orders', Icon: ClipboardList, label: t.tabOrders, path: '/orders' },
-      { key: 'stock',  Icon: Package,       label: t.tabStock,  path: '/stock' },
-      { key: 'hours',  Icon: Clock,         label: t.tabHours,  path: '/hours' },
-      { key: 'more',   Icon: MenuIcon,      label: t.tabMore,   path: null },
-    ];
-  }
+  // Primary tabs depend on role. After 2026-04 cleanup, both roles show
+  // exactly 4 tabs — no narrow-viewport collapse needed. Phase B will add
+  // a 5th tab (Customers) for the owner and reintroduce the narrow logic.
+  const tabs = isOwner
+    ? [
+        { key: 'orders',  Icon: ClipboardList, label: t.tabOrders,  path: '/orders' },
+        { key: 'stock',   Icon: Package,       label: t.tabStock,   path: '/stock' },
+        { key: 'catalog', Icon: Flower2,       label: t.tabCatalog, path: '/catalog/bouquets' },
+        { key: 'more',    Icon: MenuIcon,      label: t.tabMore,    path: null },
+      ]
+    : [
+        { key: 'orders', Icon: ClipboardList, label: t.tabOrders, path: '/orders' },
+        { key: 'stock',  Icon: Package,       label: t.tabStock,  path: '/stock' },
+        { key: 'hours',  Icon: Clock,         label: t.tabHours,  path: '/hours' },
+        { key: 'more',   Icon: MenuIcon,      label: t.tabMore,   path: null },
+      ];
 
   function isActive(tab) {
     if (!tab.path) return false;
@@ -100,26 +76,22 @@ export default function BottomNav() {
     window.location.href = window.location.pathname + '?_cb=' + Date.now();
   }
 
-  // More menu — owner gets all florist actions plus owner-only ones.
-  // Waste Log is accessible to both roles (backend allows florist CRUD too).
+  // More menu — trimmed in 2026-04 per owner feedback. Waste Log, Purchase
+  // Orders and Day Summary were removed from here because Waste Log + PO are
+  // reachable from the Stock tab's Operations tile row, and Day Summary wasn't
+  // being used. Stock Evaluation stays as the one remaining stock-adjacent
+  // entry that doesn't yet have an Operations tile (owner + florist both use it).
   const baseItems = [
-    { Icon: Trash2,         label: t.wasteLog,        action: () => navigate('/stock/waste') },
     { Icon: ClipboardCheck, label: t.stockEvaluation, action: () => navigate('/stock-evaluation') },
   ];
   const ownerOnlyItems = [
-    { Icon: BarChart3, label: t.daySummary,   action: () => navigate('/day-summary') },
-    { Icon: Clock,     label: t.floristHours, action: () => navigate('/hours') },
-    { Icon: Truck,     label: t.purchaseOrders || 'Закупки', action: () => navigate('/purchase-orders') },
+    { Icon: Clock, label: t.floristHours, action: () => navigate('/hours') },
   ];
-  const shoppingWhenNarrow = (isOwner && narrow)
-    ? [{ Icon: ShoppingCart, label: t.tabShopping, action: () => navigate('/shopping-support') }]
-    : [];
   const helpItem = isOwner
     ? [{ Icon: HelpCircle, label: t.help || 'Help', action: () => navigate('/orders') }]
     : [];
 
   const moreItems = [
-    ...shoppingWhenNarrow,
     ...(isOwner ? ownerOnlyItems : []),
     ...baseItems,
     ...helpItem,

--- a/apps/florist/src/components/bouquets/PushBar.jsx
+++ b/apps/florist/src/components/bouquets/PushBar.jsx
@@ -1,31 +1,35 @@
-import { Upload, Loader2 } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import t from '../../translations.js';
 
-// Sticky bar that appears when there are pending changes to push to Wix.
-// Manual-only by owner's choice (no auto-debounce) — one deliberate tap
-// synchronizes everything.
+// Passive "you have N unsaved changes" banner at the bottom of the bouquets page.
+// Renders only when count > 0. Not a button — the actual Push trigger lives in
+// the page header next to Pull (see BouquetsPage.jsx). This banner exists so a
+// scrolled-down owner still sees the pending-change indicator without scrolling
+// back up.
 
-export default function PushBar({ count, pushing, onPush }) {
+export default function PushBar({ count, pushing }) {
   if (count === 0) return null;
   const label = count === 1 ? t.changeQueued : t.changesQueued;
 
   return (
     <div className="fixed bottom-16 left-0 right-0 z-30 px-3 pb-2 pointer-events-none safe-area-bottom">
-      <button
-        onClick={onPush}
-        disabled={pushing}
-        className="pointer-events-auto w-full h-14 rounded-2xl bg-brand-600 text-white shadow-lg
-                   flex items-center justify-between px-5 active:bg-brand-700 active-scale
-                   disabled:opacity-70"
+      <div
+        role="status"
+        aria-live="polite"
+        className="w-full h-11 rounded-2xl bg-ios-fill2 dark:bg-dark-elevated
+                   border border-gray-200 dark:border-dark-separator shadow-sm
+                   flex items-center justify-between px-4"
       >
-        <span className="text-sm font-semibold tabular-nums">
+        <span className="text-sm font-semibold tabular-nums text-ios-label dark:text-dark-label">
           {count} {label}
         </span>
-        <span className="inline-flex items-center gap-2 text-sm font-semibold">
-          {pushing ? <Loader2 size={18} className="animate-spin" /> : <Upload size={18} />}
-          {pushing ? t.pushing : t.pushToWix}
-        </span>
-      </button>
+        {pushing && (
+          <span className="inline-flex items-center gap-2 text-sm text-ios-secondary">
+            <Loader2 size={16} className="animate-spin" />
+            {t.pushing}
+          </span>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/florist/src/pages/BouquetsPage.jsx
+++ b/apps/florist/src/pages/BouquetsPage.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, Search, X, Flower2, RefreshCw, Loader2 } from 'lucide-react';
+import { ArrowLeft, Search, X, Flower2, Download, Upload, Loader2 } from 'lucide-react';
 import {
   IconButton,
   EmptyState,
@@ -166,14 +166,30 @@ export default function BouquetsPage() {
         <h1 className="text-base font-semibold text-ios-label dark:text-dark-label flex-1">
           {t.bouquetsTitle}
         </h1>
-        <IconButton
+        {/* Explicit Pull + Push buttons so both sync directions are discoverable.
+            Replaces the old generic RefreshCw icon that looked like a page refresh. */}
+        <button
+          type="button"
           onClick={pullFromWix}
           disabled={pulling || pushing}
-          ariaLabel={t.pullFromWix || 'Pull from Wix'}
-          variant="tinted"
+          aria-label={t.pullFromWix}
+          className="flex items-center gap-1 px-2.5 h-9 rounded-xl bg-blue-50 dark:bg-blue-900/20
+                     text-ios-blue text-sm font-semibold active-scale disabled:opacity-50"
         >
-          {pulling ? <Loader2 size={20} className="animate-spin" /> : <RefreshCw size={20} />}
-        </IconButton>
+          {pulling ? <Loader2 size={16} className="animate-spin" /> : <Download size={16} />}
+          <span>{t.pullShort}</span>
+        </button>
+        <button
+          type="button"
+          onClick={pushToWix}
+          disabled={pulling || pushing}
+          aria-label={t.pushToWix}
+          className="flex items-center gap-1 px-2.5 h-9 rounded-xl bg-emerald-50 dark:bg-emerald-900/20
+                     text-emerald-700 dark:text-emerald-400 text-sm font-semibold active-scale disabled:opacity-50"
+        >
+          {pushing ? <Loader2 size={16} className="animate-spin" /> : <Upload size={16} />}
+          <span>{t.pushShort}</span>
+        </button>
       </header>
 
       <div className="container-mobile py-3">
@@ -234,7 +250,7 @@ export default function BouquetsPage() {
         ))}
       </div>
 
-      <PushBar count={dirtyIds.size} pushing={pushing} onPush={pushToWix} />
+      <PushBar count={dirtyIds.size} pushing={pushing} />
     </div>
   );
 }

--- a/apps/florist/src/pages/StockPanelPage.jsx
+++ b/apps/florist/src/pages/StockPanelPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { Truck, ShoppingCart, ClipboardCheck, Trash2 } from 'lucide-react';
 import { useDebouncedValue } from '@flower-studio/shared';
 import client from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
@@ -201,25 +202,29 @@ export default function StockPanelPage() {
 
       <main className="max-w-2xl mx-auto px-4 py-5 pb-28">
 
-        {/* Owner: Purchase Orders button */}
-        {role === 'owner' && (
+        {/* Owner operations — a compact 2×2 tile grid replaces the stacked
+            Purchase Orders + Waste Log buttons from before. Moved here in 2026-04
+            to consolidate every stock-adjacent workflow under the Stock tab
+            (Shopping was its own bottom-nav tab before; Purchase Orders and
+            Waste Log were in the burger menu). */}
+        {role === 'owner' ? (
+          <div className="grid grid-cols-2 gap-2 mb-3">
+            <OpsTile Icon={Truck}          label={t.po?.title || 'Purchase Orders'} onClick={() => navigate('/purchase-orders')} />
+            <OpsTile Icon={ShoppingCart}   label={t.tabShopping}                    onClick={() => navigate('/shopping-support')} />
+            <OpsTile Icon={ClipboardCheck} label={t.stockEvaluation}                onClick={() => navigate('/stock-evaluation')} />
+            <OpsTile Icon={Trash2}         label={t.wasteLog}                       onClick={() => navigate('/stock/waste')} variant="muted" />
+          </div>
+        ) : (
+          /* Florist: only Waste Log — stock-adjacent ops like POs and Shopping
+             are owner-only workflows. */
           <button
-            onClick={() => navigate('/purchase-orders')}
-            className="w-full mb-3 h-12 rounded-2xl bg-indigo-600 text-white text-base font-semibold shadow-sm active:bg-indigo-700 active-scale"
+            onClick={() => navigate('/stock/waste')}
+            className="w-full mb-3 h-11 rounded-2xl bg-red-50 dark:bg-red-900/20 text-ios-red
+                       text-sm font-semibold active:bg-red-100 active-scale flex items-center justify-center gap-2"
           >
-            {t.po?.title || 'Purchase Orders'}
+            <Trash2 size={16} /> {t.wasteLog}
           </button>
         )}
-
-        {/* Waste log shortcut — both roles. Keeps the log one tap away from the
-            inventory screen where dead stems usually get noticed. */}
-        <button
-          onClick={() => navigate('/stock/waste')}
-          className="w-full mb-3 h-11 rounded-2xl bg-red-50 dark:bg-red-900/20 text-ios-red
-                     text-sm font-semibold active:bg-red-100 active-scale flex items-center justify-center gap-2"
-        >
-          🗑 {t.wasteLog}
-        </button>
 
         {/* Pending arrivals — PO overview */}
         <PendingArrivalsSection
@@ -365,5 +370,28 @@ export default function StockPanelPage() {
 
       {showHelp && <HelpPanel onClose={() => setShowHelp(false)} />}
     </div>
+  );
+}
+
+// Compact operations tile used in the owner's 2×2 grid at the top of the
+// Stock page. Icon over label, 80 px tall, rounded-2xl. The "muted" variant
+// uses the red palette for destructive-ish actions (Waste Log) so it reads
+// as the "exception" tile in the grid.
+function OpsTile({ Icon, label, onClick, variant = 'default' }) {
+  const palette = variant === 'muted'
+    ? 'bg-red-50 dark:bg-red-900/20 text-ios-red'
+    : 'bg-brand-50 dark:bg-brand-900/20 text-brand-700 dark:text-brand-300';
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`h-20 rounded-2xl flex flex-col items-center justify-center gap-1
+                  active-scale ${palette}`}
+    >
+      <Icon size={22} />
+      <span className="text-[12px] font-semibold text-center px-2 leading-tight line-clamp-2">
+        {label}
+      </span>
+    </button>
   );
 }

--- a/apps/florist/src/translations.js
+++ b/apps/florist/src/translations.js
@@ -551,7 +551,7 @@ const en = {
   orderDeleted:                 'Order deleted',
 
   // ── Catalog / Bouquets (2026-04) ──
-  tabCatalog:            'Catalog',
+  tabCatalog:            'Wix',
   bouquetsTitle:         'Bouquets',
   bouquetsCount:         'bouquets',
   bouquetsActive:        'active',
@@ -569,6 +569,8 @@ const en = {
   bouquetMix:            'mix',
   pushToWix:             'Push to Wix',
   pullFromWix:           'Pull from Wix',
+  pullShort:             'Pull',
+  pushShort:             'Push',
   pullSuccess:           'Updated from Wix',
   pullFailed:            'Pull from Wix failed',
   pushing:               'Syncing…',
@@ -1159,7 +1161,7 @@ const ru = {
   orderDeleted:                 'Заказ удалён',
 
   // ── Catalog / Bouquets (2026-04) ──
-  tabCatalog:            'Каталог',
+  tabCatalog:            'Wix',
   bouquetsTitle:         'Букеты',
   bouquetsCount:         'букетов',
   bouquetsActive:        'активных',
@@ -1177,6 +1179,8 @@ const ru = {
   bouquetMix:            'микс',
   pushToWix:             'Отправить в Wix',
   pullFromWix:           'Загрузить из Wix',
+  pullShort:             'Загрузить',
+  pushShort:             'Отправить',
   pullSuccess:           'Обновлено из Wix',
   pullFailed:            'Не удалось загрузить из Wix',
   pushing:               'Синхронизация…',


### PR DESCRIPTION
## Summary

First of **three PRs** from the 2026-04-22 florist app cleanup plan. Tackles the owner's discoverability and clutter feedback after PR #117.

- **Wix tab** (was Catalog): label rename + single ambiguous `RefreshCw` icon replaced with two labeled buttons — blue **⬇ Pull** + emerald **⬆ Push**, both always visible. `PushBar` converted to a passive "N changes pending" banner. Zero backend changes (`/products/pull` and `/products/push` already exist).
- **Bottom nav**: Shopping tab removed from owner nav (folded into Stock page Operations row). Burger menu dropped Day Summary, Purchase Orders, and Waste Log — all reachable from Stock or unused.
- **Stock page**: owner gets a 2×2 Operations tile grid (Purchase Orders · Shopping · Stock Evaluation · Waste Log) replacing 3 stacked full-width buttons. Florist still sees only the red Waste Log button (PO/Shopping are owner-only flows).
- **Translations**: new `pullShort` / `pushShort` keys (EN + RU) — the full "Pull from Wix" strings didn't fit in the header on narrow phones.

Routes `/shopping-support` and `/day-summary` stay live — direct URL still works. CHANGELOG entry under 2026-04-22.

## Files changed
- `apps/florist/src/components/BottomNav.jsx` — 4-tab structure both roles, burger trimmed, narrow-viewport logic removed (Phase B will restore)
- `apps/florist/src/pages/BouquetsPage.jsx` — two header buttons replace one icon
- `apps/florist/src/components/bouquets/PushBar.jsx` — passive banner, no button
- `apps/florist/src/pages/StockPanelPage.jsx` — `OpsTile` sub-component + owner 2×2 grid
- `apps/florist/src/translations.js` — label rename + short-label keys
- `CHANGELOG.md` — 2026-04-22 entry

Net +186 / -96 LOC across 6 files.

## Test plan

- [ ] Log in as **owner** on florist app. Bottom nav reads Orders · Stock · **Wix** · More (no Shopping).
- [ ] Open Wix tab. Header shows two distinct labeled buttons: blue **⬇ Pull** and emerald **⬆ Push**.
- [ ] Tap **Pull** — toast reports new/updated/deactivated counts from `POST /products/pull`.
- [ ] Tap **Push** on a clean catalog — toast reports success (idempotent no-op on Wix).
- [ ] Toggle one bouquet variant active → `PushBar` shows "1 change pending" (passive banner, no tap action). Tap header **Push** — banner clears.
- [ ] Open More burger. No Day Summary / Purchase Orders / Waste Log entries. Florist Hours + Stock Evaluation + Help present.
- [ ] Open Stock page. Top shows 2×2 tile grid (Purchase Orders, Shopping, Stock Evaluation, Waste Log). Tap each — lands on the right page.
- [ ] Log in as **florist**. Bottom nav: Orders · Stock · Hours · More. Burger: Stock Evaluation only. Stock page shows red Waste Log button (no ops grid).
- [ ] Direct-nav to `/shopping-support` still works. Direct-nav to `/day-summary` still works.

## Follow-ups (Phase B + C)

- **Phase B**: Customers tab in florist app (mobile port of dashboard Customer Tab v2.0). View-only for florists.
- **Phase C**: order-card customer name → deep-link to Customers tab (parity with dashboard).

Plan file: `C:\Users\owcza\.claude\plans\but-the-legacy-orders-fancy-gadget.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)