### PR TITLE
fix(stock): trace uses Stock Item link, not Flower Name text

### DIFF
--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -484,35 +484,53 @@ router.get('/:id/usage', async (req, res, next) => {
     const siblingIds = new Set(siblingStocks.map(s => s.id));
     const siblingNames = siblingStocks.map(s => s['Display Name']).filter(Boolean);
 
-    // 1. Order lines — build an OR-formula that matches any of the sibling
-    //    display names (the Flower Name stamped on each line at creation).
-    //    Then keep only lines whose Stock Item link resolves to one of the
-    //    siblings, so we don't accidentally pick up unrelated records that
-    //    happen to share a name fragment.
-    const orSafeNames = siblingNames.map(n => `{Flower Name} = '${sanitizeFormulaValue(n)}'`);
-    const orderLineFormula = orSafeNames.length > 0 ? `OR(${orSafeNames.join(', ')})` : `{Flower Name} = '${safeBase}'`;
-    const orderLines = await db.list(TABLES.ORDER_LINES, {
-      filterByFormula: orderLineFormula,
-      fields: ['Order', 'Flower Name', 'Quantity', 'Sell Price Per Unit', 'Cost Price Per Unit', 'Stock Item'],
+    // 1. Order lines — walk from the Orders side.
+    //
+    // Previous implementation filtered Order Lines by `Flower Name` text
+    // matching the sibling Display Names. That's fragile: if any past order
+    // was created with a subtly different Flower Name (legacy casing, extra
+    // whitespace, a rename after the line was stamped, a flower whose stock
+    // row was since renamed/deleted), the line is invisible to the trace
+    // even though its Stock Item link DID deduct qty via atomicStockAdjust.
+    //
+    // The Stock Item link is the authoritative relationship; `Flower Name` is
+    // just a display snapshot taken at creation time. So we fetch recent
+    // orders (past year + anything with no Order Date), pull their line IDs,
+    // then JS-filter lines whose Stock Item resolves to one of the siblings.
+    //
+    // Trade-off: two round-trips (Orders, Order Lines) instead of one, and
+    // a larger result set. For a small shop (<2000 orders/year) both queries
+    // return in well under a second via the rate-limited queue.
+    const orderCutoff = new Date(Date.now() - 365 * 86400000).toISOString().split('T')[0];
+    const recentOrders = await db.list(TABLES.ORDERS, {
+      filterByFormula: `OR({Order Date} = '', NOT(IS_BEFORE({Order Date}, '${orderCutoff}')))`,
+      fields: ['Order Lines', 'App Order ID', 'Customer', 'Status', 'Required By', 'Order Date'],
+      maxRecords: 2000,
     });
-    const matchedLines = orderLines.filter(l => {
-      const linkedId = l['Stock Item']?.[0];
-      // No link → still keep if the name matched, so orphan lines are surfaced.
-      if (!linkedId) return true;
-      return siblingIds.has(linkedId);
-    });
-
-    // Fetch parent orders for context
-    const orderIds = [...new Set(matchedLines.flatMap(l => l.Order || []))];
-    const orders = orderIds.length > 0
-      ? await listByIds(TABLES.ORDERS, orderIds, {
-          fields: ['App Order ID', 'Customer', 'Status', 'Required By', 'Order Date'],
+    const allLineIds = recentOrders.flatMap(o => o['Order Lines'] || []);
+    const allLines = allLineIds.length > 0
+      ? await listByIds(TABLES.ORDER_LINES, allLineIds, {
+          fields: ['Order', 'Flower Name', 'Quantity', 'Sell Price Per Unit', 'Cost Price Per Unit', 'Stock Item'],
         })
       : [];
-    const orderMap = {};
-    for (const o of orders) orderMap[o.id] = o;
+    // Keep only lines whose Stock Item link resolves to one of our siblings.
+    // Orphan lines (no link) don't affect qty (atomicStockAdjust needs a
+    // stock ID), so dropping them is harmless.
+    const matchedLines = allLines.filter(l => siblingIds.has(l['Stock Item']?.[0]));
 
-    const customerIds = [...new Set(orders.flatMap(o => o.Customer || []))];
+    // Build the order map from the orders we already fetched — no second
+    // round-trip needed.
+    const orderMap = {};
+    for (const o of recentOrders) orderMap[o.id] = o;
+
+    // Fetch only the customers whose orders actually matched this stock —
+    // otherwise we'd pull every customer from the past year.
+    const matchedOrderIds = new Set(matchedLines.flatMap(l => l.Order || []));
+    const customerIds = [...new Set(
+      recentOrders
+        .filter(o => matchedOrderIds.has(o.id))
+        .flatMap(o => o.Customer || [])
+    )];
     const customers = customerIds.length > 0
       ? await listByIds(TABLES.CUSTOMERS, customerIds, { fields: ['Name', 'Nickname'] })
       : [];


### PR DESCRIPTION
## Summary

- Rose Spray Gizelle trace sums to +8 (Purchase +10, active Premade −2) while qty is 2 — a 6-stem gap. Active premade and purchase alone can't explain the missing deductions.
- Root cause: the trace endpoint filtered Order Lines by \`Flower Name\` text matching the sibling Display Names. Any line with drifted text (legacy casing, whitespace, a rename, a sibling that was later deleted/renamed) was invisible, even though its Stock Item link DID deduct \`qty\`.
- Fix: walk from the Orders side. Fetch recent orders (past year + empty-date), pull their Order Lines by ID, JS-filter by Stock Item link. The link is the authoritative relationship; Flower Name is just a display snapshot.

## What this PR fixes

| Before | After |
|---|---|
| Order line with correct Stock Item link but text-drifted Flower Name → not in trace | Order line appears in trace, correctly attributed to this stock row |
| Customers query pulled every customer from matched orders (worked) | Same, tightened to matched-order customers only |
| Orphan lines (no Stock Item link) included | Dropped. They can't affect qty because atomicStockAdjust needs a stock ID. |

## What this PR does NOT fix

If the 6-stem gap persists on Rose Spray Gizelle after this deploys, the remaining deductions came from:
1. **Dissolved premade bouquets** — the dissolution's reverse atomicStockAdjust leaves no record in any table. Needs a new Stock Events table (Ring 3).
2. **Manual Airtable edits** to Current Quantity. Not visible to any code.
3. **Dashboard reconcile button**. Silent write.

## Trade-offs

- **+ Two round-trips** (Orders → Order Lines) instead of one. For a shop with <2000 orders/year, both complete in well under a second via the rate-limited queue.
- **+ Larger Airtable result set**. \`maxRecords: 2000\` caps it. A >2000-order shop would need pagination — out of scope today.
- **− Orphan lines dropped.** Acceptable: they don't affect qty.

## Testing

- [x] \`node --check backend/src/routes/stock.js\` — syntax clean.
- [ ] Full backend vitest run — deferred to post-merge CI (this worktree lacks linked node_modules).
- [ ] Manual: open Rose Spray Gizelle trace after deploy, sum entries, compare to qty. If closes → confirmed text-drift theory. If still gaps → escalate to Ring 3.

## Follow-ups

- If this doesn't fully close Rose Spray Gizelle, ship **Ring 2** (weekly reconcile-stock.mjs cron with Telegram alerts) to surface remaining drift automatically.
- If gaps persist across many rows, ship **Ring 3** (unified Stock Events table) as the permanent source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)