### PR TITLE
fix+chore: trust proxy + shadow-health CLI + pick-up checklist

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,6 +4,42 @@ Features and improvements tracked against original build phases.
 
 ---
 
+## ⚡ Pick-up checklist for the next session
+
+If a future Claude session is opening this repo cold, here's the live state and what's queued. Updated 2026-04-28.
+
+**Migration cutover state:**
+- Phase 3 (Stock) is IN SHADOW WEEK on prod since 2026-04-28. `STOCK_BACKEND=shadow` is live.
+- Phase 4 (Orders) implementation merged but cutover NOT started — `ORDER_BACKEND` still defaults to `airtable`.
+
+**Daily owner check during shadow week** (~30 sec):
+```bash
+CLAUDE_RO_URL='<from project_postgres_access.md>' node backend/scripts/shadow-health.js
+```
+Should show "✓ Shadow-write is healthy" with zero parity mismatches. If anything but zero, investigate before flipping to postgres.
+
+**Open work items, ranked by when they unblock:**
+
+1. **Owner verifies Track A landed** (browser, 2 min) — Admin tab shows "Shadow" banner, 86 stock rows, zero parity. Without this, downstream cutover is flying blind.
+2. **Owner cleans up 2 orphan Airtable Stock rows** (`recyLyXct64ksIMFY`, `recD6p1GbmrKV7mrl`) — no Display Name, skipped by backfill. Delete them or fill in name + re-run `backend/scripts/backfill-stock.js` (idempotent).
+3. **3b E2E test harness** — separate Claude session per `docs/migration/3b-e2e-test-harness-kickoff.md`. Builds local-PG-only test mode + Playwright + mock Airtable. Unblocks: Wix webhook validation, future cutovers, dev/staging substitute. Runs in any cloud env with Node 20+ (Codespaces/Gitpod/Replit).
+4. **Stock cutover flip** (after shadow week clean) — `railway variables --service flower-studio-backend --set STOCK_BACKEND=postgres` + redeploy. Airtable Stock becomes legacy snapshot.
+5. **Phase 4 cutover** (after #3 validates Wix webhook) — `node backend/scripts/backfill-orders.js` → `ORDER_BACKEND=shadow` → 1 week shadow → `ORDER_BACKEND=postgres`.
+6. **Order parity dashboard UI in AdminTab** — backend stub already exists; full `orderRepo.runParityCheck` impl + AdminTab order-side rendering. Best after ORDER_BACKEND=shadow generates real data.
+7. **`scripts/simulate-orders.js`** — owner-runnable day-in-the-life. Integration tests already cover the same scenarios; this is convenience.
+8. **Phase 5 prep — Customers** (after Phase 4 cutover proves stable) — design doc, schema (with FK to existing customer_id text columns), customerRepo skeleton, dedup tooling for Universe A (legacy) + B (app).
+9. **Phase 6 — Config + log tables** — App Config, Florist Hours, Marketing Spend, Stock Loss Log, Webhook Log, Sync Log, Product Config. Mostly write-only; no shadow needed.
+10. **Phase 7 — Retire Airtable** — delete services/airtable.js, services/airtableSchema.js, config/airtable.js. Cancel subscription. Final snapshot.
+
+**Standing investigations (have shadow data now to debug with):**
+- "Stock not deducted via bouquet edit" bug from memory — once shadow has a few days of data, query `audit_log` for stock updates triggered by bouquet edits and cross-reference with the suspicious orders. Far easier to diagnose now.
+
+**Stale local branches to clean up** (low priority):
+- `feat/sql-migration-phase-1` (PR #156 merged via squash — local branch obsolete)
+- `feat/sql-migration-phase-4-prep` (replaced by `-clean` branch which became PR #158)
+
+---
+
 ## Done
 
 ### Phase 1 — Backend Scaffold + Airtable CRUD
@@ -276,7 +312,15 @@ reports). Each item below was re-validated against the current code on
 - [x] **Phase 1 — Postgres infra** (2026-04-27) — Railway PG provisioned, Drizzle wired, `system_meta` migration applied, `claude_ro` read-only role created.
 - [x] **Phase 2.5 — Audit log + Admin tab** (2026-04-27) — `audit_log` table + `recordAudit()` helper. Owner-only Admin tab with audit-log viewer. Per-entity registry empty until Phase 3 populates it.
 - [x] **Phase 3 — Stock cutover scaffolding** (2026-04-27) — `stock` + `parity_log` tables, `stockRepo` with three-mode backend (`airtable | shadow | postgres`), full route wiring (stock.js, dashboard.js, orderService autoMatchStock + atomicStockAdjust, wixProductSync), backfill script, AdminTab parity endpoints. **Default behaviour unchanged** (`STOCK_BACKEND=airtable`); cutover gated on env var flip.
-- [ ] **Phase 3 cutover** — owner action: apply migration on prod (`npm run db:migrate`), run `node scripts/backfill-stock.js`, set `STOCK_BACKEND=shadow`, watch parity_log for ~1 week (especially a full Saturday), then flip to `postgres`.
+- [~] **Phase 3 cutover** — IN SHADOW WEEK as of 2026-04-28.
+  - [x] Migrations applied to prod PG (0000-0003 — orders/lines/deliveries also live but inert).
+  - [x] `scripts/backfill-stock.js` ran — 86 of 88 Airtable rows seeded (2 skipped: `recyLyXct64ksIMFY`, `recD6p1GbmrKV7mrl` — no Display Name).
+  - [x] `STOCK_BACKEND=shadow` set on Railway, redeploy triggered.
+  - [ ] **Owner verify**: Admin tab shows "Shadow" banner + 86 stock rows + zero parity mismatches.
+  - [ ] **Owner clean up** the 2 orphan Airtable rows (delete them or add Display Name + re-run backfill).
+  - [ ] **Daily watch** during shadow week — `node backend/scripts/shadow-health.js` (read-only, uses `claude_ro` DSN). Especially after Saturday — peak write volume.
+  - [ ] **Cutover criterion**: 0 unexplained mismatches across a full Saturday with >50 stock writes.
+  - [ ] **Flip**: `railway variables --service flower-studio-backend --set STOCK_BACKEND=postgres` + redeploy. Airtable Stock becomes a frozen legacy snapshot.
 - [ ] **Phase 4 — Orders + Lines + Deliveries** — design + scaffolding in progress on `feat/sql-migration-phase-4-prep`.
   - [x] Design doc: `docs/migration/phase-4-orders-design.md` (schema, transaction boundary, cutover sequencing, Wix webhook risk)
   - [x] Schema: `orders` + `order_lines` + `deliveries` tables + 0003 migration. ON DELETE CASCADE on the FKs. unique(order_id) on deliveries (one delivery per order, enforced at DB level).

--- a/backend/scripts/shadow-health.js
+++ b/backend/scripts/shadow-health.js
@@ -1,0 +1,161 @@
+// shadow-health.js — read-only daily check during the Phase 3+4
+// shadow-write windows. Reports parity_log status, audit_log activity,
+// and PG row counts so the owner can confirm at a glance that
+// shadow-write is healthy before flipping to STOCK_BACKEND=postgres
+// (and later ORDER_BACKEND=postgres).
+//
+// Connects via the claude_ro DSN — read-only, can't accidentally
+// mutate prod. Safe to run any time.
+//
+// Usage:
+//   CLAUDE_RO_URL='postgresql://claude_ro:...@shuttle.proxy.rlwy.net:28897/railway' \
+//     node scripts/shadow-health.js
+//
+//   (CLAUDE_RO_URL is in Railway: `railway variables --service Postgres | grep CLAUDE_RO`,
+//    or in the local memory file at ~/.claude/projects/.../memory/project_postgres_access.md)
+
+import pg from 'pg';
+
+const url = process.env.CLAUDE_RO_URL || process.env.DATABASE_URL;
+if (!url) {
+  console.error('[shadow-health] No DSN found. Set CLAUDE_RO_URL or DATABASE_URL.');
+  console.error('[shadow-health] CLAUDE_RO_URL lives in Railway (`railway variables --service Postgres`)');
+  console.error('[shadow-health]   or in memory at ~/.claude/projects/<project>/memory/project_postgres_access.md');
+  process.exit(1);
+}
+
+const { Pool } = pg;
+const pool = new Pool({
+  connectionString: url,
+  ssl: { rejectUnauthorized: false },
+});
+
+// ── ANSI helpers ──
+const c = {
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+  green: (s) => `\x1b[32m${s}\x1b[0m`,
+  red:   (s) => `\x1b[31m${s}\x1b[0m`,
+  amber: (s) => `\x1b[33m${s}\x1b[0m`,
+  dim:   (s) => `\x1b[90m${s}\x1b[0m`,
+  cyan:  (s) => `\x1b[36m${s}\x1b[0m`,
+};
+
+function fmtTable(rows, cols) {
+  if (rows.length === 0) return c.dim('  (none)');
+  const widths = cols.map(col => Math.max(col.length, ...rows.map(r => String(r[col] ?? '').length)));
+  const header = '  ' + cols.map((col, i) => c.dim(col.padEnd(widths[i]))).join('  ');
+  const sep    = '  ' + widths.map(w => c.dim('─'.repeat(w))).join('  ');
+  const body   = rows.map(r => '  ' + cols.map((col, i) => String(r[col] ?? '').padEnd(widths[i])).join('  '));
+  return [header, sep, ...body].join('\n');
+}
+
+console.log(c.cyan(c.bold('\n═══ Shadow-Write Health Check ═══\n')));
+console.log(`  Time:    ${new Date().toISOString()}`);
+
+// Confirm we're on the read-only role.
+const { rows: [{ user, db: dbName }] } = await pool.query(
+  `SELECT current_user AS user, current_database() AS db`,
+);
+console.log(`  Role:    ${user} on ${dbName}`);
+console.log();
+
+// ── Table row counts ──
+console.log(c.bold('Tables (active rows):'));
+const tableCounts = await Promise.all([
+  pool.query(`SELECT 'stock' AS t, COUNT(*)::int AS n, COUNT(*) FILTER (WHERE current_quantity < 0)::int AS neg FROM stock WHERE deleted_at IS NULL`),
+  pool.query(`SELECT 'orders' AS t, COUNT(*)::int AS n, NULL::int AS neg FROM orders WHERE deleted_at IS NULL`),
+  pool.query(`SELECT 'order_lines' AS t, COUNT(*)::int AS n, NULL::int AS neg FROM order_lines WHERE deleted_at IS NULL`),
+  pool.query(`SELECT 'deliveries' AS t, COUNT(*)::int AS n, NULL::int AS neg FROM deliveries WHERE deleted_at IS NULL`),
+  pool.query(`SELECT 'audit_log' AS t, COUNT(*)::int AS n, NULL::int AS neg FROM audit_log`),
+  pool.query(`SELECT 'parity_log' AS t, COUNT(*)::int AS n, NULL::int AS neg FROM parity_log`),
+]);
+const tableRows = tableCounts.map(({ rows: [r] }) => ({
+  table: r.t,
+  rows:  r.n,
+  notes: r.t === 'stock' && r.neg > 0 ? c.amber(`${r.neg} with qty < 0 (demand backlog)`) : '',
+}));
+console.log(fmtTable(tableRows, ['table', 'rows', 'notes']));
+console.log();
+
+// ── Parity status ──
+console.log(c.bold('Parity log (all-time):'));
+const { rows: parityKinds } = await pool.query(`
+  SELECT entity_type, kind, COUNT(*)::int AS n
+  FROM parity_log
+  GROUP BY entity_type, kind
+  ORDER BY entity_type, kind
+`);
+if (parityKinds.length === 0) {
+  console.log(c.green('  ✓ Zero mismatches — shadow-write is clean.'));
+} else {
+  console.log(c.red('  ⚠ Mismatches found — investigate before flipping to postgres mode:'));
+  console.log(fmtTable(parityKinds, ['entity_type', 'kind', 'n']));
+}
+console.log();
+
+// ── Recent parity events (last 5) ──
+const { rows: recentParity } = await pool.query(`
+  SELECT entity_type, entity_id, kind, field, created_at
+  FROM parity_log
+  ORDER BY created_at DESC
+  LIMIT 5
+`);
+if (recentParity.length > 0) {
+  console.log(c.bold('Latest 5 parity events:'));
+  console.log(fmtTable(recentParity.map(r => ({
+    when:    r.created_at.toISOString().slice(0, 19).replace('T', ' '),
+    entity:  r.entity_type,
+    kind:    r.kind,
+    field:   r.field || '',
+    id:      r.entity_id,
+  })), ['when', 'entity', 'kind', 'field', 'id']));
+  console.log();
+}
+
+// ── Audit activity (last 24h) ──
+console.log(c.bold('Audit activity (last 24h):'));
+const { rows: auditByEntity } = await pool.query(`
+  SELECT entity_type, action, COUNT(*)::int AS n
+  FROM audit_log
+  WHERE created_at > NOW() - INTERVAL '24 hours'
+  GROUP BY entity_type, action
+  ORDER BY entity_type, action
+`);
+console.log(fmtTable(auditByEntity, ['entity_type', 'action', 'n']));
+console.log();
+
+// ── Latest 5 audit events ──
+console.log(c.bold('Latest 5 audit events:'));
+const { rows: recentAudits } = await pool.query(`
+  SELECT entity_type, action, actor_role, actor_pin_label, diff, created_at
+  FROM audit_log
+  ORDER BY id DESC
+  LIMIT 5
+`);
+if (recentAudits.length === 0) {
+  console.log(c.dim('  (no audit rows yet — no PG-side writes have happened)'));
+} else {
+  for (const a of recentAudits) {
+    const when = a.created_at.toISOString().slice(0, 19).replace('T', ' ');
+    const actor = a.actor_pin_label ? `${a.actor_role}/${a.actor_pin_label}` : a.actor_role;
+    let summary = a.action;
+    if (a.action === 'update' && a.diff?.after) {
+      const changes = Object.entries(a.diff.after).slice(0, 2)
+        .map(([k, v]) => `${k}=${v}`).join(', ');
+      if (changes) summary = `update (${changes})`;
+    }
+    console.log(`  ${c.dim(when)}  ${actor.padEnd(16)} ${a.entity_type.padEnd(10)} ${summary}`);
+  }
+}
+console.log();
+
+// ── Quick verdict ──
+const totalParity = parityKinds.reduce((sum, r) => sum + r.n, 0);
+if (totalParity === 0) {
+  console.log(c.green(c.bold('✓ Shadow-write is healthy. No parity issues to investigate.')));
+} else {
+  console.log(c.red(c.bold(`⚠ ${totalParity} parity event(s) recorded — review before cutover.`)));
+}
+console.log();
+
+await pool.end();

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -41,6 +41,15 @@ if (missing.length > 0) {
 const app = express();
 const isProduction = process.env.NODE_ENV === 'production';
 
+// Trust the first proxy hop (Railway's reverse proxy). Without this,
+// req.ip resolves to Railway's internal IP for every request, which means
+// express-rate-limit keys EVERY caller under the same IP — one brute-force
+// would lock out all other users. Setting trust proxy = 1 tells Express to
+// honour the X-Forwarded-For header from one upstream hop (Railway), so
+// req.ip returns the real client IP. The rate limiter then keys per-client
+// as intended, and express-rate-limit stops throwing ValidationError on boot.
+app.set('trust proxy', 1);
+
 // Security headers — helmet sets sensible defaults (X-Content-Type-Options,
 // X-Frame-Options, etc.). Like adding standard safety labels to every outgoing package.
 app.use(helmet());


### PR DESCRIPTION
## Summary

Three small things, packaged together because they all came out of the Phase 3 cutover going live:

1. **fix:** `app.set('trust proxy', 1)` in `backend/src/index.js` — fixes a real security regression where `express-rate-limit` was keying all callers by Railway's proxy IP instead of the real client IP. This silences the noisy `ValidationError: ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` stacktraces that have been polluting deploy logs and making the Railway dashboard look unhealthy.
2. **chore:** `backend/scripts/shadow-health.js` — read-only CLI for the daily shadow-week health check. Connects via the `claude_ro` DSN (read-only), reports parity status + audit activity + table counts. Owner runs once a day during shadow week.
3. **docs:** `BACKLOG.md` gains a "Pick-up checklist for the next session" at the top so any future Claude session opening this repo cold can resume without rummaging through the changelog.

## The trust-proxy fix in detail

Without `app.set('trust proxy', 1)`:
- `req.ip` returns Railway's proxy IP for every request
- `express-rate-limit` uses `req.ip` as the key
- The PIN rate limit (5 attempts per 15min) is therefore SHARED across all clients
- One brute-force attempt could lock out the owner + all florists + all drivers
- AND `express-rate-limit` throws `ValidationError` on every request because it detects the X-Forwarded-For mismatch

With the fix:
- Express trusts 1 upstream hop (Railway's reverse proxy)
- `req.ip` resolves to the real client IP from X-Forwarded-For
- Rate limiter keys per-client as intended
- ValidationErrors stop, deploy logs become clean

Verified the service is currently healthy (`curl /api/health` → 200, `/api/admin/status` → `{"backends":{"stock":"shadow"}}`), so this isn't a "fix what's broken" — it's "fix the latent issue that's been making us think things might be broken."

## The shadow-health CLI

```bash
CLAUDE_RO_URL='postgresql://claude_ro:...@shuttle.proxy.rlwy.net:28897/railway' \
  node backend/scripts/shadow-health.js
```

Output:
- PG table row counts (stock / orders / lines / deliveries / audit_log / parity_log)
- Parity log status by kind (zero = clean ✓ green, anything else = ⚠ red)
- Latest 5 parity events (if any)
- Audit activity in last 24h grouped by entity + action
- Latest 5 audit events with timestamps
- One-line verdict at the bottom

Use during shadow week and right before flipping `STOCK_BACKEND=postgres` (and later `ORDER_BACKEND=postgres`).

## The BACKLOG checklist

New "Pick-up checklist for the next session" section at the top of `BACKLOG.md` — documents the live shadow-week state, the open work items ranked by what unblocks what, and a few standing investigations that now have shadow data to debug with. Designed so a fresh session can pick up cold.

## Test plan

- [x] Backend tests: 201/202 (1 pre-existing analyticsService failure)
- [x] Backend boots locally with the trust-proxy change
- [x] `shadow-health.js` runs against prod claude_ro DSN — clean output
- [ ] After merge: confirm Railway deploy logs no longer show `ERR_ERL_*` ValidationErrors

🤖 Generated with [Claude Code](https://claude.com/claude-code)