### PR TITLE
feat(payments): partial-payment on post-create price change (Tier 2 G)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -247,7 +247,7 @@ reports). Each item below was re-validated against the current code on
 - [ ] **Sorting by delivery date not working** — sort function broken
 - [ ] **Cancelled status irreversible** — clicking Cancelled can't be changed back
 - [ ] **Florist should see important NOTE prominently** — notes not visible on order front page
-- [ ] **Total paid amount not shown** — only flower price visible, not full order total
+- [x] **Total paid amount not shown** — fixed 2026-04-23. Collapsed card in florist (`OrderCardSummary.jsx`) + dashboard (`OrdersTab.jsx` price column) now shows `Оплачено X · Остаток Y` for Partial orders. Bouquet-edit raising the price on a Paid order surfaces an amber mismatch banner with two actions: `Collect remainder` (→ Partial + existing Payment 2 flow) and `Mark as fully paid` (→ bumps `Payment 1 Amount` to match new total). Backend now backfills `Payment 1 Amount` + `Method` when status flips to Paid via create or PATCH so the banner has a baseline. Legacy Paid orders with P1=0 stay silent.
 - [ ] **Show negative stock on top** in stock tab
 - [ ] **Order edit: new flower should show full form** — cost, sell, lot size, supplier fields + create negative stock
 - [ ] **PO add planned date** — visible in collapsed PO view

--- a/apps/dashboard/src/components/OrderDetailPanel.jsx
+++ b/apps/dashboard/src/components/OrderDetailPanel.jsx
@@ -364,6 +364,44 @@ export default function OrderDetailPanel({ orderId, onUpdate, onNavigate }) {
 
       {/* Payment row */}
       <div className="space-y-3">
+        {/* Mismatch banner — Paid orders whose recorded payment no longer covers
+            the current total (usually because a bouquet edit raised the price).
+            Two escapes: Collect remainder (→ Partial + existing P2 flow) or
+            Mark as fully paid (→ bump P1 to match the new total, quieting the
+            banner without inventing data beyond the new total). */}
+        {(() => {
+          const p1 = Number(o['Payment 1 Amount'] || 0);
+          const p2 = Number(o['Payment 2 Amount'] || 0);
+          const paid = p1 + p2;
+          const showMismatch = o['Payment Status'] === 'Paid'
+            && paid > 0 && effectivePrice > 0 && paid < effectivePrice;
+          if (!showMismatch) return null;
+          const delta = effectivePrice - paid;
+          return (
+            <div className="bg-amber-50 border border-amber-200 rounded-xl px-3 py-3 space-y-2">
+              <p className="text-xs font-semibold text-amber-800">⚠ {t.priceExceedsPaid}</p>
+              <p className="text-xs text-amber-700">
+                {t.paidAmount}: {paid.toFixed(0)} {t.zl} · {t.price}: {effectivePrice.toFixed(0)} {t.zl} · {t.remaining}: <span className="font-semibold">{delta.toFixed(0)} {t.zl}</span>
+              </p>
+              <div className="flex gap-2 flex-wrap">
+                <button
+                  onClick={() => patchOrder({ 'Payment Status': 'Partial' })}
+                  disabled={saving}
+                  className="text-xs font-medium px-3 py-1.5 rounded-lg bg-amber-600 text-white hover:bg-amber-700"
+                >{t.collectRemainder}</button>
+                <button
+                  onClick={() => patchOrder({
+                    'Payment 1 Amount': effectivePrice,
+                    'Payment 1 Method': o['Payment 1 Method'] || o['Payment Method'] || null,
+                  })}
+                  disabled={saving}
+                  className="text-xs font-medium px-3 py-1.5 rounded-lg bg-white border border-amber-300 text-amber-800 hover:bg-amber-100"
+                >{t.markAsFullyPaid}</button>
+              </div>
+            </div>
+          );
+        })()}
+
         <Section label={t.paymentStatus}>
           <Pills
             options={PAYMENT_STATUSES}

--- a/apps/dashboard/src/components/OrdersTab.jsx
+++ b/apps/dashboard/src/components/OrdersTab.jsx
@@ -579,11 +579,26 @@ export default function OrdersTab({ initialFilter, onNavigate }) {
                   : 'bg-rose-400';
                 return <span className={`w-2 h-2 rounded-full shrink-0 ${dotColor}`} title={margin !== null ? `${t.margin}: ${margin.toFixed(0)}%` : ''} />;
               })()}
