### PR TITLE
fix(orders): florist driver picker renders for all Delivery orders

### DIFF
--- a/apps/florist/src/components/OrderCard.jsx
+++ b/apps/florist/src/components/OrderCard.jsx
@@ -170,10 +170,29 @@ function OrderCard({
   }
 
   async function patchDelivery(fields) {
-    const deliveryId = detail?.delivery?.id;
-    if (!deliveryId) return;
     setSaving(true);
     try {
+      // If no delivery record is attached yet (Airtable's back-link from
+      // Deliveries → Orders can be eventually-consistent, and some older
+      // Delivery orders were created before the explicit back-link write
+      // in orderService), create one on-the-fly. /convert-to-delivery 400s
+      // if a record exists on the server; in that case, refetch to pull
+      // the now-attached delivery before patching.
+      let deliveryId = detail?.delivery?.id;
+      if (!deliveryId) {
+        try {
+          const res = await client.post(`/orders/${order.id}/convert-to-delivery`, {});
+          deliveryId = res.data.id;
+          setDetail(prev => prev ? { ...prev, 'Delivery Type': 'Delivery', delivery: res.data } : prev);
+        } catch (convertErr) {
+          if (convertErr.response?.status === 400) {
+            const fresh = await client.get(`/orders/${order.id}`);
+            deliveryId = fresh.data.delivery?.id;
+            if (deliveryId) setDetail(fresh.data);
+          }
+          if (!deliveryId) throw convertErr;
+        }
+      }
       await client.patch(`/deliveries/${deliveryId}`, fields);
       setDetail(prev => ({
         ...prev,
@@ -1035,18 +1054,26 @@ function OrderCard({
                 </div>
               )}
 
-              {/* ── Driver assignment ── */}
-              {isDelivery && detail?.delivery && drivers.length > 0 && (
+              {/* ── Driver assignment ──
+                  Gate on `isDelivery && drivers.length` only: do NOT require
+                  `detail?.delivery` here. For fresh Delivery orders the
+                  Airtable back-link from Deliveries → Orders can take a
+                  moment to populate, and legacy orders may have been created
+                  before the explicit back-link write. The click handler
+                  below (patchDelivery) auto-creates a delivery record via
+                  /convert-to-delivery when one is missing, so the picker
+                  can work even when `detail.delivery` is undefined. */}
+              {isDelivery && drivers.length > 0 && (
                 <div>
                   <p className="text-xs font-semibold text-ios-tertiary uppercase tracking-wide mb-1">{t.assignedDriver}</p>
                   <div className="flex flex-wrap gap-1.5">
                     {drivers.map(driver => (
                       <button
                         key={driver}
-                        onClick={() => patchDelivery({ 'Assigned Driver': detail.delivery['Assigned Driver'] === driver ? '' : driver })}
+                        onClick={() => patchDelivery({ 'Assigned Driver': detail?.delivery?.['Assigned Driver'] === driver ? '' : driver })}
                         disabled={saving}
                         className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-colors active-scale disabled:opacity-40 ${
-                          detail.delivery['Assigned Driver'] === driver
+                          detail?.delivery?.['Assigned Driver'] === driver
                             ? 'bg-brand-600 text-white border-brand-600 shadow-sm'
                             : 'bg-gray-100 dark:bg-gray-700 text-ios-secondary dark:text-gray-300 border-gray-200 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600'
                         }`}
@@ -1055,7 +1082,7 @@ function OrderCard({
                       </button>
                     ))}
                   </div>
-                  {!detail.delivery['Assigned Driver'] && (
+                  {!detail?.delivery?.['Assigned Driver'] && (
                     <p className="text-xs text-ios-tertiary mt-1">{t.noDriver}</p>
                   )}
                 </div>

--- a/apps/florist/src/pages/OrderDetailPage.jsx
+++ b/apps/florist/src/pages/OrderDetailPage.jsx
@@ -209,10 +209,29 @@ export default function OrderDetailPage() {
   // Patch the linked delivery record (address, recipient, fee, driver assignment).
   // Mirrors OrderCard.patchDelivery so the full-page detail and the list card stay in sync.
   async function patchDelivery(fields) {
-    const deliveryId = order?.delivery?.id;
-    if (!deliveryId) return;
     setSaving(true);
     try {
+      // See OrderCard.patchDelivery for the full rationale: Airtable's
+      // reciprocal back-link Deliveries → Orders is eventually-consistent,
+      // so a freshly-created Delivery order may arrive here without
+      // order.delivery populated. Heal via convert-to-delivery when needed;
+      // if that 400s ("already exists"), refetch to pull the delivery that
+      // has since been linked.
+      let deliveryId = order?.delivery?.id;
+      if (!deliveryId) {
+        try {
+          const res = await client.post(`/orders/${order.id}/convert-to-delivery`, {});
+          deliveryId = res.data.id;
+          setOrder(prev => prev ? { ...prev, 'Delivery Type': 'Delivery', delivery: res.data } : prev);
+        } catch (convertErr) {
+          if (convertErr.response?.status === 400) {
+            const fresh = await client.get(`/orders/${order.id}`);
+            deliveryId = fresh.data.delivery?.id;
+            if (deliveryId) setOrder(fresh.data);
+          }
+          if (!deliveryId) throw convertErr;
+        }
+      }
       await client.patch(`/deliveries/${deliveryId}`, fields);
       setOrder(prev => prev ? { ...prev, delivery: { ...prev.delivery, ...fields } } : prev);
       showToast(t.updated || 'Updated!', 'success');
@@ -531,8 +550,12 @@ export default function OrderDetailPage() {
               </div>
             )}
 
-            {/* Driver assignment — same picker as the expanded OrderCard. */}
-            {isDelivery && order.delivery && drivers.length > 0 && (
+            {/* Driver assignment — same picker as the expanded OrderCard.
+                Gate on `isDelivery && drivers.length` only. Do NOT require
+                `order.delivery` — patchDelivery auto-heals a missing
+                delivery record via /convert-to-delivery. See OrderCard.jsx
+                for the full rationale. */}
+            {isDelivery && drivers.length > 0 && (
               <div>
                 <p className="ios-label">{t.assignedDriver}</p>
                 <div className="ios-card p-4">
@@ -541,11 +564,11 @@ export default function OrderDetailPage() {
                       <button
                         key={driver}
                         onClick={() => patchDelivery({
-                          'Assigned Driver': order.delivery['Assigned Driver'] === driver ? '' : driver,
+                          'Assigned Driver': order.delivery?.['Assigned Driver'] === driver ? '' : driver,
                         })}
                         disabled={saving}
                         className={`px-3.5 py-1.5 rounded-full text-sm font-medium border transition-colors active-scale disabled:opacity-40 ${
-                          order.delivery['Assigned Driver'] === driver
+                          order.delivery?.['Assigned Driver'] === driver
                             ? 'bg-brand-600 text-white border-brand-600 shadow-sm'
                             : 'bg-gray-100 dark:bg-gray-700 text-ios-secondary dark:text-gray-300 border-gray-200 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600'
                         }`}
@@ -554,7 +577,7 @@ export default function OrderDetailPage() {
                       </button>
                     ))}
                   </div>
-                  {!order.delivery['Assigned Driver'] && (
+                  {!order.delivery?.['Assigned Driver'] && (
                     <p className="text-xs text-ios-tertiary mt-2">{t.noDriver}</p>
                   )}
                 </div>

--- a/backend/src/services/orderService.js
+++ b/backend/src/services/orderService.js
@@ -215,6 +215,15 @@ export async function createOrder(params, config, opts = {}) {
         'Driver Payout':    getConfig('driverCostPerDelivery') || 0,
         Status:             DELIVERY_STATUS.PENDING,
       });
+      // Explicitly write the back-link on the Order row. Airtable is meant
+      // to auto-populate the reciprocal `Deliveries` field when you set
+      // `Linked Order` on the delivery side, but this has been observed to
+      // be eventually-consistent — GET /orders/:id right after creation can
+      // come back with `Deliveries: []`, which makes the florist's
+      // `detail?.delivery` gate false, which hides the driver picker. Writing
+      // the back-link explicitly guarantees it's persisted before we return.
+      await db.update(TABLES.ORDERS, order.id, { 'Deliveries': [createdDelivery.id] })
+        .catch(err => console.error('[ORDER] Back-link write failed (non-fatal, Airtable auto-sync should recover):', err.message));
     }
 
     // 5. Update customer record (non-blocking)


### PR DESCRIPTION
## Summary

Bug: creating a Delivery order in the florist mobile app → open the order → driver bubbles aren't there. Impossible to assign a driver from the florist app. Only after opening the dashboard and assigning a driver there does the picker finally appear in the florist app.

## Root cause (two-part)

1. **Airtable reciprocal-link lag** — when orderService creates the delivery with \`Linked Order: [orderId]\`, the ORDERS row's \`Deliveries\` back-link is supposed to auto-populate. In practice it's eventually-consistent. GET /orders/:id right after creation can come back with \`order.Deliveries === []\`, so the response has no \`delivery\` sub-record attached.
2. **Florist UI gates the picker** on \`detail?.delivery\`. With the sub-record missing, the picker hides, and there's no escape hatch. On the dashboard it appears to work because by the time the owner opens it, Airtable has caught up.

## Fix

**Backend (\`backend/src/services/orderService.js\`):** after creating the delivery row, explicitly write the back-link:
\`\`\`js
await db.update(TABLES.ORDERS, order.id, { 'Deliveries': [createdDelivery.id] });
\`\`\`
Guarantees the link is persisted before POST /orders returns. Non-fatal on error (Airtable auto-sync remains the fallback).

**Frontend (\`apps/florist/src/components/OrderCard.jsx\` + \`apps/florist/src/pages/OrderDetailPage.jsx\`):**
- Picker render gate drops \`detail?.delivery\`. Now shows whenever \`isDelivery && drivers.length > 0\`.
- \`patchDelivery()\` auto-heals: calls \`POST /orders/:id/convert-to-delivery\` if no delivery record is attached, then patches the driver. Handles the 400 race ("Delivery record already exists") by refetching.
- All reads guarded with optional chaining.

## Why this is the right shape

- Backend fix closes the data-level race for all **new** orders going forward.
- Frontend fix handles **legacy** broken orders that were created before this PR (and any residual race cases where the explicit back-link write somehow doesn't stick).
- No schema changes. No new endpoints. Reuses \`/convert-to-delivery\` which was already there.

## Testing

- [x] Shared test suite: 93/93 pass.
- [x] Backend syntax-checked via \`node --check\`.
- [ ] Full backend \`vitest\` deferred to CI (worktree lacks linked node_modules).
- [ ] Manual verification after deploy:
  1. Create a fresh Delivery order in the florist mobile app.
  2. Expand the order card → driver bubbles visible immediately.
  3. Tap a driver → toast "Updated"; selected bubble highlights.
  4. Refresh: driver is still selected.

## Out of scope

- Diagnosing whether Wix-webhook-created delivery orders had the same back-link issue (\`wix.js\` also creates a delivery record but doesn't explicitly write the back-link — could add the same one-liner in a follow-up if needed).
- Unified Stock Events / Order Events log (Ring 3 from the stock-math thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)