### PR TITLE
docs(claude): superpowers as default workflow + .worktrees gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ tmp_*.json
 *.backup
 C\357\200\272*
 backend/package-lock.json
+
+# Git worktrees for isolated dev sessions (per CLAUDE.md "Default Workflow Skills")
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,21 @@ These bug patterns have been found and fixed. Follow these rules to avoid reintr
 - `backend/src/routes/` — all API endpoints
 - `packages/shared/` — shared contexts, hooks, API client, utils
 
+## Default Workflow Skills (mandatory for non-trivial work)
+
+For any feature/bugfix that takes more than a one-line change, this is the default sequence. Future Claude sessions in this repo should follow it without being asked:
+
+1. **`superpowers:brainstorming`** — explore intent + design BEFORE writing code. Invoked before any plan-mode entry. Skip only if the user has already locked in scope.
+2. **`superpowers:writing-plans`** — produce a phased implementation plan saved under `docs/superpowers/plans/YYYY-MM-DD-<feature>.md`. Plans use bite-sized checkbox steps with exact code + commands, no placeholders.
+3. **`superpowers:using-git-worktrees`** — create an isolated worktree under `.worktrees/<feature>/` so the session has its own checkout, branch, and index. **Never share the main repo's working tree across two Claude sessions** — the cross-session git collisions of 2026-05-02 (stray commits, branch flips mid-task, mangled commit messages) were caused by this. Main repo (top-level checkout) stays on `master` for general operations only.
+4. **`superpowers:subagent-driven-development`** — execute plan tasks via fresh subagents with two-stage review between tasks. Keeps the main context clean and parallelises independent work.
+5. **`superpowers:test-driven-development`** — write the failing test first, then the minimal implementation. Required for backend services + shared utils per the Testing Rules section above.
+6. **`superpowers:verification-before-completion`** — run the actual verification commands (tests, builds, smoke tests) and confirm their output BEFORE claiming the work is done. Evidence beats assertion. Especially load-bearing for prod cutovers and integration changes (also see "Verification Gate" below).
+
+Skip the chain only for: typo fixes, one-line bugfixes obvious from a stack trace, dependency bumps, or doc-only PRs.
+
+If two Claude sessions are active in this repo simultaneously, **each session must operate in its own worktree** under `.worktrees/`. Use `git worktree list` before any branch operation to see who's on what.
+
 ## Workflow Rules
 - Update `CHANGELOG.md` for any schema, env, or deployment-affecting change
 - Check off completed items in `BACKLOG.md`


### PR DESCRIPTION
## Summary

- **CLAUDE.md** new section: \"Default Workflow Skills (mandatory for non-trivial work)\" — codifies the superpowers chain future sessions follow without being asked: brainstorming → writing-plans → using-git-worktrees → subagent-driven-development → test-driven-development → verification-before-completion.
- **.gitignore** adds .worktrees/ so per-session checkouts don't pollute the main repo's git status.

## Why

Today (2026-05-02) two Claude sessions ran in the same repo simultaneously and the main repo's working tree was shared between them. Symptoms:
- Branch flipped mid-task (one session checked out a different branch on the shared tree)
- Stray commit \`4aa243c\` bundled my staged changes under someone else's commit message
- A docs branch I created (\`docs/superpowers-default-workflow\` v1) ended up tracking the bouquet branch's tip instead of master because my cwd had drifted into the other session's worktree

Root cause: no enforcement that two sessions stay isolated. Fix: make worktrees the documented default, and let .gitignore handle the path so they don't show up in status.

## Test plan

- [x] CLAUDE.md renders cleanly (markdown lint)
- [x] .gitignore picks up .worktrees/ — verified by \`git status\` no longer showing the directory after this commit
- [ ] Owner read the new section and approves the skill chain

## Notes

This PR was opened from the **main repo's master branch** with both active feature branches running in their own worktrees:
- \`/Users/oliwer/Projects/flower-studio/.worktrees/cancel\` → \`feat/florist-cancel-with-return\` (PR #168)
- \`/Users/oliwer/Projects/flower-studio/.worktrees/bouquet-image-upload\` → \`feat/bouquet-image-upload\` (other session's work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)