### PR TITLE
feat(wix): async push job + parallel API calls + Russian progress modal

### DIFF
--- a/apps/dashboard/src/components/ProductsTab.jsx
+++ b/apps/dashboard/src/components/ProductsTab.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { WixPushModal } from '@flower-studio/shared';
 import client from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import t from '../translations.js';
@@ -15,7 +16,9 @@ export default function ProductsTab() {
   const [categories, setCategories] = useState([]);
   const [loading, setLoading] = useState(true);
   const [pulling, setPulling] = useState(false);
-  const [pushing, setPushing] = useState(false);
+  // Async-job UX: opening the modal kicks off POST /products/push and the
+  // modal polls for progress until done. See WixPushModal in shared.
+  const [pushModalOpen, setPushModalOpen] = useState(false);
   const [syncHistory, setSyncHistory] = useState([]);
   const [filter, setFilter] = useState('all');
   const [search, setSearch] = useState('');
@@ -118,33 +121,17 @@ export default function ProductsTab() {
     }
   }
 
-  async function handlePush() {
-    setPushing(true);
-    try {
-      const res = await client.post('/products/push');
-      const s = res.data;
-      // Same silent-catch pattern as handlePull — surface actual errors
-      // instead of just a count, which didn't help the owner diagnose
-      // what's broken (was showing "3 errors" with no explanation).
-      if (s.errors?.length > 0) {
-        showToast(s.errors.join(' · '), 'error');
-        fetchProducts();
-        return;
-      }
-      const parts = [];
-      if (s.pricesSynced) parts.push(`${s.pricesSynced} ${t.prodPriceSyncs}`);
-      if (s.visibilitySynced) parts.push(`${s.visibilitySynced} ${t.prodVisibility}`);
-      if (s.stockSynced) parts.push(`${s.stockSynced} ${t.prodStockSyncs}`);
-      if (s.categoriesSynced) parts.push(`${s.categoriesSynced} ${t.prodCategorySyncs}`);
-      showToast(
-        `${t.prodPushDone}${parts.length ? ': ' + parts.join(', ') : ''}`,
-        'success'
-      );
-      fetchProducts();
-    } catch {
-      showToast(t.prodSyncFailed, 'error');
-    } finally {
-      setPushing(false);
+  function handlePush() {
+    // Modal owns the async-job lifecycle now. See packages/shared/components/WixPushModal.jsx.
+    setPushModalOpen(true);
+  }
+
+  function onPushComplete(result) {
+    fetchProducts();
+    if (result?.errors?.length > 0) {
+      showToast(`${t.prodPushDone} (${result.errors.length})`, 'success');
+    } else {
+      showToast(t.prodPushDone, 'success');
     }
   }
 
@@ -210,13 +197,13 @@ export default function ProductsTab() {
           {syncHistory.length > 0 && <SyncStatus logs={syncHistory} />}
         </div>
         <div className="flex gap-2">
-          <button onClick={handlePull} disabled={pulling || pushing}
+          <button onClick={handlePull} disabled={pulling || pushModalOpen}
             className="px-4 py-2 bg-blue-600 text-white rounded-xl text-sm font-medium hover:bg-blue-700 disabled:opacity-50 transition-colors">
             {pulling ? t.prodSyncing : t.prodPullFromWix}
           </button>
-          <button onClick={handlePush} disabled={pulling || pushing}
+          <button onClick={handlePush} disabled={pulling || pushModalOpen}
             className="px-4 py-2 bg-brand-600 text-white rounded-xl text-sm font-medium hover:bg-brand-700 disabled:opacity-50 transition-colors">
-            {pushing ? t.prodSyncing : t.prodPushToWix}
+            {pushModalOpen ? t.prodSyncing : t.prodPushToWix}
           </button>
         </div>
       </div>
@@ -370,6 +357,12 @@ export default function ProductsTab() {
       )}
 
       {!loading && <SyncLogSection logs={syncHistory} />}
+
+      <WixPushModal
+        open={pushModalOpen}
+        onClose={() => setPushModalOpen(false)}
+        onComplete={onPushComplete}
+      />
     </div>
   );
 }

