### PR TITLE
fix: bouquet image picker offers library + files (not camera-only)

### DIFF
--- a/packages/shared/components/BouquetImageEditor.jsx
+++ b/packages/shared/components/BouquetImageEditor.jsx
@@ -109,11 +109,18 @@ export default function BouquetImageEditor({
       className="relative rounded-xl border border-gray-200 overflow-hidden focus:outline-none focus:ring-2 focus:ring-brand-400"
       onClick={() => !uploading && fileInputRef.current?.click()}
     >
+      {/*
+        No `capture` attr — owner needs the full picker (camera + photo
+        library + Files / iCloud Drive). With `capture="environment"`
+        mobile browsers jump straight to the camera and never offer the
+        library, which is the wrong default for bouquet photos that are
+        usually taken in advance and stored on the phone.
+        Clipboard paste is wired separately on the container (see onPaste).
+      */}
       <input
         ref={fileInputRef}
         type="file"
         accept="image/jpeg,image/png,image/webp"
-        capture="environment"
         className="hidden"
         data-testid="bouquet-image-file-input"
         onChange={(e) => {


### PR DESCRIPTION
## Summary
Tapping the bouquet image slot jumped straight to the camera with no way to pick from the photo library or Files.

`capture=\"environment\"` is a hint mobile browsers honor by skipping the picker entirely and going to the back camera. Bouquet photos are usually taken in advance, so camera-only is the wrong default. Drop the attribute → native iOS/Android sheet now offers Photo Library / Take Photo / Choose Files.

Clipboard paste was already working on desktop via the existing onPaste handler.

## Test plan
- [x] Shared vitest \`BouquetImageEditor.test.jsx\`: 5/5 pass
- [x] All 3 app builds green locally (florist, dashboard, delivery)
- [ ] Owner manual: florist app → tap image → picker shows library + camera + files
- [ ] Owner manual: dashboard → paste from clipboard still works
- [ ] Owner manual: dashboard → picker dialog opens on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)