### PR TITLE
fix(wix-sync): surface stats.errors in Pull/Push toasts (florist + da…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,40 @@ entries. First PR of a three-part cleanup.
   nav slot and adds it to the florist burger; Phase C wires
   order-card customer names to navigate there.
 
+### Bug surfaced — silent Wix sync failures now visible
+
+When the explicit Pull/Push buttons went live, the owner hit a
+pre-existing silent-failure bug: Wix sync would report "completed"
+but nothing would actually sync to Wix. Root cause was in
+`backend/src/services/wixProductSync.js` — both `runPull()` (lines
+727–730) and `runPush()` (lines 1039–1042) wrap their entire bodies
+in try/catch blocks that push fatal errors into `stats.errors` and
+still return HTTP 200. The frontend never inspected `data.errors`,
+so a failed sync (expired token, Wix API error, network issue)
+looked identical to a clean no-op success toast.
+
+**Frontend fix** (both apps, maintains parity per CLAUDE.md):
+- `apps/florist/src/pages/BouquetsPage.jsx` — `pullFromWix` and
+  `pushToWix` now check `data.errors` before showing success. If
+  errors present, show them joined with ` · ` as a red error toast.
+- `apps/dashboard/src/components/ProductsTab.jsx` — `handlePull` and
+  `handlePush` same check. Previously `handlePush` showed a count
+  like "3 errors" with no explanation; now shows the actual error
+  messages so the owner can diagnose (token expired, Wix API 429, etc.).
+
+**Follow-up** (not in this PR): the backend should return HTTP 500
+when `stats.errors.length > 0`. That's the proper contract — would
+catch the issue in the frontend's existing `catch` block without
+needing a defensive check — but changes endpoint behaviour for all
+callers. Deferred to a separate ticket.
+
+**Why this matters**: the old `RefreshCw` icon only ran Pull and
+rarely got tapped on a failing setup, so the silent failure sat
+hidden. Phase A's explicit buttons invited the owner to actually use
+sync, and the cracks showed. Fix is mechanical — surface the error
+array the backend was already collecting, stop pretending it was a
+success.
+
 ---
 
 ## 2026-04-21 — Owner can hard-delete orders (dashboard + florist app)

--- a/apps/dashboard/src/components/ProductsTab.jsx
+++ b/apps/dashboard/src/components/ProductsTab.jsx
@@ -94,6 +94,15 @@ export default function ProductsTab() {
     try {
       const res = await client.post('/products/pull');
       const s = res.data;
+      // Defensive: runPull() in wixProductSync.js wraps its entire body in a
+      // try/catch that pushes fatal errors into stats.errors and STILL returns
+      // 200. Without this check a failed Wix API call (bad token, network
+      // error) looks like a no-op success with zero counts. Surface the actual
+      // errors so they can be diagnosed.
+      if (s.errors?.length > 0) {
+        showToast(s.errors.join(' · '), 'error');
+        return;
+      }
       showToast(`${t.prodPullDone}: ${s.new} ${t.prodNew}, ${s.updated} ${t.prodUpdated}`, 'success');
       fetchProducts();
     } catch {
@@ -108,16 +117,22 @@ export default function ProductsTab() {
     try {
       const res = await client.post('/products/push');
       const s = res.data;
+      // Same silent-catch pattern as handlePull — surface actual errors
+      // instead of just a count, which didn't help the owner diagnose
+      // what's broken (was showing "3 errors" with no explanation).
+      if (s.errors?.length > 0) {
+        showToast(s.errors.join(' · '), 'error');
+        fetchProducts();
+        return;
+      }
       const parts = [];
       if (s.pricesSynced) parts.push(`${s.pricesSynced} ${t.prodPriceSyncs}`);
       if (s.visibilitySynced) parts.push(`${s.visibilitySynced} ${t.prodVisibility}`);
       if (s.stockSynced) parts.push(`${s.stockSynced} ${t.prodStockSyncs}`);
       if (s.categoriesSynced) parts.push(`${s.categoriesSynced} ${t.prodCategorySyncs}`);
-      const errCount = s.errors?.length || 0;
-      if (errCount) parts.push(`${errCount} ${t.prodErrors || 'errors'}`);
       showToast(
         `${t.prodPushDone}${parts.length ? ': ' + parts.join(', ') : ''}`,
-        errCount ? 'warning' : 'success'
+        'success'
       );
       fetchProducts();
     } catch {

--- a/apps/florist/src/pages/BouquetsPage.jsx
+++ b/apps/florist/src/pages/BouquetsPage.jsx
@@ -114,6 +114,16 @@ export default function BouquetsPage() {
       // Backend returns the stats object directly (no wrapping).
       // Pull shape: { new, updated, deactivated, errors }
       const { data } = await client.post('/products/pull', {});
+      // Defensive: runPull() in wixProductSync.js wraps its entire body in a
+      // try/catch that pushes fatal errors into stats.errors and STILL returns
+      // 200. Without checking here, a failed Wix API call (bad token, expired
+      // session, network error) looks like a no-op success — the toast just
+      // says "Updated from Wix" with zero counts and the owner thinks the
+      // sync worked. Surface the actual errors so they can be diagnosed.
+      if (data?.errors?.length > 0) {
+        showToast(data.errors.join(' · '), 'error');
+        return;
+      }
       const parts = [];
       if (data?.new) parts.push(`+${data.new}`);
       if (data?.updated) parts.push(`~${data.updated}`);
@@ -134,6 +144,11 @@ export default function BouquetsPage() {
     try {
       // Push shape: { pricesSynced, stockSynced, categoriesSynced, errors }
       const { data } = await client.post('/products/push', {});
+      // Same silent-catch pattern as pullFromWix — see comment there.
+      if (data?.errors?.length > 0) {
+        showToast(data.errors.join(' · '), 'error');
+        return;
+      }
       const parts = [];
       if (data?.pricesSynced) parts.push(`${data.pricesSynced} prices`);
       if (data?.stockSynced) parts.push(`${data.stockSynced} stock`);


### PR DESCRIPTION
…shboard)

Phase A's explicit Pull/Push buttons on the Wix tab made the owner try to use sync for real and immediately hit a pre-existing silent-failure pattern: the backend wraps runPull() and runPush() (wixProductSync.js lines 727–730 and 1039–1042) in try/catches that push fatal errors into stats.errors but still return HTTP 200. The frontend only read the success counts, never errors — so a failed sync with a bad token or expired session showed "Updated from Wix" with zero counts, identical to a clean no-op.

Frontend fix in both apps (parity per CLAUDE.md):
- BouquetsPage.jsx — pullFromWix and pushToWix now check data.errors before showing success. If present, show the actual messages joined with ` · ` as a red error toast (not a fake success).
- ProductsTab.jsx — handlePull and handlePush same check. handlePush previously showed a bare count like "3 errors" with warning color; now shows the actual error messages so the owner can see what's wrong (token expired, Wix 429, etc.).

Not fixed here: backend should return HTTP 500 when stats.errors is non-empty — that's the proper contract. Filed as follow-up because it changes endpoint behaviour and isn't strictly needed: with the frontend check, the owner sees real error messages either way.

Builds pass (florist + dashboard). CHANGELOG 2026-04-22 entry updated with the bug explanation.