### PR TITLE
fix(wix-sync): zero-UUID variant price + Telegram alerts for sync errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,65 @@ sync, and the cracks showed. Fix is mechanical — surface the error
 array the backend was already collecting, stop pretending it was a
 success.
 
+### Zero-UUID variant price fix (simple Wix products)
+
+Once the owner saw actual error messages, a second bug surfaced:
+
+```
+Price <productId>::00000000-0000-0000-0000-000000000000:
+  requirement failed: Product variants must be managed
+```
+
+Wix represents products in two shapes: products WITH managed variants
+(size/color options, each variant has a real UUID) and simple products
+WITHOUT variants (single SKU — Wix exposes a synthetic "default variant"
+with the all-zero UUID). The `PATCH /products/{id}/variants` endpoint
+only works for the first shape. For simple products, price lives on
+the product itself and has to be PATCHed via `/products/{id}`.
+
+Inventory handling for zero-UUID variants was already fixed in commit
+`8148b45` (the `updateWixInventory` batch endpoint accepts them), but
+price had been missed — every push on a simple product generated one
+of these errors.
+
+**Fix** (`backend/src/services/wixProductSync.js`):
+- New `updateWixProductPrice(productId, price)` helper using
+  `PATCH /stores/v1/products/{id}` with `{ product: { priceData: { price } } }`.
+  Same pattern as the existing `updateWixProductContent` helper.
+- The push loop now branches: zero-UUID variant → product endpoint;
+  real UUID → variant batch endpoint.
+
+### Telegram alerts for Wix sync errors (owner-only)
+
+Added `notifyWixSyncError({ direction, errors })` to
+`backend/src/services/telegram.js`. Owner-only (uses `sendAlert`, not
+`broadcastAlert` — florists don't need these pings). Formatted as:
+
+```
+🔴 Wix sync — Push errors
+3 errors
+
+• Price <id>: Wix price update failed for ...
+• Price <id>: Wix price update failed for ...
+• Price <id>: Wix price update failed for ...
+…and 1 more
+```
+
+First 3 errors shown verbatim (truncated to 200 chars each); remainder
+summarised. HTML-escaped inside `<code>` spans so angle brackets in
+Wix payloads don't confuse Telegram's HTML parser.
+
+Wired into both `runPull()` and `runPush()` after `logSync()`. Fires
+when `stats.errors.length > 0`. No new env vars — reuses the existing
+`TELEGRAM_BOT_TOKEN` + `TELEGRAM_OWNER_CHAT_ID` that already power
+new-order alerts. If creds aren't set, `sendAlert` no-ops gracefully.
+
+**Why this matters**: sync can run without anyone watching the app
+(scheduled runs, webhook-triggered refreshes, rapid manual taps). A
+toast only helps if the owner happens to be looking at the screen.
+Telegram routes the alert to her pocket so a failing token or API
+change doesn't go unnoticed for hours.
+
 ---
 
 ## 2026-04-21 — Owner can hard-delete orders (dashboard + florist app)

--- a/backend/src/services/telegram.js
+++ b/backend/src/services/telegram.js
@@ -73,3 +73,46 @@ export async function notifyNewOrder({ source, customerName, request, deliveryTy
   ].filter(Boolean);
   await broadcastAlert(lines.join('\n'));
 }
+
+/**
+ * Owner-only alert when Wix pull/push completes with errors.
+ *
+ * Why owner-only: Wix sync is the owner's workflow — florists don't need
+ * these pings and would get noise. Uses `sendAlert` (single-chat) not
+ * `broadcastAlert`.
+ *
+ * Format: title line + error count + up to 3 truncated error messages.
+ * Full error list lives in the app toast + Railway logs — this is just
+ * a signal that something needs attention.
+ *
+ * @param direction "pull" | "push"
+ * @param errors array of error strings from stats.errors
+ */
+export async function notifyWixSyncError({ direction, errors }) {
+  if (!errors || errors.length === 0) return;
+  const dirLabel = direction === 'pull' ? 'Pull' : 'Push';
+  const shown = errors.slice(0, 3).map(e => {
+    // Truncate very long messages so the Telegram message stays readable.
+    const s = String(e);
+    return s.length > 200 ? s.slice(0, 200) + '…' : s;
+  });
+  const moreLine = errors.length > 3 ? `\n<i>…and ${errors.length - 3} more</i>` : '';
+  const lines = [
+    `🔴 <b>Wix sync — ${dirLabel} errors</b>`,
+    `${errors.length} error${errors.length === 1 ? '' : 's'}`,
+    '',
+    ...shown.map(e => `• <code>${escapeHtml(e)}</code>`),
+    moreLine,
+  ].filter(Boolean);
+  await sendAlert(lines.join('\n'));
+}
+
+// Telegram parses HTML in message bodies (parse_mode: 'HTML'), so raw
+// angle brackets in Wix error payloads would confuse the parser. Escape
+// only inside <code> blocks where the owner sees the raw error.
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}

--- a/backend/src/services/wixProductSync.js
+++ b/backend/src/services/wixProductSync.js
@@ -8,7 +8,7 @@
 
 import * as db from './airtable.js';
 import { TABLES } from '../config/airtable.js';
-import { sendAlert } from './telegram.js';
+import { sendAlert, notifyWixSyncError } from './telegram.js';
 import { getActiveSeasonalCategory, getConfig, updateConfig } from '../routes/settings.js';
 
 const WIX_API_URL = 'https://www.wixapis.com';
