### PR TITLE
feat(po): lot-rounded costs + aggregate total on every saved PO

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -251,7 +251,7 @@ reports). Each item below was re-validated against the current code on
 - [x] **Show negative stock on top in stock tab** — confirmed working 2026-04-23 by owner.
 - [ ] **Order edit: new flower should show full form** — cost, sell, lot size, supplier fields + create negative stock
 - [x] **PO add planned date** — verified working 2026-04-23. Florist `PurchaseOrderPage.jsx:481` + dashboard `StockOrderPanel.jsx:585-587` render `Planned Date` in the collapsed PO view.
-- [ ] **PO total cost by lot size** — if 7 needed but lot size 10, calculate cost for 10. Also: show aggregate PO total on creation so the owner knows how much cash the driver needs for suppliers.
+- [x] **PO total cost by lot size + aggregate total** — fixed 2026-04-23. Florist save path now lot-rounds stored `Quantity Needed` to match the create-form cost badge (dashboard already stored lot-rounded). Aggregate PO total now renders on every saved PO: compact `X zł` badge in the collapsed row + "Cost total" line in the expanded editable view. Both apps fetch `/stock-orders?include=lines` for the client-side sum so the owner knows how much cash the driver needs before sending the run.
 - [ ] **Non-floral components in compositions** — foam, baskets, boxes, ribbons as addable materials separate from flower stock
 - [ ] **Stock write-offs sortable** — filter by daily/weekly/monthly
 - [ ] **Stock filter: in-stock only + by arrival date** — two filter modes