-              <span className={`text-sm font-semibold w-20 text-right shrink-0 ${
-                order['Payment Status'] === 'Unpaid' ? 'text-ios-red' : 'text-ios-label'
-              }`}>
-                {(order['Final Price'] || order['Price Override'] || order['Sell Total'] || 0).toFixed(0)} {t.zl}
-              </span>
+              {/* Price column — for Partial, show remaining underneath so the owner
+                  sees outstanding money without expanding the row. */}
+              {(() => {
+                const total = Number(order['Final Price'] || order['Price Override'] || order['Sell Total'] || 0);
+                const isPartial = order['Payment Status'] === 'Partial';
+                const paid = Number(order['Payment 1 Amount'] || 0) + Number(order['Payment 2 Amount'] || 0);
+                const remaining = isPartial ? Math.max(0, total - paid) : 0;
+                return (
+                  <span className={`w-20 text-right shrink-0 flex flex-col ${
+                    order['Payment Status'] === 'Unpaid' ? 'text-ios-red' : 'text-ios-label'
+                  }`}>
+                    <span className="text-sm font-semibold leading-tight">{total.toFixed(0)} {t.zl}</span>
+                    {isPartial && remaining > 0 && (
+                      <span className="text-[10px] font-medium text-orange-600 leading-tight">
+                        −{remaining.toFixed(0)} {t.zl}
+                      </span>
+                    )}
+                  </span>
+                );
+              })()}
               {unpaidOnly && (
                 <span className={`text-xs font-medium w-16 text-right shrink-0 ${
                   isCritical ? 'text-ios-red' : isOverdue ? 'text-ios-orange' : 'text-ios-tertiary'

--- a/apps/dashboard/src/translations.js
+++ b/apps/dashboard/src/translations.js
@@ -501,6 +501,9 @@ const en = {
   payment2:           'Payment 2',
   remaining:          'Remaining',
   paidAmount:         'Paid',
+  priceExceedsPaid:   'Price exceeds paid amount',
+  collectRemainder:   'Collect remainder',
+  markAsFullyPaid:    'Mark as fully paid',
   paymentPartial:     'Partial',
 
   // Order detail panel
@@ -1342,6 +1345,9 @@ const ru = {
   payment2:           'Оплата 2',
   remaining:          'Остаток',
   paidAmount:         'Оплачено',
+  priceExceedsPaid:   'Цена превышает сумму оплаты',
+  collectRemainder:   'Взять доплату',
+  markAsFullyPaid:    'Считать полностью оплаченным',
   paymentPartial:     'Частичная',
 
   // Order detail panel

--- a/apps/florist/src/components/OrderCard.jsx
+++ b/apps/florist/src/components/OrderCard.jsx
@@ -826,6 +826,44 @@ function OrderCard({
                 )}
               </div>
 
+              {/* Mismatch banner — Paid orders where the price has since moved above
+                  the recorded payment. Owner either collects the remainder (flip
+                  to Partial + existing Payment 2 flow handles the rest) or accepts
+                  the current state (backfill P1 to match the total, silencing the
+                  banner without fabricating data beyond the new total). */}
+              {(() => {
+                const p1 = Number(d['Payment 1 Amount'] || 0);
+                const p2 = Number(d['Payment 2 Amount'] || 0);
+                const paid = p1 + p2;
+                const showMismatch = d['Payment Status'] === 'Paid'
+                  && paid > 0 && currentPrice > 0 && paid < currentPrice;
+                if (!showMismatch) return null;
+                const delta = currentPrice - paid;
+                return (
+                  <div className="bg-amber-50 border border-amber-200 rounded-xl px-3 py-3 space-y-2">
+                    <p className="text-xs font-semibold text-amber-800">⚠ {t.priceExceedsPaid}</p>
+                    <p className="text-xs text-amber-700">
+                      {t.paidAmount}: {paid} zł · {t.grandTotal || 'Total'}: {currentPrice} zł · {t.remaining}: <span className="font-semibold">{delta} zł</span>
+                    </p>
+                    <div className="flex gap-2 flex-wrap">
+                      <button
+                        onClick={() => patch({ 'Payment Status': 'Partial' })}
+                        disabled={saving}
+                        className="text-xs font-medium px-3 py-1.5 rounded-lg bg-amber-600 text-white active:bg-amber-700"
+                      >{t.collectRemainder}</button>
+                      <button
+                        onClick={() => patch({
+                          'Payment 1 Amount': currentPrice,
+                          'Payment 1 Method': d['Payment 1 Method'] || d['Payment Method'] || null,
+                        })}
+                        disabled={saving}
+                        className="text-xs font-medium px-3 py-1.5 rounded-lg bg-white border border-amber-300 text-amber-800 active:bg-amber-100"
+                      >{t.markAsFullyPaid}</button>
+                    </div>
+                  </div>
+                );
+              })()}
+
               {/* ── Payment controls ── */}
               <div>
                 <p className="text-xs font-semibold text-ios-tertiary uppercase tracking-wide mb-1">{t.labelPayment}</p>

--- a/apps/florist/src/components/OrderCardSummary.jsx
+++ b/apps/florist/src/components/OrderCardSummary.jsx
@@ -86,6 +86,25 @@ export default function OrderCardSummary({ order, d, currentStatus, currentPaid,
         )}
       </div>
 
+      {/* Partial: show paid + remaining inline so the owner doesn't have to
+          expand the card just to see how much is still outstanding. Paid mismatch
+          banner lives in the expanded view (it carries action buttons). */}
+      {d['Payment Status'] === 'Partial' && currentPrice > 0 && (() => {
+        const paid = Number(d['Payment 1 Amount'] || 0) + Number(d['Payment 2 Amount'] || 0);
+        const remaining = Math.max(0, currentPrice - paid);
+        return (
+          <p className="text-xs text-ios-tertiary mb-1">
+            {t.paidAmount || 'Paid'}: <span className="font-medium text-green-600">{paid} zł</span>
+            {remaining > 0 && (
+              <>
+                {' · '}
+                {t.remaining || 'Remaining'}: <span className="font-semibold text-orange-600">{remaining} zł</span>
+              </>
+            )}
+          </p>
+        );
+      })()}
+
       <div className="flex items-center gap-2 flex-wrap">
         <p className="text-base font-semibold text-ios-label">{d['Customer Name'] || order['Customer Name'] || '—'}</p>
         <CallButton phone={order['Customer Phone']} label={t.callCustomer} variant="subtle" />

--- a/apps/florist/src/pages/OrderDetailPage.jsx
+++ b/apps/florist/src/pages/OrderDetailPage.jsx
@@ -608,6 +608,40 @@ export default function OrderDetailPage() {
             <div>
               <p className="ios-label">Payment</p>
               <div className="ios-card p-4 flex flex-col gap-3">
+                {/* Mismatch banner — Paid with P1 below current total. See
+                    OrderCard.jsx for the rationale. */}
+                {(() => {
+                  const p1 = Number(order['Payment 1 Amount'] || 0);
+                  const p2 = Number(order['Payment 2 Amount'] || 0);
+                  const paid = p1 + p2;
+                  const total = Number(order['Final Price'] || 0);
+                  if (order['Payment Status'] !== 'Paid' || paid === 0 || total === 0 || paid >= total) return null;
+                  const delta = total - paid;
+                  return (
+                    <div className="bg-amber-50 border border-amber-200 rounded-xl px-3 py-3 space-y-2">
+                      <p className="text-xs font-semibold text-amber-800">⚠ {t.priceExceedsPaid}</p>
+                      <p className="text-xs text-amber-700">
+                        {t.paidAmount}: {paid} zł · {t.grandTotal || 'Total'}: {total} zł · {t.remaining}: <span className="font-semibold">{delta} zł</span>
+                      </p>
+                      <div className="flex gap-2 flex-wrap">
+                        <button
+                          onClick={() => patch({ 'Payment Status': 'Partial' })}
+                          disabled={saving}
+                          className="text-xs font-medium px-3 py-1.5 rounded-lg bg-amber-600 text-white active:bg-amber-700"
+                        >{t.collectRemainder}</button>
+                        <button
+                          onClick={() => patch({
+                            'Payment 1 Amount': total,
+                            'Payment 1 Method': order['Payment 1 Method'] || order['Payment Method'] || null,
+                          })}
+                          disabled={saving}
+                          className="text-xs font-medium px-3 py-1.5 rounded-lg bg-white border border-amber-300 text-amber-800 active:bg-amber-100"
+                        >{t.markAsFullyPaid}</button>
+                      </div>
+                    </div>
+                  );
+                })()}
+
                 <Pills
                   value={order['Payment Status'] || 'Unpaid'}
                   onChange={val => patch({

--- a/apps/florist/src/translations.js
+++ b/apps/florist/src/translations.js
@@ -159,6 +159,9 @@ const en = {
   payment2:         'Payment 2',
   remaining:        'Remaining',
   paidAmount:       'Paid',
+  priceExceedsPaid: 'Price exceeds paid amount',
+  collectRemainder: 'Collect remainder',
+  markAsFullyPaid:  'Mark as fully paid',
   paymentPartial:   'Partial',
   partialAmountPaid:'Amount paid',
 
@@ -843,6 +846,9 @@ const ru = {
   payment2:         'Оплата 2',
   remaining:        'Остаток',
   paidAmount:       'Оплачено',
+  priceExceedsPaid: 'Цена превышает сумму оплаты',
+  collectRemainder: 'Взять доплату',
+  markAsFullyPaid:  'Считать полностью оплаченным',
   paymentPartial:   'Частичная',
   partialAmountPaid:'Оплачено сейчас',
 

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -348,6 +348,34 @@ router.patch('/:id', async (req, res, next) => {
       }
     }
 
+    // Backfill Payment 1 Amount when the caller flips Payment Status to Paid
+    // without recording the split. Keeps the "price-exceeds-paid" banner honest
+    // on future bouquet edits — without this, Paid orders have no baseline and
+    // a later edit can't distinguish a real mismatch from a pre-feature order.
+    if (otherFields['Payment Status'] === PAYMENT_STATUS.PAID
+        && otherFields['Payment 1 Amount'] == null) {
+      const current = await db.getById(TABLES.ORDERS, req.params.id).catch(() => null);
+      const existingP1 = Number(current?.['Payment 1 Amount']) || 0;
+      if (existingP1 === 0) {
+        const lineIds = current?.['Order Lines'] || [];
+        const lines = lineIds.length > 0 ? await listByIds(TABLES.ORDER_LINES, lineIds) : [];
+        const flowerTotal = lines.reduce(
+          (s, l) => s + (Number(l['Sell Price Per Unit']) || 0) * (Number(l.Quantity) || 0), 0
+        );
+        const deliveryIdsForPrice = current?.['Deliveries'] || [];
+        const deliv = deliveryIdsForPrice[0] ? await db.getById(TABLES.DELIVERIES, deliveryIdsForPrice[0]).catch(() => null) : null;
+        const delivFee = current?.['Delivery Type'] === 'Delivery'
+          ? Number(current?.['Delivery Fee'] ?? deliv?.['Delivery Fee'] ?? 0) : 0;
+        const finalPrice = (Number(current?.['Price Override']) || flowerTotal) + delivFee;
+        if (finalPrice > 0) {
+          otherFields['Payment 1 Amount'] = finalPrice;
+          if (!otherFields['Payment 1 Method'] && (otherFields['Payment Method'] || current?.['Payment Method'])) {
+            otherFields['Payment 1 Method'] = otherFields['Payment Method'] || current['Payment Method'];
+          }
+        }
+      }
+    }
+
     // No status change — just update other fields
     const order = await db.update(TABLES.ORDERS, req.params.id, otherFields);
 

--- a/backend/src/services/orderService.js
+++ b/backend/src/services/orderService.js
@@ -6,7 +6,7 @@ import { TABLES } from '../config/airtable.js';
 import { broadcast } from './notifications.js';
 import { notifyNewOrder } from './telegram.js';
 import { listByIds } from '../utils/batchQuery.js';
-import { ORDER_STATUS, DELIVERY_STATUS } from '../constants/statuses.js';
+import { ORDER_STATUS, DELIVERY_STATUS, PAYMENT_STATUS } from '../constants/statuses.js';
 
 // ── Status transition state machine ──
 // Exported so routes + tests can reference it.
@@ -73,6 +73,22 @@ export async function createOrder(params, config, opts = {}) {
   try {
     const appOrderId = await generateOrderId();
 
+    // Backfill Payment 1 for orders created as Paid so the mismatch banner has
+    // a baseline to compare against when the bouquet is later edited. Without
+    // this, a price-raising edit on a Paid order has no "what was originally
+    // paid" reference and the banner can't distinguish real mismatches from
+    // legacy orders. Respect an explicitly-provided payment1Amount.
+    const resolvedDeliveryFee = deliveryType === 'Delivery'
+      ? (delivery?.fee ?? getConfig('defaultDeliveryFee')) : 0;
+    const flowerTotal = orderLines.reduce(
+      (sum, l) => sum + (Number(l.sellPricePerUnit) || 0) * (Number(l.quantity) || 0), 0
+    );
+    const finalPriceAtCreate = (Number(priceOverride) || flowerTotal) + resolvedDeliveryFee;
+    const p1AmountBackfill = paymentStatus === PAYMENT_STATUS.PAID
+      && payment1Amount == null && finalPriceAtCreate > 0
+      ? finalPriceAtCreate : null;
+    const p1MethodBackfill = p1AmountBackfill != null && !payment1Method ? (paymentMethod || null) : null;
+
     // 1. Create parent order
     order = await db.create(TABLES.ORDERS, {
       Customer:             [customer],
@@ -89,7 +105,9 @@ export async function createOrder(params, config, opts = {}) {
       'Payment Method':     paymentMethod || null,
       ...(payment1Amount != null ? { 'Payment 1 Amount': Number(payment1Amount) } : {}),
       ...(payment1Method ? { 'Payment 1 Method': payment1Method } : {}),
-      'Delivery Fee':       deliveryType === 'Delivery' ? (delivery?.fee ?? getConfig('defaultDeliveryFee')) : 0,
+      ...(p1AmountBackfill != null ? { 'Payment 1 Amount': p1AmountBackfill } : {}),
+      ...(p1MethodBackfill ? { 'Payment 1 Method': p1MethodBackfill } : {}),
+      'Delivery Fee':       resolvedDeliveryFee,
       'Price Override':     priceOverride || null,
       'App Order ID':       appOrderId,
       Status:               ORDER_STATUS.NEW,


### PR DESCRIPTION
## Summary

Addresses the real owner workflow: customer orders a bouquet for 200 zł
and pays in full. Florist edits the bouquet at the customer's request,
new total becomes 235 zł. The owner should be able to convert the
order to Partial with 200 already paid, and collect the 35 zł delta,
without re-entering data the system already has.

Four commits, independent and revertible:

1. `feat(payments): backfill Payment 1 Amount when status flips to Paid` —
   `orderService.createOrder` and `PATCH /orders/:id` now write
   `Payment 1 Amount` (and `Payment 1 Method` when known) whenever the
   status is set to Paid without an explicit split. This gives the new
   banner a baseline to compare against. Respect an explicitly-provided
   `payment1Amount`; skip backfill when the order already has P1 > 0.
2. `feat(payments): show paid/remaining inline for Partial on list rows` —
   collapsed cards (florist `OrderCardSummary.jsx`, dashboard
   `OrdersTab.jsx` price column) now show `Оплачено X · Остаток Y` for
   Partial orders so the owner sees outstanding money without expanding.
3. `feat(payments): mismatch banner on Paid orders where price > paid` —
   amber banner on florist `OrderCard.jsx` + `OrderDetailPage.jsx` and
   dashboard `OrderDetailPanel.jsx` with two actions:
   - **Collect remainder** → flips `Payment Status = 'Partial'`, keeps
     P1 as-is, hands off to the existing Payment 2 flow.
   - **Mark as fully paid** → opt-out. Bumps `Payment 1 Amount` to the
     current total. Math adds up, banner quiets, order stays Paid.

   Trigger: `Payment Status === 'Paid' && (P1 + P2) > 0 && (P1 + P2) < Final Price`.
   Legacy Paid orders with P1=0 stay silent — no false positives.
4. `docs(backlog)` — checks off Tier 2 item G.

No schema change. No new Airtable fields.

## Files

10 files, +210 / −8.

- Backend: `orders.js` (PATCH), `orderService.js` (createOrder)
- Florist: `OrderCardSummary.jsx`, `OrderCard.jsx`, `OrderDetailPage.jsx`, `translations.js`
- Dashboard: `OrdersTab.jsx`, `OrderDetailPanel.jsx`, `translations.js`
- `BACKLOG.md`

## Test plan

- [ ] Backend vitest: `cd backend && node node_modules/vitest/vitest.mjs run` → 83 pass, 1 pre-existing analytics failure unrelated to this PR.
- [ ] Create a Paid order via the dashboard wizard (any amount, any method). Open it in Airtable — `Payment 1 Amount` and `Payment 1 Method` should be populated.
- [ ] Create an Unpaid order, then flip to Paid via the dashboard panel → same check in Airtable.
- [ ] Open an existing Paid order, edit bouquet to raise the price. Expanded panel should show the amber "Price exceeds paid amount" banner with Paid / Total / Remaining numbers.
- [ ] Click **Collect remainder** → order flips to Partial, Payment 2 input appears below, enter remainder amount + method → order auto-flips back to Paid with P1+P2 matching total.
- [ ] Same scenario, click **Mark as fully paid** instead → banner disappears, order stays Paid, `Payment 1 Amount` now equals new total.
- [ ] Legacy Paid order (P1=0, P2=0) with bouquet edit raising price → banner should NOT appear.
- [ ] Partial order on the orders list → price column shows total + small `−N zł` in orange; florist collapsed card shows `Оплачено X · Остаток Y`.
- [ ] Russian language toggle: all new strings render in Russian.

🤖 Generated with [Claude Code](https://claude.com/claude-code)