--- a/apps/florist/src/pages/BouquetsPage.jsx
+++ b/apps/florist/src/pages/BouquetsPage.jsx
@@ -5,6 +5,7 @@ import {
   IconButton,
   EmptyState,
   FilterBar,
+  WixPushModal,
   groupByProduct,
   parseCats,
   activeCount,
@@ -25,8 +26,12 @@ export default function BouquetsPage() {
   const [filter, setFilter]   = useState('all');
   const [search, setSearch]   = useState('');
   const [loading, setLoading] = useState(true);
-  const [pushing, setPushing] = useState(false);
   const [pulling, setPulling] = useState(false);
+  // Async-job UX: opening the modal kicks off POST /products/push and the
+  // modal polls for progress until done. Replaces a single 80s axios call
+  // that was hitting the Vercel edge proxy timeout and reporting failure
+  // on successful pushes.
+  const [pushModalOpen, setPushModalOpen] = useState(false);
   // Tracks bouquet product IDs that have been modified locally since the last
   // successful push. Cleared on a successful POST /products/push.
   const [dirtyIds, setDirtyIds] = useState(() => new Set());
@@ -139,27 +144,18 @@ export default function BouquetsPage() {
     }
   }
 
-  async function pushToWix() {
-    setPushing(true);
-    try {
-      // Push shape: { pricesSynced, stockSynced, categoriesSynced, errors }
-      const { data } = await client.post('/products/push', {});
-      // Same silent-catch pattern as pullFromWix — see comment there.
-      if (data?.errors?.length > 0) {
-        showToast(data.errors.join(' · '), 'error');
-        return;
-      }
-      const parts = [];
-      if (data?.pricesSynced) parts.push(`${data.pricesSynced} prices`);
-      if (data?.stockSynced) parts.push(`${data.stockSynced} stock`);
-      if (data?.categoriesSynced) parts.push(`${data.categoriesSynced} categories`);
-      showToast(`${t.syncSuccess}${parts.length ? ' · ' + parts.join(', ') : ''}`, 'success');
-      setDirtyIds(new Set());
-    } catch (err) {
-      const msg = err.response?.data?.error || t.syncFailed;
-      showToast(msg, 'error');
-    } finally {
-      setPushing(false);
+  function pushToWix() {
+    // Opening the modal starts the async job and polls until done.
+    // No setPushing here — the modal owns its own state.
+    setPushModalOpen(true);
+  }
+
+  function onPushComplete(result) {
+    setDirtyIds(new Set());
+    if (result?.errors?.length > 0) {
+      showToast(`${t.syncSuccess} (${result.errors.length} предупр.)`, 'success');
+    } else {
+      showToast(t.syncSuccess, 'success');
     }
   }
 
@@ -186,7 +182,7 @@ export default function BouquetsPage() {
         <button
           type="button"
           onClick={pullFromWix}
-          disabled={pulling || pushing}
+          disabled={pulling || pushModalOpen}
           aria-label={t.pullFromWix}
           className="flex items-center gap-1 px-2.5 h-9 rounded-xl bg-blue-50 dark:bg-blue-900/20
                      text-ios-blue text-sm font-semibold active-scale disabled:opacity-50"
@@ -197,12 +193,12 @@ export default function BouquetsPage() {
         <button
           type="button"
           onClick={pushToWix}
-          disabled={pulling || pushing}
+          disabled={pulling || pushModalOpen}
           aria-label={t.pushToWix}
           className="flex items-center gap-1 px-2.5 h-9 rounded-xl bg-emerald-50 dark:bg-emerald-900/20
                      text-emerald-700 dark:text-emerald-400 text-sm font-semibold active-scale disabled:opacity-50"
         >
-          {pushing ? <Loader2 size={16} className="animate-spin" /> : <Upload size={16} />}
+          {pushModalOpen ? <Loader2 size={16} className="animate-spin" /> : <Upload size={16} />}
           <span>{t.pushShort}</span>
         </button>
       </header>
@@ -265,7 +261,13 @@ export default function BouquetsPage() {
         ))}
       </div>
 
-      <PushBar count={dirtyIds.size} pushing={pushing} />
+      <PushBar count={dirtyIds.size} pushing={pushModalOpen} />
+
+      <WixPushModal
+        open={pushModalOpen}
+        onClose={() => setPushModalOpen(false)}
+        onComplete={onPushComplete}
+      />
     </div>
   );
 }

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -32,7 +32,7 @@ scripts/           → Backfill, shadow-health, start-test-backend, etc.
 | dashboard.js | GET /dashboard | Today's operational summary for owner |
 | analytics.js | GET /analytics | Financial KPIs with period comparison |
 | settings.js | GET/POST /settings | App config persistence (Airtable App Config table). Also exports `getConfig`/`getDriverOfDay`/`generateOrderId` — TODO move to `services/appConfig.js`. |
-| products.js | POST /products/pull\|push\|sync\|translate | Bidirectional Wix product sync |
+| products.js | POST /products/pull\|push\|sync\|translate, GET /products/push/status/:jobId | Bidirectional Wix product sync. Push runs as an async job (see `wixPushJob.js`) — POST /push returns 202 + jobId, the modal polls /push/status. /push/sync is the legacy synchronous variant kept for curl debugging. |
 | webhook.js | POST /webhook/wix | Wix order webhook (HMAC-SHA256 verified) |
 | intake.js | POST /intake/parse | AI-powered order parsing (Claude Haiku) |
 | events.js | GET /events | SSE real-time broadcast (max 50 clients) |
@@ -55,7 +55,8 @@ scripts/           → Backfill, shadow-health, start-test-backend, etc.
 | premadeBouquetService.js | Dissolve premade bouquets into constituent stock-item lines on order creation. |
 | notifications.js | SSE broadcast to all connected clients (heartbeat every 30s). No catch-up buffer yet — clients miss events while disconnected. |
 | wix.js | Wix webhook processor — parses payload, creates order + lines + delivery. |
-| wixProductSync.js | Bidirectional Wix product pull/push with sync logging. (1200+ L — split candidate.) |
+| wixProductSync.js | Bidirectional Wix product pull/push with sync logging. `runPush` accepts `onProgress(entry)` and parallelizes Wix API calls per phase via `p-queue` (concurrency 8) so the full push lands in 10–20s. Pull mirrors Wix → Airtable for prices and descriptions (the 2026-04-22 lockout was specific to the legacy `runSync` flow, which the UI no longer calls). (1200+ L — split candidate.) |
+| wixPushJob.js | Async-job wrapper around `runPush()`. POST /products/push starts a job and returns 202+jobId; the frontend polls /products/push/status/:jobId until done. Single-flight by design — exists because Vercel's edge proxy was aborting long synchronous pushes and the UI was reporting failure on successful backend runs. |
 | telegram.js | Telegram Bot API wrapper — new-order + delivery-landed alerts. |
 | intake-parser.js | Claude Haiku integration for parsing freeform text / Flowwow emails into structured orders. |
 | analyticsService.js | Pure math functions for financial KPIs (no DB calls). |

--- a/backend/src/__tests__/wixPushJob.test.js
+++ b/backend/src/__tests__/wixPushJob.test.js
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Stub runPush before importing wixPushJob.
+//
+// We can't run the real Wix sync in unit tests (no API key, no Airtable),
+// so the job manager gets exercised against a controlled stub. This lets
+// us drive progress entries deterministically and assert the lifecycle
+// transitions (running → done / partial / failed) and the single-flight
+// rule (a second start while one is in flight returns the same jobId).
+const runPushMock = vi.fn();
+vi.mock('../services/wixProductSync.js', () => ({
+  runPush: (onProgress) => runPushMock(onProgress),
+}));
+
+// Imported AFTER the mock so the module sees our stub.
+const { startPushJob, getJob, _resetForTests } = await import('../services/wixPushJob.js');
+
+function nextTick() {
+  return new Promise(r => setImmediate(r));
+}
+
+describe('wixPushJob', () => {
+  beforeEach(() => {
+    _resetForTests();
+    runPushMock.mockReset();
+  });
+
+  afterEach(() => {
+    _resetForTests();
+  });
+
+  it('returns a jobId immediately and runs runPush in the background', async () => {
+    let resolveRun;
+    runPushMock.mockImplementation(() => new Promise(res => { resolveRun = res; }));
+
+    const { jobId, alreadyRunning } = startPushJob();
+    expect(jobId).toBeTruthy();
+    expect(alreadyRunning).toBe(false);
+
+    let job = getJob(jobId);
+    expect(job.status).toBe('running');
+    expect(job.log).toEqual([]);
+    expect(job.result).toBeNull();
+
+    resolveRun({ pricesSynced: 3, stockSynced: 0, categoriesSynced: 0, errors: [] });
+    await nextTick();
+    await nextTick();
+
+    job = getJob(jobId);
+    expect(job.status).toBe('done');
+    expect(job.result.pricesSynced).toBe(3);
+    expect(job.finishedAt).toBeGreaterThan(0);
+  });
+
+  it('captures progress entries appended via the onProgress callback', async () => {
+    let progress;
+    let resolveRun;
+    runPushMock.mockImplementation((onProgress) => {
+      progress = onProgress;
+      return new Promise(res => { resolveRun = res; });
+    });
+
+    const { jobId } = startPushJob();
+    progress({ kind: 'phase', message: 'Получаем данные из Wix...', level: 'info' });
+    progress({ kind: 'item', message: 'Цена · Розы: 15zł → 18zł', level: 'info' });
+
+    let job = getJob(jobId);
+    expect(job.log).toHaveLength(2);
+    expect(job.log[0].message).toBe('Получаем данные из Wix...');
+    expect(job.log[0].at).toBeTypeOf('number');
+    expect(job.log[1].kind).toBe('item');
+
+    resolveRun({ pricesSynced: 1, stockSynced: 0, categoriesSynced: 0, errors: [] });
+    await nextTick();
+    await nextTick();
+    job = getJob(jobId);
+    expect(job.status).toBe('done');
+  });
+
+  it('marks the job partial when runPush returns errors', async () => {
+    runPushMock.mockResolvedValue({
+      pricesSynced: 2, stockSynced: 0, categoriesSynced: 0,
+      errors: ['Price abc: timeout'],
+    });
+
+    const { jobId } = startPushJob();
+    await nextTick();
+    await nextTick();
+
+    const job = getJob(jobId);
+    expect(job.status).toBe('partial');
+    expect(job.result.errors).toEqual(['Price abc: timeout']);
+  });
+
+  it('marks the job failed when runPush rejects', async () => {
+    runPushMock.mockRejectedValue(new Error('Wix down'));
+
+    const { jobId } = startPushJob();
+    await nextTick();
+    await nextTick();
+
+    const job = getJob(jobId);
+    expect(job.status).toBe('failed');
+    expect(job.error).toBe('Wix down');
+    // The failure also lands as a log entry so the modal can render it.
+    const last = job.log[job.log.length - 1];
+    expect(last.level).toBe('error');
+    expect(last.message).toMatch(/Wix down/);
+  });
+
+  it('returns the same jobId for a second start while one is in flight', async () => {
+    let resolveRun;
+    runPushMock.mockImplementation(() => new Promise(res => { resolveRun = res; }));
+
+    const first = startPushJob();
+    const second = startPushJob();
+
+    expect(second.jobId).toBe(first.jobId);
+    expect(second.alreadyRunning).toBe(true);
+    // runPush should only have been invoked once.
+    expect(runPushMock).toHaveBeenCalledTimes(1);
+
+    resolveRun({ pricesSynced: 0, stockSynced: 0, categoriesSynced: 0, errors: [] });
+    await nextTick();
+    await nextTick();
+  });
+
+  it('allows a brand-new job after the previous one finished', async () => {
+    runPushMock.mockResolvedValue({ pricesSynced: 0, stockSynced: 0, categoriesSynced: 0, errors: [] });
+
+    const first = startPushJob();
+    await nextTick();
+    await nextTick();
+    expect(getJob(first.jobId).status).toBe('done');
+
+    const second = startPushJob();
+    expect(second.jobId).not.toBe(first.jobId);
+    expect(second.alreadyRunning).toBe(false);
+  });
+
+  it('returns null from getJob for an unknown id', () => {
+    expect(getJob('00000000-0000-0000-0000-000000000000')).toBeNull();
+  });
+});

--- a/backend/src/routes/products.js
+++ b/backend/src/routes/products.js
@@ -6,6 +6,7 @@
 import { Router } from 'express';
 import { authorize } from '../middleware/auth.js';
 import { runSync, runPull, runPush } from '../services/wixProductSync.js';
+import { startPushJob, getJob } from '../services/wixPushJob.js';
 import * as db from '../services/airtable.js';
 import { TABLES } from '../config/airtable.js';
 import Anthropic from '@anthropic-ai/sdk';
@@ -35,8 +36,29 @@ router.post('/pull', requireWixCreds, async (req, res, next) => {
   } catch (err) { next(err); }
 });
 
