### PR TITLE
fix(deploy): auto-apply PG migrations on release + boot

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "node --env-file=.env src/db/migrate.js",
+    "db:migrate:prod": "node src/db/migrate.js",
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {

--- a/backend/src/db/index.js
+++ b/backend/src/db/index.js
@@ -24,6 +24,9 @@
 
 import pg from 'pg';
 import { drizzle as drizzlePg } from 'drizzle-orm/node-postgres';
+import { migrate as migratePg } from 'drizzle-orm/node-postgres/migrator';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 import * as schema from './schema.js';
 
 // Drizzle returns `bigserial` columns (audit_log.id, parity_log.id) as JS
@@ -143,6 +146,25 @@ export async function connectPostgres() {
     console.log(`[PG] Connected: ${rows[0].v}`);
   } finally {
     client.release();
+  }
+
+  // Apply pending migrations on boot. Primary path is railway.toml's
+  // preDeployCommand; this is the fallback for manual restarts and for any
+  // environment that boots without going through Railway's release pipeline.
+  // Drizzle's migrator takes a Postgres advisory lock so concurrent replicas
+  // serialize safely — only one applies, the rest see no-op.
+  if (process.env.PG_AUTO_MIGRATE === 'false') {
+    console.log('[PG] PG_AUTO_MIGRATE=false — skipping boot-time migrate.');
+    return;
+  }
+  try {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const migrationsFolder = join(__dirname, 'migrations');
+    await migratePg(db, { migrationsFolder });
+    console.log('[PG] Migrations up to date.');
+  } catch (err) {
+    console.error('[PG] Migration failed on boot:', err);
+    throw err;
   }
 }
 

--- a/railway.toml
+++ b/railway.toml
@@ -2,6 +2,13 @@
 builder = "NIXPACKS"
 
 [deploy]
+# Pre-deploy runs once per release before Railway swaps in the new container.
+# Applies any pending Drizzle migrations against the prod PG. Idempotent — Drizzle's
+# __drizzle_migrations journal skips already-applied files, and the migrator takes
+# an advisory lock so concurrent boots are safe. Boot also retries via
+# connectPostgres() in db/index.js as a belt-and-suspenders fallback (e.g. for
+# manual restarts that bypass the release pipeline).
+preDeployCommand = "npm --prefix backend run db:migrate:prod"
 startCommand = "node src/index.js"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary
- Today's outage: dashboard could not create orders. Root cause was migration `0005_orders_image_url.sql` (shipped in 26fbd58) never reaching prod PG — every order query then 500'd on `column \"image_url\" does not exist`. Hand-applied at ~10:05 GMT+2; this PR makes it impossible to recur.
- Adds a Railway `preDeployCommand` that runs `npm run db:migrate:prod` once per release before the new container takes traffic.
- Adds a fallback `migrate()` call in `connectPostgres()` for any boot that bypasses the release pipeline (manual restarts, bare `node src/index.js`).
- Both paths are idempotent — Drizzle's `__drizzle_migrations` journal short-circuits already-applied files; the migrator's advisory lock serialises concurrent replicas.

## Why two paths
Belt + suspenders. `preDeployCommand` is the canonical path on every Railway deploy. The boot-time fallback covers the case where the container is restarted via the dashboard, scaled up, or run outside Railway entirely. `PG_AUTO_MIGRATE=false` disables the boot path if we ever need it (e.g. a controlled rollback that must NOT auto-apply a new migration).

## Test plan
- [x] `cd backend && npx vitest run` — 254 / 254 pass
- [x] Pglite + no-DSN paths early-return before the new block — confirmed in diff; harness unaffected
- [ ] Owner approval before merge — first deploy after merge will exercise `preDeployCommand` against prod for the first time
- [ ] Post-merge: confirm Railway deploy logs show `[PG] Migrations applied.` then `[PG] Migrations up to date.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)