### PR TITLE
feat(public-api): expose seasonalSlugs for Wix mobile menu fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,55 @@ AIRTABLE_PREMADE_BOUQUET_LINES_TABLE=tbl...  # Premade Bouquet Lines table ID
 
 ---
 
+## 2026-04-25 — Wix mobile menu: seasonal slot self-heals across PL/UK/RU
+
+Mobile menu in Polish / Ukrainian / Russian still showed the previous
+seasonal (Valentine's labelled "Walentynki" / "Валентинки" / "День
+Валентина") and clicked through to `/category/valentines-day` even after
+the owner flipped the active seasonal in the dashboard to peonies.
+UK additionally had a generic "СЕЗОННІ БУКЕТИ" item plus a manually-added
+"ПІОНИ" item — three candidates for the same slot. Desktop was fine —
+`#button7` is renamed directly by `masterPage.js` and its link was
+updated per language manually. Mobile relied on `transformMenuItems`,
+which only matched 4 hardcoded English/Polish-spring labels (`SEASONAL`,
+`WIOSNA`, `SPRING`, `ВЕСНА`), only rewrote the **label** (never the
+link), and didn't dedupe duplicates.
+
+The canonical seasonal URL across all four languages is `/category/seasonal`
+— a single Wix Stores category whose product membership flips automatically
+as the active seasonal changes. Same pattern as `/category/available-today`.
+
+Fix:
+- `backend/src/routes/public.js` — `/api/public/categories` now returns
+  `seasonalSlugs: [...]` (every configured seasonal slug, current + past).
+- `Blossom-Wix/src/pages/masterPage.js`:
+  1. Detect seasonal items three ways — link is `/category/seasonal`
+     (canonical, EN today), OR link contains any historic seasonal slug
+     (Valentine's, Easter, Christmas, …), OR label contains a seasonal
+     stem (`SEASONAL`, `SEZON`, `СЕЗОН`, `SPRING`, `WIOSN`, `ВЕСН`).
+     Stems chosen so UK "ВЕСІЛЛЯ" (Weddings) does NOT false-match `ВЕСН`
+     (4th char differs).
+  2. Rewrite BOTH label AND link of matched items — label = active
+     seasonal title in user's language, link = `/category/seasonal`.
+  3. Dedupe — keep only the first item pointing at `/category/seasonal`,
+     drop later duplicates so UK's three candidates collapse to one.
+
+Net effect: when the owner flips the seasonal in the dashboard, every
+language and every menu element (`HorizontalMenu`, `VerticalMenu`,
+`ExpandableMenu`, `DropDownMenu`) picks up the new label, URL, and
+duplicate-free structure on the next page load — including EN, whose
+"PEONIES" label will now auto-update when the seasonal flips. No
+per-language Editor edits needed.
+
+Out of scope (would require option B / canonical menu generation): the
+PL mobile menu is missing an "Accessories" item the desktop has, and
+Ukrainian "Available Today" / Russian "Доступно сегодня" are truncated
+in the editor item width. Both fixable later by generating the full
+mobile menu from category data instead of trusting per-language Editor
+items.
+
+---
+
 ## 2026-04-22 — Florist app cleanup (Phase B): Customers tab on mobile
 
 Second PR of the three-part florist cleanup plan. Phase A shipped the nav

--- a/backend/src/routes/public.js
+++ b/backend/src/routes/public.js
@@ -249,6 +249,11 @@ router.get('/categories', (_req, res) => {
     categoryMap[s.slug] = { name: s.name, slug: s.slug, description: s.description || '', translations: s.translations || {} };
   }
 
+  // All seasonal slugs (current + historic) so Velo can detect any prior
+  // seasonal menu item (Valentine's, Easter, Christmas, …) and rewrite it
+  // to the currently active one — independent of the item's display label.
+  const seasonalSlugs = (sc.seasonal || []).map(s => s.slug).filter(Boolean);
+
   res.json({
     permanent: permanentNames,
     seasonal: seasonal
@@ -263,6 +268,7 @@ router.get('/categories', (_req, res) => {
     all,
     allCategories,
     categoryMap,
+    seasonalSlugs,
   });
 });
 


### PR DESCRIPTION
## Summary

Adds `seasonalSlugs: [...]` to the `/api/public/categories` response so Wix Velo can detect any historic seasonal menu item (Valentine's, Easter, Christmas, Women's Day, Mother's Day, …) and redirect it to the canonical `/category/seasonal` URL.

Companion to [`OliwerO/Blossom-Wix#6`](https://github.com/OliwerO/Blossom-Wix/pull/6) which consumes the field. Velo has a `|| []` fallback so this can deploy independently — without it, only canonical-link + label-stem detection works on the Wix side, leaving PL `Walentynki` and RU `День Валентина` items unrewrittten until this lands.

One-line change to the JSON response, plus a CHANGELOG entry. No new endpoints, no schema changes, no test breakage (no existing test covers `/public/categories`).

## Test plan

- [ ] After Railway deploy, `curl https://flower-studio-backend-production.up.railway.app/api/public/categories | jq .seasonalSlugs` returns an array with at least `["valentines-day","womens-day","mothers-day","easter","christmas","peonies"]`
- [ ] Existing Wix product sync continues to function (no regressions in `/api/public/categories` callers)
- [ ] Once both this and Blossom-Wix#6 are deployed: PL/UK/RU mobile menus show the active seasonal label and route to `/category/seasonal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)