### PR TITLE
chore(workflow): /feature + /branches commands, SessionStart branch-audit hook

### DIFF
--- a/.claude/commands/branches.md
+++ b/.claude/commands/branches.md
@@ -1,0 +1,92 @@
+---
+description: "Branch hygiene audit + cleanup. Surfaces strays, prunes [gone] locals, unmounts merged worktrees, lists open PRs, asks owner before destructive remote actions."
+---
+
+# /branches — branch hygiene
+
+Run this whenever you suspect branch sprawl, before starting new feature work, or when the SessionStart hook flags issues. Pairs with the SessionStart hook at `.claude/hooks/branch-audit.sh` (which is read-only — surfaces state but never mutates).
+
+## What this command does
+
+Five passes, in order. Stop and report after each. Take destructive actions only with the safety rails described.
+
+### 1. Refresh + audit
+
+```bash
+git fetch --prune
+git worktree list
+git branch -vv
+gh pr list --author @me --state open --json number,title,headRefName,createdAt,updatedAt
+gh pr list --state all --limit 20 --json number,title,headRefName,state,mergedAt
+```
+
+Build a table:
+- Local branches → upstream status (tracked / `[gone]` / no upstream)
+- Worktrees → branch + whether merged into `origin/master`
+- Open PRs by current user → age + last update
+- Recent merged PRs → so you can correlate `[gone]` locals to the PR that merged
+
+### 2. Safe prune (no confirmation needed)
+
+These are reversible from reflog and pure local cleanup:
+- **Local branches with `[gone]` upstream** — `git branch -D <name>` for each. The branch's PR was merged + remote auto-deleted. Local copy is dead weight.
+- **Worktrees whose branch is fully merged into `origin/master`** — `git worktree remove <path>`, then `git branch -D <branch>` if not the active branch. Use `git merge-base --is-ancestor <branch> origin/master` to verify.
+
+Do these without asking. They never lose work.
+
+### 3. Stale branch decisions (ask owner per branch)
+
+For each local branch AND each remote branch that is:
+- More than 7 days old (per CLAUDE.md "Land or kill within 7 days")
+- More than 50 commits behind master, AND
+- Has no open PR
+
+…build a one-line summary: branch name, age, commits behind, last commit subject, whether the work is salvageable. **Ask the owner per branch:** kill (delete + reflog as recovery), salvage to BACKLOG.md (write a backlog entry referencing the sha then delete), or open a draft PR right now.
+
+Never auto-delete real feature work. The reflog protects against fat-fingering, but ask anyway — the owner may know context the audit can't see.
+
+### 4. Forbidden-prefix purge (ask once, then proceed)
+
+Per CLAUDE.md: branches starting with `claude/` are forbidden. They were a Claude Code default that turned into a graveyard of one-commit stubs. Auto-flag any local or remote branches with `claude/` prefix. Confirm once with the owner ("delete N `claude/*` branches?") then `git push origin --delete <name>` for each.
+
+### 5. Open-PR sanity check
+
+For every open PR by the current user:
+- If updated >5 days ago → flag for either landing or closing.
+- If branched from a non-master parent → flag for rebase or land of the parent first.
+- If the title or branch name matches a feature already merged in master → flag as duplicate work.
+
+Output the flags but don't act — owner triages.
+
+## Output format
+
+When done, print:
+
+```
+Branch hygiene report — YYYY-MM-DD HH:MM
+Local: N branches (M pruned this run, K kept).
+Remote: N branches (M deleted this run, K kept).
+Worktrees: N (M unmounted this run, K kept).
+Open PRs: N.
+
+Pending owner decisions:
+- <bullet list, one line each>
+
+Cache invalidated — next session's branch-audit hook will re-scan.
+```
+
+Then run `rm -f ~/.claude/cache/flower-studio-branch-audit.txt` so the SessionStart hook re-audits on next start instead of showing stale cleaned-up state.
+
+## Hard rules
+
+- **Never** delete a branch with uncommitted changes from a worktree without owner ack. Run `git status` in the worktree first.
+- **Never** delete the currently-checked-out branch.
+- **Never** force-push to delete (use `git push origin --delete <name>`).
+- **Never** close someone else's PR — only the current user's (`gh pr list --author @me`).
+- If `gh` isn't authenticated, skip the PR-side checks and report which steps were skipped.
+
+## When NOT to run
+
+- Mid-feature, on a branch with uncommitted work — finish that first.
+- During a shadow window for a constrained domain — branch ops are fine, just don't accidentally touch the constrained-domain code in this same session.
+- If the SessionStart hook reported clean state in the last hour — you have nothing to do.

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -1,0 +1,111 @@
+---
+description: "Tuned superpowers chain for flower-studio: brainstorm → plan → worktree → subagent-driven exec → finish. Cost-disciplined defaults (Sonnet executors, batched reviews, tight prompts, MVP-sized plans)."
+---
+
+# /feature — tuned superpowers for flower-studio
+
+Run the full superpowers chain with the cost-discipline rules from `CLAUDE.md` enforced as hard defaults. Use this for any feature/bugfix that takes more than a one-line change. For typo fixes, dependency bumps, or doc-only PRs, skip and edit directly.
+
+The user invoked this with `/feature <one-line description>` (or no args; ask once if missing).
+
+## Hard-coded defaults (do not deviate without owner sign-off)
+
+These override the generic superpowers skill defaults. They exist to keep a feature inside one 5h Opus window instead of two.
+
+### Model selection per subagent role
+
+When spawning subagents via the `Agent` tool, **pass `model` explicitly**:
+
+| Role | Model | Why |
+|------|-------|-----|
+| `code-architect` / `writing-plans` driver / brainstorming partner | `opus` | Reasoning-heavy. Bad designs cost more than the model premium. |
+| `code-reviewer` (final pass + phase-boundary passes) | `opus` | Catches the bugs that ship. |
+| `systematic-debugging` driver | `opus` | Root-cause work. |
+| Implementer subagent (executes a written plan task) | `sonnet` | ~5× cheaper, adequate for "follow these steps + run these commands". |
+| Spec-compliance reviewer | `sonnet` | Mechanical diff vs. plan. |
+| Code-quality reviewer (between phases, not per task) | `opus` | The one place quality reviews actually pay off. |
+| `Explore` agent (greps, file lookups) | inherit (defaults to `sonnet`) | Fine. Don't override. |
+
+**Never default subagents to Opus.** That's the single biggest waste lever from the bouquet-image-upload burn (2× 5h Opus windows for one feature).
+
+### Review cadence: phase boundaries, not per task
+
+The default `subagent-driven-development` skill spec runs spec-reviewer + code-quality-reviewer **after every task**. For a 17-task plan that's ~34 review subagents, each re-reading CLAUDE.md + plan + spec.
+
+**Override:** group tasks into phases of 3–5. Run spec-compliance review **after each task** (cheap, Sonnet). Run code-quality review **only at phase boundaries** (Opus, expensive). Final code-reviewer pass over the whole branch diff before PR.
+
+**Exception — keep per-task code-quality review** when the task touches a Known Pitfall area from `CLAUDE.md`:
+- Status workflows (`backend/src/constants/statuses.js`, any `*Service.js` state machine)
+- Stock math (`packages/shared/utils/stockMath.js`, `StockItem.jsx`, `StockTab.jsx`)
+- Cancel-with-return (three lockstep files in CLAUDE.md Known Pitfalls #7)
+- Wix sync / webhook (`backend/src/services/wix*.js`, `backend/src/routes/wix*.js`)
+- Shadow-window writes (anything routed through `stockRepo` / `orderRepo` while a `*_BACKEND` flag is at `shadow`)
+
+### Pre-trim subagent prompts
+
+Don't paste the full plan into every executor subagent. The plan exists on disk under `docs/superpowers/plans/`. Each implementer gets:
+- The single task's section (verbatim, including its checklist)
+- The plan path so the subagent can read more if it needs to
+- The 3–5 file paths that task touches
+- The spec excerpt that constrains the task (1–2 paragraphs, not the whole spec)
+- Pointer to `CLAUDE.md` for repo conventions (subagent reads automatically)
+
+That's it. No prior tasks, no future tasks, no chat history.
+
+### Right-size plans
+
+Hard limits before starting `subagent-driven-development`:
+- ≤ 15 tasks
+- ≤ 1500 lines of plan markdown
+- Each task = one commit's worth (≤ ~300 LOC, ≤ 2 files in most cases)
+
+If `writing-plans` produces something larger, **split**: land an MVP first (≤ 8 tasks), file follow-up plans for the rest. The 2300-line bouquet-image-upload plan was a smell that cost a full Opus window.
+
+### Skip TDD red phase for low-signal task types
+
+TDD red/green stays mandatory for: new backend services, new shared utils, new shared hooks, new repos, anything in `Known Pitfalls`.
+
+**Skip the formal red phase** (write the test alongside or after instead) for:
+- Pure UI wiring (importing an existing shared component into a page)
+- CSS / Tailwind tweaks
+- Copy / translation changes (`packages/shared/translations.js`)
+- Doc-only edits
+- Simple route handlers that compose existing services with no new logic
+
+Verification via `superpowers:verification-before-completion` stays mandatory regardless.
+
+### Worktree mandatory
+
+If two Claude sessions might run in this repo, create a worktree under `.worktrees/<feature>/` via `superpowers:using-git-worktrees`. The cross-session git collisions of 2026-05-02 (stray commits, branch flips mid-task, mangled commit messages) were caused by skipping this.
+
+### Pre-PR verification gate
+
+Before announcing the PR is ready, run the check matrix from `CLAUDE.md` § "Pre-PR Verification". Specifically:
+1. Backend changes → `cd backend && npx vitest run` + `npm run harness &` then `npm run test:e2e`
+2. Shared changes → `cd packages/shared && ../../backend/node_modules/.bin/vitest run` AND build all three apps (`apps/florist`, `apps/dashboard`, `apps/delivery`)
+3. Single-app frontend changes → build that app, plus any other app touching files you changed in `packages/shared/`
+
+Quote the actual output. No "tests pass" claims without the green output in the conversation.
+
+## Sequence
+
+0. **Branch hygiene gate** — before anything else, run `BRANCH_AUDIT_FRESH=1 bash .claude/hooks/branch-audit.sh` (or invoke `/branches` for an interactive audit). If the audit reports >2 stale branches >7d old without an open PR, OR any open PR by the current user that hasn't been touched in >5 days, **stop and resolve those first**. Land them, close them, or salvage to BACKLOG. The "pile new work onto whatever branch is checked out" trap that produced the May 2026 branch graveyard happens because new features get started while old ones are still half-shipped. Don't add to the pile.
+1. **`superpowers:brainstorming`** — explore intent + design. Skip if the user's prompt to `/feature` already pins scope down to file-level decisions.
+2. **`superpowers:writing-plans`** — write the plan to `docs/superpowers/plans/YYYY-MM-DD-<feature>.md`. Enforce the right-size limits above. If the plan exceeds them, propose an MVP split before continuing.
+3. **`superpowers:using-git-worktrees`** — `.worktrees/<feature>/` with branch `feat/<feature>` (or `fix/`, `chore/`, etc. per `CLAUDE.md`).
+4. **`superpowers:subagent-driven-development`** — execute with the model + review-cadence overrides above. Use phase-boundary reviews; per-task only for Known-Pitfall tasks.
+5. **`superpowers:verification-before-completion`** — run the check matrix, paste output.
+6. **`superpowers:finishing-a-development-branch`** — propose merge / PR / cleanup. PR description must name the verification path per `CLAUDE.md` § "Verification Gate".
+
+## When to bail to a lighter flow
+
+If after `brainstorming` it's clear the work is:
+- A single-file copy / Tailwind / translation change → drop the chain. Just edit + verify + commit.
+- A bug obvious from a stack trace → skip to `superpowers:systematic-debugging`, then edit + verify + commit. No plan, no worktree.
+- 1–3 file mechanical refactor → use `feature-dev:feature-dev` (single guided pass, no subagent fanout) instead of this command.
+
+Tell the user explicitly: "This looks lighter than `/feature` warrants — proposing X instead."
+
+## Cost target
+
+A medium feature (5–15 files, no schema change, no shadow-window write) should fit in **one** 5h Opus window when this command's defaults are followed. If two windows look likely, the plan is too big — split it.

--- a/.claude/hooks/branch-audit.sh
+++ b/.claude/hooks/branch-audit.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# SessionStart hook — surfaces branch hygiene issues at the start of every
+# Claude Code session so the user (and Claude) can see what's accumulating
+# before starting new work.
+#
+# Outputs nothing if state is clean. If issues are found, emits a JSON
+# additionalContext payload that Claude Code injects into the session.
+#
+# Triggers on: any local branch with `[gone]` upstream, any worktree whose
+# branch is merged or gone, any open PR by the current user, any local
+# branch >7 days old without an open PR. Cached for 1h to avoid network
+# overhead on rapid session restarts.
+#
+# Cache: ~/.claude/cache/flower-studio-branch-audit.txt
+# Bypass cache: `BRANCH_AUDIT_FRESH=1` in env.
+#
+# Repo-relative — only runs if invoked from the flower-studio repo.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT" 2>/dev/null || exit 0
+
+# Only run for flower-studio repo (cheap guard against accidental global use)
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+if ! git remote get-url origin 2>/dev/null | grep -q "flower-studio"; then
+  exit 0
+fi
+
+CACHE_DIR="${HOME}/.claude/cache"
+CACHE_FILE="${CACHE_DIR}/flower-studio-branch-audit.txt"
+mkdir -p "$CACHE_DIR"
+
+# Use cache if <1h old and not bypassed
+if [[ "${BRANCH_AUDIT_FRESH:-0}" != "1" ]] && [[ -f "$CACHE_FILE" ]]; then
+  AGE=$(( $(date +%s) - $(stat -f %m "$CACHE_FILE" 2>/dev/null || stat -c %Y "$CACHE_FILE" 2>/dev/null || echo 0) ))
+  if [[ $AGE -lt 3600 ]]; then
+    cat "$CACHE_FILE"
+    exit 0
+  fi
+fi
+
+ISSUES=()
+
+# 1. Local branches with `[gone]` upstream (PR merged, remote deleted)
+git fetch --prune --quiet 2>/dev/null || true
+GONE_BRANCHES=$(git branch -vv 2>/dev/null | awk '/: gone\]/ {print $1}' | sed 's/^[*+]//' | tr -d ' ')
+if [[ -n "$GONE_BRANCHES" ]]; then
+  COUNT=$(echo "$GONE_BRANCHES" | wc -l | tr -d ' ')
+  ISSUES+=("$COUNT local branch(es) with deleted upstream — run \`/branches\` to prune: $(echo $GONE_BRANCHES | tr '\n' ' ')")
+fi
+
+# 2. Worktrees whose branch is gone or merged into master
+WORKTREE_ISSUES=()
+while IFS= read -r line; do
+  WT_PATH=$(echo "$line" | awk '{print $1}')
+  WT_BRANCH=$(echo "$line" | grep -oE '\[[^]]+\]' | tr -d '[]' || echo "")
+  [[ "$WT_PATH" == "$REPO_ROOT" ]] && continue
+  [[ -z "$WT_BRANCH" ]] && continue
+  # Is the branch merged into master?
+  if git merge-base --is-ancestor "$WT_BRANCH" origin/master 2>/dev/null; then
+    WORKTREE_ISSUES+=("$WT_PATH (branch $WT_BRANCH already in master)")
+  fi
+done < <(git worktree list)
+if [[ ${#WORKTREE_ISSUES[@]} -gt 0 ]]; then
+  ISSUES+=("${#WORKTREE_ISSUES[@]} worktree(s) with merged branches — should be unmounted: ${WORKTREE_ISSUES[*]}")
+fi
+
+# 3. Open PRs by current user (informational, not "issue" but worth surfacing)
+OPEN_PRS=""
+if command -v gh >/dev/null 2>&1; then
+  OPEN_PRS=$(gh pr list --author @me --state open --json number,title,headRefName --jq '.[] | "#\(.number) \(.title) [\(.headRefName)]"' 2>/dev/null || echo "")
+fi
+
+# 4. Local branches with no upstream and last commit >7 days ago (forgotten work)
+NOW_EPOCH=$(date +%s)
+SEVEN_DAYS_AGO=$(( NOW_EPOCH - 7*86400 ))
+STALE_BRANCHES=()
+while IFS= read -r b; do
+  [[ "$b" == "master" ]] && continue
+  [[ -z "$b" ]] && continue
+  # Skip branches that already have an upstream tracked
+  if git rev-parse --abbrev-ref --symbolic-full-name "$b@{u}" >/dev/null 2>&1; then
+    continue
+  fi
+  COMMIT_EPOCH=$(git log -1 --format=%ct "$b" 2>/dev/null || echo 0)
+  if [[ $COMMIT_EPOCH -lt $SEVEN_DAYS_AGO ]] && [[ $COMMIT_EPOCH -gt 0 ]]; then
+    AGE_DAYS=$(( (NOW_EPOCH - COMMIT_EPOCH) / 86400 ))
+    STALE_BRANCHES+=("$b (${AGE_DAYS}d, no upstream)")
+  fi
+done < <(git for-each-ref --format='%(refname:short)' refs/heads/)
+if [[ ${#STALE_BRANCHES[@]} -gt 0 ]]; then
+  ISSUES+=("${#STALE_BRANCHES[@]} local branch(es) >7d old without upstream (per CLAUDE.md \"Land or kill within 7 days\"): ${STALE_BRANCHES[*]}")
+fi
+
+# Build output
+if [[ ${#ISSUES[@]} -eq 0 ]] && [[ -z "$OPEN_PRS" ]]; then
+  # Clean state — empty output, write empty cache
+  : > "$CACHE_FILE"
+  exit 0
+fi
+
+# Build context block
+CONTEXT="Branch hygiene audit (cached 1h, bypass with BRANCH_AUDIT_FRESH=1):"
+CONTEXT+=$'\n'
+
+if [[ ${#ISSUES[@]} -gt 0 ]]; then
+  for issue in "${ISSUES[@]}"; do
+    CONTEXT+="- [!] $issue"$'\n'
+  done
+fi
+
+if [[ -n "$OPEN_PRS" ]]; then
+  CONTEXT+=$'\n'"Your open PRs:"$'\n'
+  while IFS= read -r pr; do
+    CONTEXT+="  $pr"$'\n'
+  done <<< "$OPEN_PRS"
+fi
+
+CONTEXT+=$'\n'"Run \`/branches\` to clean up. CLAUDE.md rule: land or kill within 7 days. Per-feature work goes on its own branch — do not pile new features onto an open PR's branch."
+
+# Emit JSON for Claude Code SessionStart hook protocol
+JSON_PAYLOAD=$(cat <<EOF
+{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": $(printf '%s' "$CONTEXT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' 2>/dev/null || node -e 'process.stdout.write(JSON.stringify(require("fs").readFileSync(0,"utf8")))')}}
+EOF
+)
+
+echo "$JSON_PAYLOAD" | tee "$CACHE_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "shell": "bash",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/branch-audit.sh\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,18 @@ dist/
 .DS_Store
 *.log
 
-# Claude Code local config (machine-specific, not for git)
+# Claude Code local config
+# Tracked (repo workflow discipline — must sync across clones):
+#   .claude/settings.json     — project hooks (SessionStart branch audit, etc)
+#   .claude/commands/         — slash commands (/feature, /branches, ...)
+#   .claude/hooks/            — hook scripts invoked by settings.json
+# Ignored (machine-local):
 .claude/settings.local.json
 .claude/agents/
-.claude/commands/
 .claude/plans/
+.claude/scheduled_tasks.lock
+.claude/cache/
+.claude/commands/.local/
 
 # Temp files
 tmp/
@@ -21,3 +28,6 @@ backend/package-lock.json
 
 # Git worktrees for isolated dev sessions (per CLAUDE.md "Default Workflow Skills")
 .worktrees/
+
+# Airtable / database backups — too large + sensitive for git
+backups/

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -361,19 +361,27 @@ Branch counts: **local 45 → 9**, **remote ~60 → 13**. Master fast-forwarded
 `wip/scratch-2026-04-27`, `chore/migration-tooling`, `docs/audit-2026-04-07`).
 Worktree count: 11 → 0. Items still requiring an owner decision:
 
-- [ ] **Open PR for `feat/stock-ledger`** — full Stock Ledger feature
-  (append-only event log on every `Current Quantity` change). Branch is
-  pushed and PR-ready. Includes the owner-action checklist: create the
-  Stock Ledger Airtable table per the field list in `CHANGELOG.md`,
-  set `AIRTABLE_STOCK_LEDGER_TABLE` on Railway, restart backend.
+- [ ] **Stock Ledger / traceability** (salvaged from `feat/stock-ledger`,
+  branch killed 2026-05-04 — recoverable from reflog at sha `a76c6cb`) —
+  goal is traceability of every `Current Quantity` change. The Airtable
+  append-only-table approach (Stock Ledger table + `AIRTABLE_STOCK_LEDGER_TABLE`
+  env var) was the pre-Postgres design. **Likely obsoleted by the
+  Postgres cutover** — once orders + stock are on PG, query-based history
+  via `stock_movements` / per-row audit columns is the natural shape and
+  removes the dual-write rate-limit overhead. **Decision to re-take after
+  Phase 4 cutover completes:** if PG schema gives us the traceability
+  natively, archive this. If still missing, re-cut from current master
+  rather than rebasing the old branch (was 33 commits behind).
 
-- [ ] **Decide on `feat/florist-cleanup-phase-a`** — 2 unmerged real
-  fixes that never got PR'd (verified 2026-04-27): (a) `7ba180f` —
-  silence Available Today reminders by default behind an env-var gate;
-  (b) `2826b19` — persist `cutoffReminderLastDate` to App Config so
-  redeploys after 18:00 don't re-fire the reminder. Master still has
-  the old in-memory `cutoffReminderSentDate = null`. Either PR these
-  or explicitly archive.
+- [ ] **Available Today reminder fixes** (salvaged from
+  `feat/florist-cleanup-phase-a`, branch killed 2026-05-04 — recoverable
+  from reflog at sha `7ba180f`) — 2 fixes still unmerged: (a) silence
+  Available Today reminders by default behind an env-var gate; (b)
+  persist `cutoffReminderLastDate` to App Config so redeploys after 18:00
+  don't re-fire the reminder. Master still has the old in-memory
+  `cutoffReminderSentDate = null`. Re-cut from current master when picked
+  up; the original branch was 76 commits behind so a rebase is more work
+  than a re-do.
 
 - [ ] **Decide on `wip/scratch-2026-04-27`** — two orphan drafts saved
   here so they're not lost: `apps/florist/src/pages/ReconciliationPage.jsx`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,10 @@ These bug patterns have been found and fixed. Follow these rules to avoid reintr
 
 ## Default Workflow Skills (mandatory for non-trivial work)
 
+**Canonical entry point: `/feature`.** The `.claude/commands/feature.md` command bundles the chain below with the cost-discipline overrides from this file (Sonnet executors, batched reviews, tight subagent prompts, MVP-sized plans, TDD red-phase exemptions). Use `/feature <one-line description>` instead of invoking the skills one-by-one — the command exists specifically so future sessions don't re-derive the discipline. The manual chain below is documented for cases where `/feature` is overkill or where you need to deviate.
+
+**Branch hygiene gate.** The SessionStart hook at `.claude/hooks/branch-audit.sh` runs at every session start and surfaces local branches with `[gone]` upstream, finished worktrees, open PRs by the current user, and local branches >7d old without an upstream. If the hook flags issues, run `/branches` to clean up before starting new work — the May 2026 branch graveyard happened because new features were piled onto whatever branch was checked out instead of landing the prior work first. `/feature` enforces this gate at step 0; if you skip `/feature` for a quick fix, you can still hit it manually with `/branches`. The hook is read-only (never mutates); only `/branches` and `/feature` take destructive action, and only with the safety rails described in those commands.
+
 For any feature/bugfix that takes more than a one-line change, this is the default sequence. Future Claude sessions in this repo should follow it without being asked:
 
 1. **`superpowers:brainstorming`** — explore intent + design BEFORE writing code. Invoked before any plan-mode entry. Skip only if the user has already locked in scope.


### PR DESCRIPTION
## Summary
- New `/feature` slash command bundling the superpowers chain with cost-discipline overrides from CLAUDE.md (Sonnet executors, batched reviews, MVP-sized plans, TDD red-phase exemptions). Replaces ad-hoc invocation of the chain's individual skills.
- New `/branches` slash command + read-only SessionStart hook that audits branch hygiene at every session start. Prevents the branch-graveyard pattern that produced 5+ stray branches over the May 2026 sprint.
- BACKLOG.md salvage entries updated for `feat/florist-cleanup-phase-a` and `feat/stock-ledger`; both remote branches will be deleted in a follow-up after owner ack.
- .gitignore reorganised: `.claude/{commands,hooks,settings.json}` are now tracked (workflow discipline syncs across clones), `{agents,plans,cache,scheduled_tasks.lock,settings.local.json,commands/.local}` stay local. `backups/` added to ignore.

## How it works
1. Every session start triggers `.claude/hooks/branch-audit.sh` (cached 1h). If local has `[gone]` branches, finished worktrees, stale local branches >7d old without upstream, or open PRs by the user, it injects an `additionalContext` block into the session so Claude (and the user) sees the state immediately.
2. If anything's flagged → run `/branches` for an interactive audit + cleanup.
3. `/feature` step 0 enforces the same gate before starting new work — blocks new feature work if there's >2 stale branches without PRs.

## Test plan
- [x] Hook runs silently on a clean repo (verified: empty output, exit 0)
- [x] Hook detects a `[gone]` upstream branch and emits properly-shaped JSON `hookSpecificOutput.additionalContext` (verified with a simulated tracking ref)
- [ ] Owner: open a fresh terminal, start a new Claude Code session in this repo, confirm no branch warnings on a clean state
- [ ] Owner: deliberately leave a stale branch around, restart session, confirm the hook surfaces it
- [ ] Owner: invoke `/branches` and confirm it audits + offers cleanup
- [ ] Owner: invoke `/feature <some-tiny-task>` and confirm step 0 (branch hygiene gate) runs

## Verification path
Doc + workflow tooling only. No backend, frontend, or shared-package code changed → CLAUDE.md "Pre-PR Verification" matrix doesn't apply. CI on this PR is essentially a no-op smoke test that the workflow runs.

## Follow-ups (not in this PR)
- Owner ack required to remote-delete: `claude/flower-studio-claude-integration-IMS2N` (forbidden prefix, 209 commits behind), `docs/audit-2026-04-07` (content already in master via #171), `feat/florist-cleanup-phase-a` (salvaged to BACKLOG), `feat/stock-ledger` (salvaged to BACKLOG, possibly obsoleted by PG cutover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)