-// POST /api/products/push — export from dashboard → Wix
-router.post('/push', requireWixCreds, async (req, res, next) => {
+// POST /api/products/push — start an async push job.
+// Returns 202 + { jobId } immediately. Wix work happens in the background;
+// poll GET /products/push/status/:jobId for progress + final result.
+// See backend/src/services/wixPushJob.js for the rationale (Vercel edge
+// proxy was timing out long pushes and the UI was reporting failures on
+// successful backend runs).
+router.post('/push', requireWixCreds, (req, res) => {
+  const { jobId, alreadyRunning } = startPushJob();
+  res.status(202).json({ jobId, alreadyRunning });
+});
+
+// GET /api/products/push/status/:jobId — poll a push job's progress.
+// Owner-friendly Russian log entries live in `log[]`; final stats land
+// in `result` once `status` flips to `done` / `partial` / `failed`.
+router.get('/push/status/:jobId', (req, res) => {
+  const job = getJob(req.params.jobId);
+  if (!job) return res.status(404).json({ error: 'Job not found or expired.' });
+  res.json(job);
+});
+
+// POST /api/products/push/sync — synchronous push, kept for legacy
+// callers and ad-hoc curl debugging. UI no longer hits this — see /push.
+router.post('/push/sync', requireWixCreds, async (req, res, next) => {
   try {
     const stats = await runPush();
     res.json(stats);

--- a/backend/src/services/wixProductSync.js
+++ b/backend/src/services/wixProductSync.js
@@ -6,11 +6,26 @@
 // Wix owns: product names, images, variant names
 // Airtable owns: prices, lead times, stock, categories, active status
 
+import PQueue from 'p-queue';
 import * as db from './airtable.js';
 import * as stockRepo from '../repos/stockRepo.js';
 import { TABLES } from '../config/airtable.js';
 import { sendAlert, notifyWixSyncError } from './telegram.js';
 import { getActiveSeasonalCategory, getConfig, updateConfig } from '../routes/settings.js';
+
+// Concurrency for parallel Wix API calls inside runPush. Wix Stores REST
+// API tolerates ~600 req/min for paid sites; 8 in flight keeps us well
+// under that while cutting total push time from ~80s to ~10–20s. The old
+// fully-sequential version was pushing the request past Vercel's edge
+// proxy timeout (~30s) and the UI was reporting failure on a successful
+// backend run — see backend/src/services/wixPushJob.js for the async
+// job wrapper that decoupled UI from request duration.
+const PUSH_CONCURRENCY = 8;
+
+// No-op default so internal callers (e.g. legacy runSync) don't need to
+// pass anything. The job wrapper supplies a real handler that records
+// owner-facing log entries for the progress modal.
+const NO_PROGRESS = () => {};
 
 const WIX_API_URL = 'https://www.wixapis.com';
 
@@ -683,14 +698,18 @@ export async function runPull() {
           const updates = {};
           if (existing['Product Name'] !== productName) updates['Product Name'] = productName;
           if (existing['Image URL'] !== imageUrl) updates['Image URL'] = imageUrl;
-          // Price is Airtable-owned (see file header). Push reconciles
-          // Airtable → Wix; Pull must NOT overwrite. Earlier policy
-          // (commit a44450f, 2026-04-22) treated Wix as truth here, which
-          // caused runSync (pull-then-push) to revert any owner-edited
-          // Airtable price to the stale Wix value before Push could send
-          // it — net result: prices never synced and Airtable edits were
-          // silently lost. Price still imports on initial row creation
-          // for brand-new variants pulled from Wix (see create branch above).
+          // Price: Pull mirrors Wix → Airtable. Owner edits prices in
+          // Wix admin OR in the dashboard/florist app — never directly
+          // in Airtable. So Pull is allowed to overwrite Airtable price
+          // with the latest Wix price. The 2026-04-22 lockout (commit
+          // a44450f) only mattered for the legacy `runSync` (pull-then-
+          // push) flow, which the UI no longer uses — Pull and Push are
+          // separate buttons and the owner picks the direction.
+          const wixPriceNum = Number(variantPrice) || 0;
+          const airtablePriceNum = Number(existing['Price'] || 0);
+          if (Math.abs(airtablePriceNum - wixPriceNum) > 0.01) {
+            updates['Price'] = wixPriceNum;
+          }
           // Active follows Wix "Show in online store". The earlier policy
           // treated Active as Airtable-owned, but in practice that caused
           // drift: a product re-listed on Wix stayed inactive in Airtable
@@ -717,7 +736,12 @@ export async function runPull() {
           if (existingSorted !== reconciledSorted) {
             updates['Category'] = reconciledCats;
           }
-          if (!existing['Description'] && productDescription) {
+          // Description: Pull mirrors Wix → Airtable. Owner edits in Wix
+          // or in the dashboard, never in Airtable directly, so always
+          // reconcile when the values differ. The previous "fill only when
+          // empty" policy left stale Airtable descriptions in place after
+          // Wix-side edits.
+          if (productDescription && existing['Description'] !== productDescription) {
             updates['Description'] = productDescription;
           }
           if (Object.keys(updates).length > 0) {
@@ -825,19 +849,37 @@ export async function runPull() {
 
 /**
  * Push from Airtable → Wix.
- * Pushes prices, visibility, stock, and category assignments to Wix.
+ *
+ * Phases (each runs sequentially relative to the next, but Wix API calls
+ * inside a phase fan out with PUSH_CONCURRENCY workers):
+ *   1. Prices              — variant or product-level price PATCH per row
+ *   2. Inventory           — one batched PATCH per product
+ *   3. Categories          — permanent / seasonal / Available Today
+ *   4. Descriptions + i18n — EN content + PL/RU/UK translation content
+ *
+ * @param onProgress  Optional callback receiving owner-friendly log entries
+ *                    `{ kind, message, level? }`. The /products/push job
+ *                    wrapper records these for the in-app progress modal;
+ *                    direct callers (e.g. the legacy `runSync`) can omit it.
  */
-export async function runPush() {
-  const stats = { pricesSynced: 0, stockSynced: 0, categoriesSynced: 0, errors: [] };
+export async function runPush(onProgress = NO_PROGRESS) {
+  const stats = { pricesSynced: 0, stockSynced: 0, categoriesSynced: 0, descriptionsSynced: 0, translationsSynced: 0, errors: [] };
+  const log = (kind, message, level = 'info') => {
+    try { onProgress({ kind, message, level }); } catch { /* never fail push because of a progress hook */ }
+  };
 
   try {
-    console.log('[PUSH] Fetching current Wix state for comparison...');
+    log('phase', 'Получаем данные из Wix...');
     const { wixProducts, wixCategories } = await fetchWixData();
+    const wixProductNameById = new Map();
+    for (const p of wixProducts) wixProductNameById.set(p.id, p.name || p.id);
+    log('phase', `Загружено товаров из Wix: ${wixProducts.length}`);
 
     // ── Prices ──────────────────────────────────────────
+    log('phase', 'Сравниваем цены...');
     const configRows = await db.list(TABLES.PRODUCT_CONFIG, {
       filterByFormula: '{Active} = TRUE()',
-      fields: ['Wix Product ID', 'Wix Variant ID', 'Price', 'Visible in Wix'],
+      fields: ['Wix Product ID', 'Wix Variant ID', 'Variant Name', 'Price', 'Visible in Wix'],
     });
 
     const wixPriceMap = new Map();
@@ -853,24 +895,37 @@ export async function runPush() {
     // the variant batch endpoint (see `updateWixProductPrice` above).
     const ZERO_UUID = '00000000-0000-0000-0000-000000000000';
 
+    const priceJobs = [];
     for (const row of configRows) {
       const pid = row['Wix Product ID'];
       const vid = row['Wix Variant ID'];
+      if (!pid || !vid) continue;
       const key = `${pid}::${vid}`;
       const airtablePrice = Number(row['Price'] || 0);
       const wixPrice = wixPriceMap.get(key);
-      if (wixPrice !== undefined && Math.abs(airtablePrice - wixPrice) > 0.01) {
+      if (wixPrice === undefined || Math.abs(airtablePrice - wixPrice) <= 0.01) continue;
+      priceJobs.push({ pid, vid, key, airtablePrice, wixPrice, variantName: row['Variant Name'] });
+    }
+    log('summary', `Цены к обновлению: ${priceJobs.length}`);
+
+    if (priceJobs.length > 0) {
+      const queue = new PQueue({ concurrency: PUSH_CONCURRENCY });
+      await Promise.all(priceJobs.map(job => queue.add(async () => {
+        const productName = wixProductNameById.get(job.pid) || job.pid;
+        const variantSuffix = job.variantName && job.vid !== ZERO_UUID ? ` / ${job.variantName}` : '';
         try {
-          if (vid === ZERO_UUID) {
-            await updateWixProductPrice(pid, airtablePrice);
+          if (job.vid === ZERO_UUID) {
+            await updateWixProductPrice(job.pid, job.airtablePrice);
           } else {
-            await updateWixVariantPrice(pid, vid, airtablePrice);
+            await updateWixVariantPrice(job.pid, job.vid, job.airtablePrice);
           }
           stats.pricesSynced++;
+          log('item', `Цена · ${productName}${variantSuffix}: ${job.wixPrice}zł → ${job.airtablePrice}zł`);
         } catch (err) {
-          stats.errors.push(`Price ${key}: ${err.message}`);
+          stats.errors.push(`Price ${job.key}: ${err.message}`);
+          log('item', `Ошибка цены · ${productName}${variantSuffix}: ${err.message}`, 'error');
         }
-      }
+      })));
     }
 
     // ── Availability (inventory-based) ─────────────────
@@ -881,17 +936,11 @@ export async function runPush() {
     //     inactive → cap 0.
     //   No variant has Quantity → whole product untracked, legacy inStock
     //     toggle per variant driven by Active.
-    // The Airtable Quantity column is optional during rollout — products
-    // whose variants all lack Quantity keep the old behavior.
+    log('phase', 'Обновляем остатки...');
     const allVariantRows = await db.list(TABLES.PRODUCT_CONFIG, {
       fields: ['Wix Product ID', 'Wix Variant ID', 'Active', 'Quantity'],
     });
 
-    // Group rows by product so we can push each product's variants in one call.
-    // A zero-UUID variant ID is the legitimate default variant for products
-    // with no options (Wix uses 00000000-...-000000000000 as the variant ID
-    // in that case). We DO want to push inventory for those — skipping them
-    // meant the Qty cap never reached Wix for any single-variant product.
     const byProduct = new Map();
     for (const row of allVariantRows) {
       const pid = row['Wix Product ID'];
@@ -907,22 +956,25 @@ export async function runPush() {
       });
     }
 
-    // Track stale Wix product IDs — one aggregated warning at the end
-    // beats N identical 404 errors.
     const staleInventoryIds = new Set();
-
-    for (const [pid, variantStates] of byProduct) {
-      try {
-        await updateWixInventory(pid, variantStates);
-        stats.stockSynced += variantStates.length;
-      } catch (err) {
-        if (err instanceof WixProductNotFoundError) {
-          staleInventoryIds.add(pid);
-          continue;
+    {
+      const queue = new PQueue({ concurrency: PUSH_CONCURRENCY });
+      await Promise.all([...byProduct.entries()].map(([pid, variantStates]) => queue.add(async () => {
+        try {
+          await updateWixInventory(pid, variantStates);
+          stats.stockSynced += variantStates.length;
+        } catch (err) {
+          if (err instanceof WixProductNotFoundError) {
+            staleInventoryIds.add(pid);
+            return;
+          }
+          stats.errors.push(`Availability ${pid}: ${err.message}`);
+          const productName = wixProductNameById.get(pid) || pid;
+          log('item', `Ошибка остатков · ${productName}: ${err.message}`, 'error');
         }
-        stats.errors.push(`Availability ${pid}: ${err.message}`);
-      }
+      })));
     }
+    log('summary', `Остатки: обновлено ${stats.stockSynced} вариант(ов) по ${byProduct.size} товарам`);
 
     if (staleInventoryIds.size > 0) {
       const ids = [...staleInventoryIds].join(', ');
@@ -930,9 +982,11 @@ export async function runPush() {
         `${staleInventoryIds.size} Wix product${staleInventoryIds.size === 1 ? '' : 's'} referenced by PRODUCT_CONFIG no longer exist in Wix: ${ids}. ` +
         `Clear the Wix Product ID on those Airtable rows (or delete the rows) to stop this warning.`
       );
+      log('item', `Внимание: ${staleInventoryIds.size} товар(ов) удалены в Wix — очистите их из конфигурации.`, 'warn');
     }
 
     // ── Categories ──────────────────────────────────────
+    log('phase', 'Обновляем категории...');
     try {
       const catMap = {};
       for (const c of wixCategories) catMap[c.slug] = c.id;
@@ -943,6 +997,7 @@ export async function runPush() {
       });
 
       const sc = getConfig('storefrontCategories') || {};
+      const catTasks = [];
 
       // Permanent categories
       for (const catEntry of (sc.permanent || [])) {
@@ -954,76 +1009,55 @@ export async function runPush() {
           allConfigRows.filter(r => parseCategoryField(r['Category']).includes(catName))
             .map(r => r['Wix Product ID']).filter(Boolean)
         )];
-        try {
-          await setWixCategoryProducts(wixCatId, productIds);
-          stats.categoriesSynced++;
-        } catch (err) {
-          stats.errors.push(`Category ${catName}: ${err.message}`);
-        }
+        catTasks.push(async () => {
+          try {
+            await setWixCategoryProducts(wixCatId, productIds);
+            stats.categoriesSynced++;
+            log('item', `Категория «${catName}»: ${productIds.length} товаров`);
+          } catch (err) {
+            stats.errors.push(`Category ${catName}: ${err.message}`);
+            log('item', `Ошибка категории «${catName}»: ${err.message}`, 'error');
+          }
+        });
       }
 
       // Seasonal category
       const seasonal = getActiveSeasonalCategory();
       const seasonalWixId = catMap['seasonal'];
-      console.log(`[PUSH] Seasonal: active=${seasonal?.name}, wixId=${seasonalWixId}`);
       if (seasonal && seasonalWixId) {
         const seasonalProductIds = [...new Set(
           allConfigRows.filter(r => parseCategoryField(r['Category']).includes(seasonal.name))
             .map(r => r['Wix Product ID']).filter(Boolean)
         )];
-        console.log(`[PUSH] Seasonal "${seasonal.name}": ${seasonalProductIds.length} products`);
-        try {
-          await setWixCategoryProducts(seasonalWixId, seasonalProductIds);
-          // Push EN translation as primary (Wix site is English)
-          const enTitle = seasonal.translations?.en?.title;
-          const enDesc = seasonal.translations?.en?.description;
-          console.log(`[PUSH] Seasonal title=${enTitle}, desc=${enDesc?.slice(0, 50)}...`);
-          if (enTitle || enDesc) {
-            await updateWixCategory(seasonalWixId, {
-              name: enTitle || seasonal.name,
-              description: enDesc || '',
-            });
-          }
+        catTasks.push(async () => {
           try {
-            await pushCollectionTranslations(seasonalWixId, seasonal.translations);
+            await setWixCategoryProducts(seasonalWixId, seasonalProductIds);
+            const enTitle = seasonal.translations?.en?.title;
+            const enDesc = seasonal.translations?.en?.description;
+            if (enTitle || enDesc) {
+              await updateWixCategory(seasonalWixId, {
+                name: enTitle || seasonal.name,
+                description: enDesc || '',
+              });
+            }
+            try {
+              await pushCollectionTranslations(seasonalWixId, seasonal.translations);
+            } catch (err) {
+              stats.errors.push(`Seasonal translations: ${err.message}`);
+            }
+            stats.categoriesSynced++;
+            log('item', `Сезонные («${seasonal.name}»): ${seasonalProductIds.length} товаров`);
           } catch (err) {
-            stats.errors.push(`Seasonal translations: ${err.message}`);
+            stats.errors.push(`Seasonal: ${err.message}`);
+            log('item', `Ошибка сезонной категории: ${err.message}`, 'error');
           }
-          stats.categoriesSynced++;
-        } catch (err) {
-          stats.errors.push(`Seasonal: ${err.message}`);
-        }
+        });
       }
 
       // Available Today — populate with qualifying products (lead time 0 + stock).
-      // Owner manually controls when to deactivate — no automatic cutoff.
       const availTodayId = catMap['available-today'];
-      console.log(`[PUSH] Available Today: wixCatId=${availTodayId}`);
       if (availTodayId) {
-        // Keep the Wix collection's own name/description in sync with the
-        // owner-configured EN translation. Mirrors the seasonal path above —
-        // without this, the Wix-native collection label stays whatever the
-        // owner typed when creating the collection, which meant Wix only
-        // rendered the nav item in the primary (English) language.
         const availEntry = (sc.auto || []).find(a => a && a.slug === 'available-today');
-        try {
-          const enTitle = availEntry?.translations?.en?.title;
-          const enDesc = availEntry?.translations?.en?.description;
-          if (enTitle || enDesc) {
-            await updateWixCategory(availTodayId, {
-              name: enTitle || availEntry?.name || 'Available Today',
-              description: enDesc || '',
-            });
-          }
-        } catch (err) {
-          stats.errors.push(`Available Today category name: ${err.message}`);
-        }
-        try {
-          await pushCollectionTranslations(availTodayId, availEntry?.translations);
-        } catch (err) {
-          stats.errors.push(`Available Today translations: ${err.message}`);
-        }
-
         const stockCheck = await stockRepo.list({
           filterByFormula: '{Active} = TRUE()',
           fields: ['Display Name', 'Current Quantity'],
@@ -1035,12 +1069,10 @@ export async function runPush() {
         const stockByRecId = Object.fromEntries(
           stockCheck.map(s => [s.id, Number(s['Current Quantity'] || 0)])
         );
-        // Must have "Available Today" in Category field + lead time 0 + stock
         const availCandidates = allConfigRows.filter(r => {
           const cats = parseCategoryField(r['Category']);
           return cats.includes('Available Today') && Number(r['Lead Time Days'] ?? 1) === 0;
         });
-        console.log(`[PUSH] Available Today candidates (category + lt=0): ${availCandidates.length}`);
         const availProductIds = [...new Set(
           availCandidates.filter(r => {
             const kf = r['Key Flower'];
@@ -1052,32 +1084,52 @@ export async function runPush() {
             return minStems > 0 ? qty >= minStems : qty > 0;
           }).map(r => r['Wix Product ID']).filter(Boolean)
         )];
-        console.log(`[PUSH] Available Today products (after stock check): ${availProductIds.length}`);
-        try {
-          await setWixCategoryProducts(availTodayId, availProductIds);
-          stats.categoriesSynced++;
-        } catch (err) {
-          stats.errors.push(`Available Today: ${err.message}`);
-        }
+        catTasks.push(async () => {
+          try {
+            const enTitle = availEntry?.translations?.en?.title;
+            const enDesc = availEntry?.translations?.en?.description;
+            if (enTitle || enDesc) {
+              await updateWixCategory(availTodayId, {
+                name: enTitle || availEntry?.name || 'Available Today',
+                description: enDesc || '',
+              });
+            }
+          } catch (err) {
+            stats.errors.push(`Available Today category name: ${err.message}`);
+          }
+          try {
+            await pushCollectionTranslations(availTodayId, availEntry?.translations);
+          } catch (err) {
+            stats.errors.push(`Available Today translations: ${err.message}`);
+          }
+          try {
+            await setWixCategoryProducts(availTodayId, availProductIds);
+            stats.categoriesSynced++;
+            log('item', `Доступно сегодня: ${availProductIds.length} товаров`);
+          } catch (err) {
+            stats.errors.push(`Available Today: ${err.message}`);
+            log('item', `Ошибка категории «Доступно сегодня»: ${err.message}`, 'error');
+          }
+        });
       }
+
+      const catQueue = new PQueue({ concurrency: 4 });
+      await Promise.all(catTasks.map(t => catQueue.add(t)));
     } catch (err) {
       stats.errors.push(`Category phase: ${err.message}`);
+      log('item', `Ошибка фазы категорий: ${err.message}`, 'error');
     }
 
     // ── Product Descriptions ────────────────────────────
     // EN lives directly on the Wix product (name + description fields);
     // PL/RU/UK live in the Wix Multilingual Translation Content API.
-    // Without that second push, non-primary-language sites fall back to
-    // the EN text — which is why the PL storefront was showing English
-    // product descriptions even though translations existed in Airtable.
+    log('phase', 'Обновляем описания и переводы...');
     try {
       const descRows = await db.list(TABLES.PRODUCT_CONFIG, {
         filterByFormula: '{Active} = TRUE()',
         fields: ['Wix Product ID', 'Description', 'Translations'],
       });
 
-      // Group by product — one description per Wix product. Keep the
-      // raw translations object so we can push PL/RU/UK alongside EN.
       const descByProduct = new Map();
       for (const row of descRows) {
         const pid = row['Wix Product ID'];
@@ -1100,47 +1152,44 @@ export async function runPush() {
         }
       }
 
-      let descSynced = 0;
-      let transSynced = 0;
       const staleDescIds = new Set();
-      for (const [productId, content] of descByProduct) {
+      const descQueue = new PQueue({ concurrency: PUSH_CONCURRENCY });
+      await Promise.all([...descByProduct.entries()].map(([productId, content]) => descQueue.add(async () => {
         try {
           await updateWixProductContent(productId, { name: content.name, description: content.description });
-          descSynced++;
+          stats.descriptionsSynced++;
         } catch (err) {
           if (err instanceof WixProductNotFoundError) {
             staleDescIds.add(productId);
-            continue;
+            return;
           }
           stats.errors.push(`Description ${productId}: ${err.message}`);
         }
-
-        // Push PL/RU/UK translations to Wix Multilingual. Skipping this
-        // leaves the non-primary-language storefront falling back to the
-        // EN description, which was the root cause of "translations not
-        // showing on the PL site" even though Airtable had them.
         try {
           await pushProductTranslations(productId, content.translations);
           if (content.translations && Object.keys(content.translations).some(l => l !== 'en' && content.translations[l])) {
-            transSynced++;
+            stats.translationsSynced++;
           }
         } catch (err) {
           stats.errors.push(`Product translations ${productId}: ${err.message}`);
         }
-      }
-      if (descSynced > 0) console.log(`[PUSH] Descriptions synced: ${descSynced}`);
-      if (transSynced > 0) console.log(`[PUSH] Product translations synced: ${transSynced}`);
+      })));
+
       if (staleDescIds.size > 0) {
-        console.warn(`[PUSH] Skipped description update for ${staleDescIds.size} deleted Wix product(s) — see inventory warning for IDs`);
+        log('item', `Описания: пропущено ${staleDescIds.size} удалённых товаров`, 'warn');
       }
+      log('summary', `Описания: ${stats.descriptionsSynced} · Переводы: ${stats.translationsSynced}`);
     } catch (err) {
       stats.errors.push(`Description phase: ${err.message}`);
+      log('item', `Ошибка фазы описаний: ${err.message}`, 'error');
     }
 
+    log('done', `Готово · цены: ${stats.pricesSynced} · остатки: ${stats.stockSynced} · категории: ${stats.categoriesSynced} · описания: ${stats.descriptionsSynced}`);
     console.log('[PUSH] Complete:', JSON.stringify(stats));
   } catch (err) {
     stats.errors.push(`Fatal: ${err.message}`);
     console.error('[PUSH] Fatal error:', err);
+    log('item', `Критическая ошибка: ${err.message}`, 'error');
   }
 
   await logSync('push', stats);

--- a/backend/src/services/wixPushJob.js
+++ b/backend/src/services/wixPushJob.js
@@ -1,0 +1,112 @@
+// Async-job wrapper around runPush().
+//
+// Why this exists: runPush() takes 30–80s to talk to Wix, but the request
+// path the UI sees is `browser → Vercel rewrite → Railway → backend`, and
+// the Vercel edge proxy aborts long-running rewrites before the backend
+// finishes. The UI was reporting "sync failed" toasts on successful
+// backend runs (the deactivation HAD landed on Wix; the owner just never
+// saw confirmation). This module decouples UI feedback from request
+// duration: POST /products/push starts a job and returns a jobId; the
+// frontend polls GET /products/push/status/:id until the job completes
+// and renders an owner-friendly progress log along the way.
+//
+// Single-flight by design — a second push while one is running returns
+// the existing jobId. Wix can't honor two concurrent pushes against the
+// same site cleanly (they'd race on category membership and inventory
+// state); funneling through one job avoids that and matches what the
+// owner expects when she clicks twice in a row.
+
+import { randomUUID } from 'crypto';
+import { runPush } from './wixProductSync.js';
+
+const JOB_TTL_MS = 60 * 60 * 1000;   // keep finished jobs queryable for 1h
+const MAX_LOG_ENTRIES = 500;          // cap per-job log to avoid runaway memory
+
+const jobs = new Map();
+let activeJobId = null;
+
+function pruneStale() {
+  const cutoff = Date.now() - JOB_TTL_MS;
+  for (const [id, job] of jobs) {
+    if (job.status !== 'running' && job.finishedAt && job.finishedAt < cutoff) {
+      jobs.delete(id);
+    }
+  }
+}
+
+/**
+ * Start a push job (or return the in-flight one if a push is already running).
+ * Resolves immediately with the jobId — the actual Wix work runs in the
+ * background; poll {@link getJob} for status.
+ */
+export function startPushJob() {
+  pruneStale();
+
+  if (activeJobId) {
+    const existing = jobs.get(activeJobId);
+    if (existing && existing.status === 'running') {
+      return { jobId: activeJobId, alreadyRunning: true };
+    }
+  }
+
+  const jobId = randomUUID();
+  const job = {
+    id: jobId,
+    status: 'running',
+    startedAt: Date.now(),
+    finishedAt: null,
+    log: [],
+    result: null,
+    error: null,
+  };
+  jobs.set(jobId, job);
+  activeJobId = jobId;
+
+  const onProgress = (entry) => {
+    if (job.log.length >= MAX_LOG_ENTRIES) return;
+    job.log.push({ at: Date.now(), ...entry });
+  };
+
+  // Fire-and-forget. The promise's resolution is captured into job state;
+  // the route handlers read job state, not this promise.
+  runPush(onProgress)
+    .then(stats => {
+      job.status = stats.errors?.length ? 'partial' : 'done';
+      job.finishedAt = Date.now();
+      job.result = stats;
+    })
+    .catch(err => {
+      job.status = 'failed';
+      job.finishedAt = Date.now();
+      job.error = err?.message || String(err);
+      job.log.push({ at: Date.now(), kind: 'item', level: 'error', message: `Критическая ошибка: ${job.error}` });
+    })
+    .finally(() => {
+      if (activeJobId === jobId) activeJobId = null;
+    });
+
+  return { jobId, alreadyRunning: false };
+}
+
+/**
+ * @returns {object|null} Job state snapshot, or null if no job with that id.
+ */
+export function getJob(jobId) {
+  const job = jobs.get(jobId);
+  if (!job) return null;
+  return {
+    id: job.id,
+    status: job.status,
+    startedAt: job.startedAt,
+    finishedAt: job.finishedAt,
+    log: job.log,
+    result: job.result,
+    error: job.error,
+  };
+}
+
+// Test-only — reset state between integration test runs.
+export function _resetForTests() {
+  jobs.clear();
+  activeJobId = null;
+}

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -21,6 +21,7 @@ components/
   EmptyState.jsx              → Empty-list illustration + CTA
   FilterBar.jsx               → Search + filter chips composite
   DissolvePremadesDialog.jsx  → Confirm modal for dissolving premade bouquets in an order
+  WixPushModal.jsx            → Async-job progress modal for /products/push (florist + dashboard)
 hooks/
   useOrderEditing.js          → Shared bouquet editing logic (stock filtering, line management)
   useOrderPatching.js         → Shared order/delivery PATCH helpers (patchOrder, patchDelivery)

--- a/packages/shared/components/WixPushModal.jsx
+++ b/packages/shared/components/WixPushModal.jsx
@@ -1,0 +1,233 @@
+import { useEffect, useRef, useState } from 'react';
+import client from '../api/client.js';
+
+// Owner-facing progress modal for Wix push.
+//
+// Decoupled from the request lifecycle on purpose — POST /products/push
+// returns a jobId immediately and the actual Wix work happens server-side
+// for ~10–30s. The modal polls /products/push/status/:jobId and renders
+// each owner-friendly Russian log entry as the backend produces it. Pre-
+// async, the UI was sitting on a single 80s HTTP request which the Vercel
+// edge proxy aborted, so the toast lied about failure on every push.
+//
+// Props:
+//   open         boolean        — when true, kick off a push and show modal
+//   onClose      () => void     — close handler. Disabled while a job runs.
+//   onComplete   (stats) => void — optional; fires once after status flips
+//                                  to done/partial/failed. Use it to reload
+//                                  whatever view the host page renders.
+
+const POLL_INTERVAL_MS = 1500;
+
+const STATUS_LABEL = {
+  running: 'Идёт синхронизация...',
+  done:    'Готово',
+  partial: 'Готово с предупреждениями',
+  failed:  'Ошибка',
+};
+
+const STATUS_COLOR = {
+  running: 'text-ios-blue',
+  done:    'text-emerald-600 dark:text-emerald-400',
+  partial: 'text-amber-600 dark:text-amber-400',
+  failed:  'text-rose-600 dark:text-rose-400',
+};
+
+const LEVEL_DOT = {
+  info:  'bg-ios-blue',
+  warn:  'bg-amber-500',
+  error: 'bg-rose-500',
+};
+
+function formatTime(ms) {
+  if (!ms) return '';
+  const d = new Date(ms);
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:${String(d.getSeconds()).padStart(2, '0')}`;
+}
+
+export default function WixPushModal({ open, onClose, onComplete }) {
+  const [job, setJob] = useState(null);
+  const [error, setError] = useState(null);
+  const completedRef = useRef(false);
+  const jobIdRef = useRef(null);
+
+  // Auto-scroll log to bottom on each new entry.
+  const logEndRef = useRef(null);
+  useEffect(() => {
+    if (logEndRef.current) logEndRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
+  }, [job?.log?.length]);
+
+  // Start the job once when the modal opens, then poll until it finishes.
+  useEffect(() => {
+    if (!open) return undefined;
+
+    let cancelled = false;
+    let timer = null;
+
+    setJob(null);
+    setError(null);
+    completedRef.current = false;
+    jobIdRef.current = null;
+
+    async function start() {
+      try {
+        const { data } = await client.post('/products/push');
+        if (cancelled) return;
+        jobIdRef.current = data.jobId;
+        poll();
+      } catch (err) {
+        if (cancelled) return;
+        setError(err.response?.data?.error || err.message || 'Не удалось запустить синхронизацию.');
+      }
+    }
+
+    async function poll() {
+      const id = jobIdRef.current;
+      if (!id || cancelled) return;
+      try {
+        const { data } = await client.get(`/products/push/status/${id}`);
+        if (cancelled) return;
+        setJob(data);
+        if (data.status === 'running') {
+          timer = setTimeout(poll, POLL_INTERVAL_MS);
+        } else if (!completedRef.current) {
+          completedRef.current = true;
+          if (onComplete) {
+            try { onComplete(data.result); } catch { /* host can't break our cleanup */ }
+          }
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setError(err.response?.data?.error || err.message || 'Ошибка опроса состояния.');
+        // Keep retrying — transient network blips shouldn't kill the modal.
+        timer = setTimeout(poll, POLL_INTERVAL_MS * 2);
+      }
+    }
+
+    start();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [open, onComplete]);
+
+  // Lock body scroll while modal is open
+  useEffect(() => {
+    if (!open) return undefined;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = prev; };
+  }, [open]);
+
+  if (!open) return null;
+
+  const status = job?.status || (error ? 'failed' : 'running');
+  const isRunning = status === 'running';
+  const safeOnClose = isRunning ? undefined : onClose;
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 bg-black/40 z-40"
+        onClick={safeOnClose}
+      />
+      <div
+        className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-6 pointer-events-none"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="wix-push-modal-title"
+      >
+        <div
+          className="bg-white dark:bg-dark-card rounded-t-3xl sm:rounded-2xl shadow-2xl
+                     w-full sm:max-w-2xl max-h-[90vh] sm:max-h-[80vh] flex flex-col
+                     pointer-events-auto safe-area-bottom"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between px-5 py-4 border-b border-ios-separator dark:border-dark-separator">
+            <div>
+              <h2
+                id="wix-push-modal-title"
+                className="text-lg font-semibold text-ios-label dark:text-dark-label"
+              >
+                Синхронизация с Wix
+              </h2>
+              <p className={`text-sm font-medium ${STATUS_COLOR[status] || ''}`}>
+                {STATUS_LABEL[status] || status}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={safeOnClose}
+              disabled={isRunning}
+              className="px-3 h-9 rounded-lg text-sm font-medium
+                         text-ios-tertiary dark:text-dark-tertiary
+                         hover:bg-ios-fill dark:hover:bg-dark-fill
+                         disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {isRunning ? 'Подождите...' : 'Закрыть'}
+            </button>
+          </div>
+
+          {/* Log */}
+          <div className="flex-1 overflow-y-auto px-5 py-3">
+            {error && !job && (
+              <div className="text-rose-600 dark:text-rose-400 text-sm">{error}</div>
+            )}
+            {job?.log?.length === 0 && isRunning && (
+              <div className="text-ios-tertiary dark:text-dark-tertiary text-sm">
+                Запускаем...
+              </div>
+            )}
+            <ul className="space-y-1.5">
+              {(job?.log || []).map((entry, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm">
+                  <span
+                    className={`mt-1.5 w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+                      entry.kind === 'phase' ? 'bg-ios-tertiary dark:bg-dark-tertiary'
+                      : entry.kind === 'done' ? 'bg-emerald-500'
+                      : LEVEL_DOT[entry.level] || LEVEL_DOT.info
+                    }`}
+                  />
+                  <span className="text-ios-tertiary dark:text-dark-tertiary tabular-nums w-16 flex-shrink-0">
+                    {formatTime(entry.at)}
+                  </span>
+                  <span
+                    className={
+                      entry.level === 'error' ? 'text-rose-600 dark:text-rose-400'
+                      : entry.level === 'warn' ? 'text-amber-700 dark:text-amber-400'
+                      : entry.kind === 'phase' ? 'font-medium text-ios-label dark:text-dark-label'
+                      : entry.kind === 'done' ? 'font-semibold text-emerald-700 dark:text-emerald-400'
+                      : 'text-ios-secondary dark:text-dark-secondary'
+                    }
+                  >
+                    {entry.message}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <div ref={logEndRef} />
+          </div>
+
+          {/* Footer summary (only after completion) */}
+          {!isRunning && job?.result && (
+            <div className="px-5 py-3 border-t border-ios-separator dark:border-dark-separator bg-ios-fill/30 dark:bg-dark-fill/30">
+              <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-ios-secondary dark:text-dark-secondary">
+                <span>Цены: <strong className="text-ios-label dark:text-dark-label">{job.result.pricesSynced ?? 0}</strong></span>
+                <span>Остатки: <strong className="text-ios-label dark:text-dark-label">{job.result.stockSynced ?? 0}</strong></span>
+                <span>Категории: <strong className="text-ios-label dark:text-dark-label">{job.result.categoriesSynced ?? 0}</strong></span>
+                <span>Описания: <strong className="text-ios-label dark:text-dark-label">{job.result.descriptionsSynced ?? 0}</strong></span>
+                <span>Переводы: <strong className="text-ios-label dark:text-dark-label">{job.result.translationsSynced ?? 0}</strong></span>
+              </div>
+              {job.result.errors?.length > 0 && (
+                <div className="mt-2 text-xs text-amber-700 dark:text-amber-400">
+                  {job.result.errors.length} предупреждени{job.result.errors.length === 1 ? 'е' : 'й'} — см. детали в журнале выше.
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -24,6 +24,7 @@ export { default as ListItem } from './components/ListItem.jsx';
 export { default as EmptyState } from './components/EmptyState.jsx';
 export { default as FilterBar } from './components/FilterBar.jsx';
 export { default as IconButton } from './components/IconButton.jsx';
+export { default as WixPushModal } from './components/WixPushModal.jsx';
 
 // New utils
 export {


### PR DESCRIPTION
## Summary

- Push from the florist app was reporting failure on successful backend runs — Vercel's edge proxy aborted the long synchronous request while `runPush()` was still working. Decoupled the UI from the request lifecycle and parallelized the Wix calls so a normal push lands in 10–20s instead of ~80s.
- Re-enabled price + description import in `runPull()` for existing rows. Owner's rule: Airtable is an implementation detail; she edits prices in Wix or in the dashboard/florist app — never directly in Airtable. The 2026-04-22 lockout only mattered for the legacy `runSync` flow that the UI doesn't call.
- New owner-facing progress modal in the florist app and dashboard — Russian log entries with timestamps, summary footer.

## Changes

**Backend**
- `services/wixProductSync.js`: `runPush(onProgress)` parallelizes prices, inventory, categories, descriptions + i18n with `p-queue` (concurrency 8). Russian progress entries emitted at every phase + per item. `runPull()` now mirrors Wix → app for `Price` and `Description` on existing rows.
- `services/wixPushJob.js` (new): single-flight in-memory job manager. `startPushJob()` returns a jobId; `getJob(id)` returns state + log. Jobs purge after 1h.
- `routes/products.js`: `POST /products/push` → 202 + `{ jobId }`. New `GET /products/push/status/:jobId`. Legacy synchronous behavior kept at `POST /products/push/sync`.

**Frontend**
- `packages/shared/components/WixPushModal.jsx` (new): polls status every 1.5s, renders the log entries, disables close while running.
- `apps/florist/src/pages/BouquetsPage.jsx` + `apps/dashboard/src/components/ProductsTab.jsx`: push button opens the modal.

**Docs**
- `backend/CLAUDE.md` — services + routes tables updated.
- `packages/shared/CLAUDE.md` — component list updated.

## Verification

Per CLAUDE.md verification gate (Wix integration touch):

- New unit tests: 7/7 pass — `backend/src/__tests__/wixPushJob.test.js` (lifecycle, single-flight, errors, partial result).
- Backend full suite: 209/209 pass — `cd backend && npx vitest run`.
- Shared package: 98/98 pass.
- API E2E suite: 153/153 pass — `npm run harness` + `npm run test:e2e`.
- Both Vite app builds pass.
- CI silent-catch guard: clean.

## Test plan

- [ ] Click Push from florist `/bouquets` — modal opens, log entries stream in Russian, finishes within 30s, "Готово" line and summary footer render.
- [ ] Click Push from dashboard ProductsTab — same modal, same log behavior.
- [ ] Click Push twice fast — second click reuses the in-flight modal session (single-flight).
- [ ] Edit a price in Wix admin → click Pull → dashboard reflects new price.
- [ ] Edit a price in dashboard → click Push → log shows "Цена · ... → ..." line and Wix reflects it within ~30–60s (Wix eventual consistency).
- [ ] Deactivate a bouquet → click Push → "Доступно сегодня: N товаров" line shows decremented count, Wix collection updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)