### PR TITLE
feat(florist): show Florist Note on collapsed order cards

### DIFF
--- a/apps/florist/src/components/OrderCard.jsx
+++ b/apps/florist/src/components/OrderCard.jsx
@@ -381,6 +381,22 @@ function OrderCard({
           {order['Delivery Time'] ? ` · ${order['Delivery Time']}` : ''}
         </p>
       )}
+      {/* Florist note — owner-authored operational guidance for the florist.
+          Shown on the collapsed card (not just on expand / detail page) so
+          important "read this first" instructions aren't buried. Styled
+          distinctly from the customer's greeting card text below: green
+          accent + bold label so it reads as staff-facing, not customer-
+          facing. Line-clamp-2 keeps a long note from ballooning the card. */}
+      {!expanded && order['Florist Note'] && (
+        <div className="mt-2 bg-green-50 dark:bg-green-900/30 border-l-4 border-green-500 rounded-lg px-3 py-2">
+          <p className="text-[10px] font-bold uppercase tracking-wide text-green-700 dark:text-green-300 mb-0.5">
+            🌸 {t.floristNote}
+          </p>
+          <p className="text-sm text-ios-label dark:text-gray-200 leading-snug whitespace-pre-wrap line-clamp-2">
+            {order['Florist Note']}
+          </p>
+        </div>
+      )}
       {/* Card text hint — truncated in collapsed view, full text in expanded */}
       {!expanded && order['Greeting Card Text'] && (
         <div className="relative mt-2 bg-amber-50 rounded-lg px-3 py-1.5 overflow-hidden" style={{ maxHeight: '2.2em' }}>


### PR DESCRIPTION
## Summary

Owner writes operational guidance into the Florist Note field from the dashboard (OrderDetailPanel → "🌸 Florist note"). The florist mobile app only rendered it **deep inside the expanded editor**, so florists would miss important notes ("start with the roses", "customer is picky", etc.) until they happened to tap open the order.

This PR surfaces the note on every **collapsed** card in the order list.

## What changed

- \`apps/florist/src/components/OrderCard.jsx\` — one new conditional block in the collapsed layout, placed between the delivery date/time and the customer greeting-card text. Green left-border accent + bold uppercase label to read as staff-facing (distinct from the amber customer-facing greeting card block below it). \`line-clamp-2\` keeps long notes from ballooning the card; full note still shows in the expanded editor.

## What did NOT change

- No existing collapsed content was moved or demoted — **purely additive**. Same price badge, customer, request, bouquet summary, date/time, greeting card, status transition button, all in the same order.
- Translation keys (\`floristNote\`) already existed in EN + RU.
- Backend returns \`'Florist Note'\` on the Orders list endpoint (no \`fields:\` restriction on the main Orders query) — no backend change needed.

## Visual hierarchy

```
[Status] [Payment] [Compose?]      [Price]
Customer Name
Customer request...
🌸 Bouquet Summary
Delivery date · time

┌─🌸 FLORIST NOTE──────────────┐  ← new (green accent)
│  Short summary (2 lines max) │
└──────────────────────────────┘
┌─✉ Greeting card text─────────┐  ← existing (amber accent)
│  Dear Olha, happy birthday…  │
└──────────────────────────────┘

[ Mark Ready ]
```

## IE framing

The SOP on the staff bulletin board was only visible if the operator actually opened the work-order binder to the detail page. Now it's also printed on the top of every traveler card — same hierarchy, less friction, no other signals suppressed.

## Verification after deploy

1. On the dashboard, add a Florist Note to any non-terminal order (🌸 Florist note field in OrderDetailPanel).
2. Open the florist app → Orders list → hard-refresh. That order's **collapsed** card should now show the green "Florist note" block with the note text.
3. Expand the card — note still appears in the editor (unchanged).
4. Clear the note on the dashboard — the green block disappears on the collapsed card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)