@@ -98,6 +98,45 @@ async function updateWixVariantPrice(productId, variantId, price) {
     const text = await res.text();
     if (isProductNotFound(res.status, text)) throw new WixProductNotFoundError(productId);
     throw new Error(`Wix price update failed for ${productId}/${variantId}: ${text}`);
+  }
+}
+
+/**
+ * Update a simple (no-variants) Wix product's price at the product level.
+ *
+ * Wix represents products in two shapes:
+ *   1. Products WITH managed variants (e.g. Small / Medium / Large) — each
+ *      variant has a real UUID and its own `priceData`. Use the batch
+ *      variants endpoint via `updateWixVariantPrice` above.
+ *   2. Products WITHOUT managed variants (simple single-SKU products) —
+ *      Wix exposes a synthetic "default variant" with ID
+ *      00000000-0000-0000-0000-000000000000 on READ, but the price lives
+ *      on the product itself. Attempting `PATCH /products/{id}/variants`
+ *      with that zero-UUID returns "requirement failed: Product variants
+ *      must be managed".
+ *
+ * This helper is the product-level endpoint for shape #2 — same URL
+ * pattern as `updateWixProductContent`, just with a `priceData` payload
+ * instead of name/description.
+ */
+async function updateWixProductPrice(productId, price) {
+  const res = await fetch(
+    `${WIX_API_URL}/stores/v1/products/${productId}`,
+    {
+      method: 'PATCH',
+      headers: wixHeaders(),
+      body: JSON.stringify({
+        product: {
+          priceData: { price },
+        },
+      }),
+    }
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    if (isProductNotFound(res.status, text)) throw new WixProductNotFoundError(productId);
+    throw new Error(`Wix product price update failed for ${productId}: ${text}`);
   }
 }
 
@@ -730,6 +769,12 @@ export async function runPull() {
   }
 
   await logSync('pull', stats);
+  // Ping the owner on Telegram if the sync collected any errors — the
+  // frontend toast is only seen when she's looking at the app; a sync
+  // run can also be triggered by automation without anyone watching.
+  if (stats.errors.length > 0) {
+    await notifyWixSyncError({ direction: 'pull', errors: stats.errors });
+  }
   return stats;
 }
 
@@ -758,13 +803,24 @@ export async function runPush() {
       }
     }
 
+    // Zero-UUID = Wix's default-variant placeholder for products without
+    // managed variants. Those need the product-level price endpoint, not
+    // the variant batch endpoint (see `updateWixProductPrice` above).
+    const ZERO_UUID = '00000000-0000-0000-0000-000000000000';
+
     for (const row of configRows) {
-      const key = `${row['Wix Product ID']}::${row['Wix Variant ID']}`;
+      const pid = row['Wix Product ID'];
+      const vid = row['Wix Variant ID'];
+      const key = `${pid}::${vid}`;
       const airtablePrice = Number(row['Price'] || 0);
       const wixPrice = wixPriceMap.get(key);
       if (wixPrice !== undefined && Math.abs(airtablePrice - wixPrice) > 0.01) {
         try {
-          await updateWixVariantPrice(row['Wix Product ID'], row['Wix Variant ID'], airtablePrice);
+          if (vid === ZERO_UUID) {
+            await updateWixProductPrice(pid, airtablePrice);
+          } else {
+            await updateWixVariantPrice(pid, vid, airtablePrice);
+          }
           stats.pricesSynced++;
         } catch (err) {
           stats.errors.push(`Price ${key}: ${err.message}`);
@@ -1042,6 +1098,9 @@ export async function runPush() {
   }
 
   await logSync('push', stats);
+  if (stats.errors.length > 0) {
+    await notifyWixSyncError({ direction: 'push', errors: stats.errors });
+  }
   return stats;
 }
 


### PR DESCRIPTION
Two follow-ups to the sync-error surfacing fix. Once the owner saw real error messages, a second bug surfaced: "requirement failed: Product variants must be managed" — our push code was calling the variant-batch endpoint for products Wix treats as simple (no managed variants). And the frontend toast only helps when she's looking at the app; scheduled or unattended runs failed silently.

**Zero-UUID variant price (wixProductSync.js)**

Wix exposes simple products with a synthetic "default variant" at the all-zero UUID. The `PATCH /products/{id}/variants` endpoint rejects that with the error above. Added `updateWixProductPrice(productId, price)` using the product-level PATCH endpoint (same pattern as the existing `updateWixProductContent`), and branched the push loop: zero- UUID → product endpoint, real UUID → variant batch endpoint. Inventory was already handled in commit 8148b45; price had been missed.

**Telegram owner alert (telegram.js)**

Added `notifyWixSyncError({ direction, errors })`. Owner-only via `sendAlert` (not broadcastAlert — florists don't need these pings). Formatted: 🔴 title + error count + up to 3 error messages truncated to 200 chars, HTML-escaped inside <code> blocks so Wix angle brackets don't break Telegram's HTML parser. Wired into runPull and runPush after logSync, fires only when stats.errors is non-empty. Reuses existing TELEGRAM_BOT_TOKEN + TELEGRAM_OWNER_CHAT_ID — no new env vars. sendAlert no-ops if creds are missing.

Why: sync runs without anyone watching (scheduled, webhook-triggered, rapid manual taps). A phone notification makes a failing token or API change noticeable within minutes instead of hours.

Backend tests: 81/82 pass; the one failure (analyticsService >
prefers Price Override) is pre-existing on master, unrelated.