### PR TITLE
fix(dashboard): align Available Today filter with Wix storefront

### DIFF
--- a/apps/dashboard/src/components/DayToDayTab.jsx
+++ b/apps/dashboard/src/components/DayToDayTab.jsx
@@ -136,7 +136,14 @@ export default function DayToDayTab({ onNavigate }) {
       setAnalytics(analyticsRes.data);
       setDriverOfDay(settingsRes.data.driverOfDay || null);
       setDrivers(settingsRes.data.drivers || []);
-      const available = (productsRes.data.products || []).filter(p => p.availableToday);
+      // Match the Wix storefront definition: LT=0 + stock (p.availableToday)
+      // AND tagged with the "Available Today" category. Without the tag check
+      // every LT=0 product would show here, while the actual Wix nav only
+      // surfaces the manually-tagged ones (see backend/src/routes/public.js
+      // productCount).
+      const available = (productsRes.data.products || []).filter(
+        p => p.availableToday && (p.category || []).includes('Available Today')
+      );
       setWixProducts(available);
       setFetchError(false);
     } catch {

--- a/apps/dashboard/src/components/ProductsTab.jsx
+++ b/apps/dashboard/src/components/ProductsTab.jsx
@@ -57,6 +57,12 @@ export default function ProductsTab() {
   function isAvailableToday(variant) {
     if (!variant['Active']) return false;
     if (Number(variant['Lead Time Days'] ?? 1) !== 0) return false;
+    // Must carry the "Available Today" Category tag — this is what the Wix
+    // storefront filters on (see backend/src/routes/public.js productCount
+    // and the push criteria in wixProductSync.js). Without this gate the
+    // dashboard reports any LT=0 product as Available Today, while Wix only
+    // shows the ones tagged in the collection.
+    if (!parseCats(variant['Category']).includes('Available Today')) return false;
     const keyFlower = variant['Key Flower'];
     const stockId = Array.isArray(keyFlower) ? keyFlower[0] : keyFlower;
     if (!stockId) return true;


### PR DESCRIPTION
## Summary
- Dashboard's **Available Today** filter (`ProductsTab` banner/filter pill + `DayToDayTab` widget) was reporting every LT=0 + in-stock variant, while the Wix storefront only surfaces products carrying the **`Available Today`** Category tag.
- Both surfaces now require the Category tag in addition to LT=0 + stock — matching `backend/src/routes/public.js` `productCount` and the push gate in `wixProductSync.js`.
- Net effect: dashboard count now equals Wix storefront count (3 vs. previously many). Push behavior was already correct; this fix removes the misleading display that made Push look unsafe.

## Test plan
- [ ] Open dashboard → **Today** tab → "Wix Available Today" widget should match the count shown in the Wix storefront nav (`/category/available-today`).
- [ ] Open dashboard → **Products** tab → green "Available Today" banner should list the same products.
- [ ] Click the **Today** filter pill on Products tab → list should narrow to those same products.
- [ ] Click **Push to Wix** → toast count for category sync should match the banner count (no surprise flood).
- [ ] Tag/untag a product's `Available Today` Category in dashboard → after save, banner updates to reflect the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)