### PR TITLE
fix(wix-sync): drop Pull-side price overwrite — Airtable owns prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,49 @@ AIRTABLE_PREMADE_BOUQUET_LINES_TABLE=tbl...  # Premade Bouquet Lines table ID
 
 ---
 
+## 2026-04-28 — Wix sync: drop Pull-side price overwrite (Airtable is the price owner)
+
+`runPull()` was reverting owner-edited Airtable prices back to the stale
+Wix value, then `runPush()` (which runs second inside `runSync`) saw no
+diff and pushed nothing. Net effect: prices never synced and Airtable
+edits were silently lost — exactly what the owner reported ("WixSync
+doesn't sync prices, Pull overrides correct prices").
+
+### Root cause
+
+Commit `a44450f` (2026-04-22) added price reconciliation in `runPull`'s
+update branch with the comment "Wix is the source of truth — reconcile
+any drift on every pull." That contradicted the file header
+(`backend/src/services/wixProductSync.js:7`) which states **Airtable
+owns: prices**, and contradicted `runPush` which already pushes
+Airtable→Wix on diff.
+
+Two reconcilers pointing opposite directions on the same field, plus
+`runSync` calling Pull before Push, meant every owner edit in Airtable
+got clobbered before Push could see it.
+
+### Fix
+
+`backend/src/services/wixProductSync.js` — removed the price-overwrite
+block in `runPull`'s update branch (lines 686-694 in the previous
+revision). Price still imports on initial row creation for brand-new
+variants pulled from Wix (the create branch is unchanged). For existing
+rows, Pull leaves Price alone; Push remains the only path that touches
+Wix prices.
+
+### What to watch for
+
+- An owner price edit done **directly in the Wix Editor** will no longer
+  flow back into Airtable. That's the correct trade-off — the dashboard
+  is the canonical price-editing surface, and Push handles the other
+  direction. If the owner wants Wix-side edits to win, change the price
+  in Airtable to match.
+- After deploy, run a manual `POST /products/sync` to confirm prices
+  flow: edit one Product Config row's Price in Airtable, hit sync, check
+  Wix variant matches. Sync log row should show `Price Syncs > 0`.
+
+---
+
 ## 2026-04-28 — SQL migration Phase 4: orderRepo implementation (transactional createOrder)
 
 The headline architectural change of the entire migration ships in this

--- a/backend/src/services/wixProductSync.js
+++ b/backend/src/services/wixProductSync.js
@@ -683,15 +683,14 @@ export async function runPull() {
           const updates = {};
           if (existing['Product Name'] !== productName) updates['Product Name'] = productName;
           if (existing['Image URL'] !== imageUrl) updates['Image URL'] = imageUrl;
-          // Price: Wix is the source of truth — reconcile any drift on every pull.
-          // Without this, a price edit made on Wix never flows back to Airtable
-          // (it only imported on initial row creation). Epsilon guards against
-          // float noise in round-trip comparisons.
-          const wixPrice = Number(variantPrice) || 0;
-          const existingPrice = Number(existing['Price'] || 0);
-          if (Math.abs(existingPrice - wixPrice) > 0.01) {
-            updates['Price'] = wixPrice;
-          }
+          // Price is Airtable-owned (see file header). Push reconciles
+          // Airtable → Wix; Pull must NOT overwrite. Earlier policy
+          // (commit a44450f, 2026-04-22) treated Wix as truth here, which
+          // caused runSync (pull-then-push) to revert any owner-edited
+          // Airtable price to the stale Wix value before Push could send
+          // it — net result: prices never synced and Airtable edits were
+          // silently lost. Price still imports on initial row creation
+          // for brand-new variants pulled from Wix (see create branch above).
           // Active follows Wix "Show in online store". The earlier policy
           // treated Active as Airtable-owned, but in practice that caused
           // drift: a product re-listed on Wix stayed inactive in Airtable


### PR DESCRIPTION
## Summary
- `runPull` was reverting owner-edited Airtable prices to the stale Wix value before `runPush` could compare, so prices never reached Wix and Airtable edits were silently lost.
- Root cause: commit a44450f (2026-04-22) added price reconciliation to Pull's update branch with the comment *"Wix is the source of truth"*, contradicting the file header (`Airtable owns: prices`) and `runPush` which already syncs Airtable→Wix on diff.
- Fix removes the Pull-side price overwrite. Price still imports on initial row creation for brand-new variants. Push remains the only path that writes Wix prices.

## Trade-off
A price edit done directly in the Wix Editor will no longer back-flow into Airtable. Dashboard is now the canonical price-editing surface — owner has been editing there anyway, which is exactly why the bug surfaced.

## Test plan
- [ ] Deploy to Railway
- [ ] Edit one Product Config row's `Price` in Airtable to a new value
- [ ] Hit `POST /products/sync` from dashboard
- [ ] Verify Wix variant price now matches the new Airtable price
- [ ] Confirm `Sync Log` row shows `Price Syncs > 0`
- [ ] Re-run `POST /products/sync` immediately — `Price Syncs` should be 0 (no drift, no flapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)