### PR TITLE
fix(delivery): live-patch on order_image_changed SSE

### DIFF
--- a/apps/delivery/src/pages/DeliveryListPage.jsx
+++ b/apps/delivery/src/pages/DeliveryListPage.jsx
@@ -88,6 +88,18 @@ export default function DeliveryListPage() {
           : d
       ));
     }
+    // Per-order override set/cleared via POST/DELETE /orders/:id/image —
+    // patch the matching delivery row by orderId. Override wins over the
+    // storefront product image, so an empty string here surfaces the
+    // fallback only after a list refetch (acceptable; fetchDeliveries
+    // catches it next time).
+    if (event.type === 'order_image_changed') {
+      setDeliveries(prev => prev.map(d =>
+        d.orderId && d.orderId === event.orderId
+          ? { ...d, bouquetImageUrl: event.imageUrl || '' }
+          : d
+      ));
+    }
   });
 
   // Check for assigned stock pickups

--- a/packages/shared/components/BouquetImageEditor.jsx
+++ b/packages/shared/components/BouquetImageEditor.jsx
@@ -109,11 +109,18 @@ export default function BouquetImageEditor({
       className="relative rounded-xl border border-gray-200 overflow-hidden focus:outline-none focus:ring-2 focus:ring-brand-400"
       onClick={() => !uploading && fileInputRef.current?.click()}
     >
+      {/*
+        No `capture` attr — owner needs the full picker (camera + photo
+        library + Files / iCloud Drive). With `capture="environment"`
+        mobile browsers jump straight to the camera and never offer the
+        library, which is the wrong default for bouquet photos that are
+        usually taken in advance and stored on the phone.
+        Clipboard paste is wired separately on the container (see onPaste).
+      */}
       <input
         ref={fileInputRef}
         type="file"
         accept="image/jpeg,image/png,image/webp"
-        capture="environment"
         className="hidden"
         data-testid="bouquet-image-file-input"
         onChange={(e) => {


### PR DESCRIPTION
## Summary
- Driver app handled `product_image_changed` only — ignored `order_image_changed` (the event fired by `POST/DELETE /orders/:id/image`).
- Owner uploaded a bouquet photo from the dashboard tonight; driver stayed stale until manual refresh.
- Add a parallel `order_image_changed` handler in `DeliveryListPage.jsx` that patches `bouquetImageUrl` on every delivery whose `orderId` matches.

## Test plan
- [ ] Driver app open → owner uploads photo via dashboard `OrderDetailPanel` → driver's matching delivery card flips to the new image without refresh.
- [ ] Owner removes the photo → matching delivery card clears to empty (next list refetch picks up the storefront fallback if applicable).
- [ ] Existing `product_image_changed` flow still works (unchanged code path).

## Verification
- `cd apps/delivery && ./node_modules/.bin/vite build` → green (255.97 kB).