--- a/apps/dashboard/src/components/StockOrderPanel.jsx
+++ b/apps/dashboard/src/components/StockOrderPanel.jsx
@@ -41,8 +41,11 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
 
   const fetchOrders = useCallback(async () => {
     try {
+      // include=lines lets us render the per-PO cost total inline (how much
+      // cash the driver needs for suppliers) without an extra round-trip
+      // per row. Backend already supports it (stockOrders.js:84).
       const [res, comRes] = await Promise.all([
-        client.get('/stock-orders'),
+        client.get('/stock-orders?include=lines'),
         client.get('/stock/committed'),
       ]);
       setOrders(res.data);
@@ -566,7 +569,14 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
         <p className="text-sm text-ios-tertiary text-center py-8">{t.noStockOrders}</p>
       ) : (
         <div className="space-y-2">
-          {orders.map(order => (
+          {orders.map(order => {
+            // Cost total from pre-fetched lines (backend returns them via
+            // ?include=lines). Owner can scan PO list and see cash needed
+            // per run without expanding each row.
+            const costTotal = (order.lines || []).reduce(
+              (sum, l) => sum + (Number(l['Quantity Needed']) || 0) * (Number(l['Cost Price']) || 0), 0
+            );
+            return (
             <div key={order.id} className="glass-card overflow-hidden">
               <div
                 onClick={() => toggleExpand(order.id)}
@@ -579,6 +589,11 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
                   <span className="text-sm font-medium text-ios-label">
                     PO #{order['Stock Order ID'] || '—'}
                   </span>
+                  {costTotal > 0 && (
+                    <span className="text-xs font-semibold text-blue-700 bg-blue-50 px-2 py-0.5 rounded-full">
+                      {costTotal.toFixed(0)} {t.zl}
+                    </span>
+                  )}
                   {order['Assigned Driver'] && (
                     <span className="text-xs text-ios-secondary">{order['Assigned Driver']}</span>
                   )}
@@ -618,6 +633,21 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
                         onAdd={addPersistedLine}
                         suppliers={SUPPLIERS}
                       />
+
+                      {/* Live cost total — reads from expandedLines so it
+                          reflects in-progress edits rather than the stale
+                          snapshot on order.lines from the list fetch. */}
+                      {(() => {
+                        const liveTotal = expandedLines.reduce(
+                          (s, l) => s + (Number(l['Quantity Needed']) || 0) * (Number(l['Cost Price']) || 0), 0
+                        );
+                        return liveTotal > 0 ? (
+                          <div className="text-sm px-1 pt-1">
+                            <span className="text-ios-tertiary">{t.costTotal}: </span>
+                            <span className="font-semibold text-ios-label">{liveTotal.toFixed(0)} {t.zl}</span>
+                          </div>
+                        ) : null;
+                      })()}
 
                       <div className="flex items-center gap-2 pt-2">
                         <select
@@ -782,7 +812,8 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
                 </div>
               )}
             </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>

--- a/apps/florist/src/pages/PurchaseOrderPage.jsx
+++ b/apps/florist/src/pages/PurchaseOrderPage.jsx
@@ -51,7 +51,9 @@ export default function PurchaseOrderPage() {
 
   const fetchOrders = useCallback(async () => {
     try {
-      const res = await client.get('/stock-orders');
+      // include=lines lets us render the per-PO cost total without an extra
+      // round-trip per row. Backend already supports it (stockOrders.js:84).
+      const res = await client.get('/stock-orders?include=lines');
       setOrders(res.data);
     } catch {
       showToast(t.error, 'error');
@@ -466,7 +468,14 @@ export default function PurchaseOrderPage() {
           <p className="text-sm text-ios-tertiary text-center py-12">{t.po?.noOrders || 'No purchase orders'}</p>
         ) : (
           <div className="space-y-2">
-            {orders.map(order => (
+            {orders.map(order => {
+              // Cost total from pre-fetched lines (backend returns them when
+              // we pass ?include=lines). Owner sees at a glance how much cash
+              // this PO will need; avoids mentally summing the line prices.
+              const costTotal = (order.lines || []).reduce(
+                (sum, l) => sum + (Number(l['Quantity Needed']) || 0) * (Number(l['Cost Price']) || 0), 0
+              );
+              return (
               <div key={order.id} className="ios-card overflow-hidden">
                 {/* PO header row */}
                 <button
@@ -481,6 +490,11 @@ export default function PurchaseOrderPage() {
                       <span className="text-sm font-medium text-ios-label">
                         PO #{order['Stock Order ID'] || '—'}
                       </span>
+                      {costTotal > 0 && (
+                        <span className="text-xs font-semibold text-ios-label bg-blue-50 text-blue-700 px-2 py-0.5 rounded-full">
+                          {costTotal.toFixed(0)} zł
+                        </span>
+                      )}
                     </div>
                     <span className="text-xs text-ios-tertiary">{order['Created Date']}</span>
                   </div>
@@ -518,6 +532,21 @@ export default function PurchaseOrderPage() {
                           onAdd={addPersistedLine}
                           suppliers={SUPPLIERS}
                         />
+
+                        {/* Cost total from the live expanded-lines state so it
+                            tracks in-progress edits, not the stale snapshot on
+                            order.lines from the list fetch. */}
+                        {(() => {
+                          const liveTotal = expandedLines.reduce(
+                            (s, l) => s + (Number(l['Quantity Needed']) || 0) * (Number(l['Cost Price']) || 0), 0
+                          );
+                          return liveTotal > 0 ? (
+                            <div className="text-sm px-1 pt-1">
+                              <span className="text-ios-tertiary">{t.po?.costTotal || 'Cost total'}: </span>
+                              <span className="font-semibold text-ios-label">{liveTotal.toFixed(0)} zł</span>
+                            </div>
+                          ) : null;
+                        })()}
 
                         <div className="flex items-center gap-2 pt-2">
                           <select
@@ -636,7 +665,8 @@ export default function PurchaseOrderPage() {
                   </div>
                 )}
               </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </main>

--- a/apps/florist/src/pages/PurchaseOrderPage.jsx
+++ b/apps/florist/src/pages/PurchaseOrderPage.jsx
@@ -144,11 +144,22 @@ export default function PurchaseOrderPage() {
         notes: formNotes,
         driver: formDriver,
         plannedDate: formPlannedDate || null,
-        lines: formLines.filter(l => l.flowerName).map(l => ({
-          ...l,
-          costPrice: Number(l.costPrice) || 0,
-          sellPrice: Number(l.sellPrice) || 0,
-        })),
+        // Lot-round the stored quantity so it matches what the create-form's
+        // grandCost math showed the owner. Without this, `Quantity Needed`
+        // would store the raw stem count (e.g. 7) but the cost badge rendered
+        // the lot-rounded value (10 stems at `Math.ceil(7/10)*10`), making
+        // the persisted-PO total inconsistent with what the owner confirmed.
+        lines: formLines.filter(l => l.flowerName).map(l => {
+          const ls = Number(l.lotSize) || 0;
+          const rawQty = Number(l.quantity) || 0;
+          const quantity = ls > 1 ? Math.ceil(rawQty / ls) * ls : rawQty;
+          return {
+            ...l,
+            quantity,
+            costPrice: Number(l.costPrice) || 0,
+            sellPrice: Number(l.sellPrice) || 0,
+          };
+        }),
       });
       showToast(t.po?.created || 'PO created');
       setShowForm(false);


### PR DESCRIPTION
## Summary

Owner feedback: during and after PO creation she needs to see how much
cash the driver will need for suppliers. The create form already showed
a grand total, but once a PO was saved the number disappeared — she'd
have to mentally re-sum the lines.

Three commits:

1. `fix(po): florist save lot-rounds stored Quantity Needed` — The
   florist create form's cost badge rendered lot-rounded qty
   (`Math.ceil(qty/lot) * lot`) but `POST /stock-orders` stored the
   raw typed qty. Persisted totals then disagreed with what the owner
   confirmed. Match the dashboard's behaviour: lot-round on submit.
2. `feat(po): show total cost on saved POs so owner sees cash needed` —
   Switch both apps' PO list fetch to `?include=lines` (backend
   already supported it). Compute `Quantity Needed * Cost Price`
   summed across lines. Render:
   - Collapsed PO row: compact `X zł` badge next to the PO ID.
   - Expanded editable view: `Cost total: X zł` line between the line
     editors and the driver action row. Reads from `expandedLines`
     state so it tracks in-progress edits.
3. `docs(backlog)` — marks the item done.

Parity across florist `PurchaseOrderPage.jsx` + dashboard
`StockOrderPanel.jsx`. No backend change, no schema change.

## Files

| File | Change |
|---|---|
| `apps/florist/src/pages/PurchaseOrderPage.jsx` | Lot-round qty on save; `?include=lines`; total badge + expanded-view total |
| `apps/dashboard/src/components/StockOrderPanel.jsx` | `?include=lines`; total badge + expanded-view total |
| `BACKLOG.md` | Checked off |

## Test plan

- [ ] Backend vitest: `cd backend && node node_modules/vitest/vitest.mjs run` → 83 pass, 1 pre-existing analytics failure unrelated to this PR.
- [ ] Dashboard: open Stock Orders. Each saved PO row now shows a blue `X zł` badge next to the PO ID. Expand an editable PO → "Cost total" line appears above the driver row and updates as you edit a line's qty/cost.
- [ ] Florist: same check on `/purchase-orders`. Badge in the header, "Cost total" in the expanded edit view.
- [ ] Create a PO in the florist app with `qty=7, lotSize=10, cost=5`. Expected: badge shows `50 zł` (not 35) because save now lot-rounds qty to 10. Open the same PO in Airtable — `Quantity Needed` = 10.
- [ ] Complete/Reviewing/Evaluating POs: the badge still appears (read from stored values), but the expanded view uses its existing read-only rendering (unchanged).
- [ ] Russian language toggle: `Cost total` / `Себестоимость` labels render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)