### PR TITLE
feat(telegram): TELEGRAM_OWNER_CHAT_ID accepts comma-separated list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,15 @@ when `stats.errors.length > 0`. No new env vars — reuses the existing
 `TELEGRAM_BOT_TOKEN` + `TELEGRAM_OWNER_CHAT_ID` that already power
 new-order alerts. If creds aren't set, `sendAlert` no-ops gracefully.
 
+**Multi-recipient owner alerts** — `TELEGRAM_OWNER_CHAT_ID` now
+accepts a comma-separated list of chat IDs (e.g.
+`123456789,987654321`). A single value stays backward-compatible;
+the split-parse pattern mirrors the existing `TELEGRAM_CHAT_IDS`
+broadcast var. Lets the owner add a second owner-tier recipient —
+co-owner, technical helper — for Wix sync error alerts through env
+config alone, no code change required. `sendAlert` broadcasts to
+every ID in the list.
+
 **Why this matters**: sync can run without anyone watching the app
 (scheduled runs, webhook-triggered refreshes, rapid manual taps). A
 toast only helps if the owner happens to be looking at the screen.

--- a/backend/src/services/telegram.js
+++ b/backend/src/services/telegram.js
@@ -40,13 +40,24 @@ async function sendTo(token, chatId, text) {
 }
 
 /**
- * Send a text message to the owner's chat only (backwards compat).
+ * Send a text message to owner-tier chats (owner + any additional recipients
+ * who should see owner-level alerts like Wix sync errors — e.g. a co-owner,
+ * a technical helper).
+ *
+ * TELEGRAM_OWNER_CHAT_ID accepts either a single chat ID (legacy) or a
+ * comma-separated list. Single values stay backward-compatible, multi-value
+ * lets the owner add a second recipient by editing the env var alone.
+ *
+ * For team-wide broadcasts (new-order alerts that everyone sees), use
+ * `broadcastAlert` instead — it reads TELEGRAM_CHAT_IDS.
  */
 export async function sendAlert(text) {
   const token = process.env.TELEGRAM_BOT_TOKEN;
-  const chatId = process.env.TELEGRAM_OWNER_CHAT_ID;
-  if (!token || !chatId) return null;
-  await sendTo(token, chatId, text);
+  const raw = process.env.TELEGRAM_OWNER_CHAT_ID;
+  if (!token || !raw) return null;
+  const chatIds = raw.split(',').map(s => s.trim()).filter(Boolean);
+  if (chatIds.length === 0) return null;
+  await Promise.all(chatIds.map(id => sendTo(token, id, text)));
 }
 
 /**


### PR DESCRIPTION
Owner asked how to add a second recipient to the Wix sync error alerts. The existing TELEGRAM_OWNER_CHAT_ID env var only accepted a single ID, so adding a co-owner or technical helper required a code change.

Enhanced sendAlert() to split the env var on commas (same pattern as the pre-existing getChatIds() for TELEGRAM_CHAT_IDS) and fan out to every ID in the list via Promise.all. A single value stays fully backward-compatible — no one needs to update existing config.

Now the owner can add a new recipient by:
  1. New person opens the bot and sends /start (Telegram requires one-time opt-in — bots can't message strangers)
  2. Get their numeric chat ID (@userinfobot or similar)
  3. Railway: set TELEGRAM_OWNER_CHAT_ID=123456789,987654321

No new env vars, no new code paths — owner manages recipients through config alone.