### PR TITLE
fix(premade): route stock writes through stockRepo post-cutover

### DIFF
--- a/backend/src/__tests__/premadeBouquetService.integration.test.js
+++ b/backend/src/__tests__/premadeBouquetService.integration.test.js
@@ -1,0 +1,171 @@
+// premadeBouquetService integration tests — exercise the stock-adjustment
+// path against a real Postgres (via pglite) to prove writes land in PG, not
+// Airtable. Backstops the 2026-05-04 bug where return-to-stock incremented
+// Airtable (frozen post-cutover) while the dashboard read from PG.
+//
+// Premade bouquet records themselves still live on Airtable (no PG migration
+// for that table yet), so those calls remain mocked. Only the stock side is
+// real-SQL.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import { stock } from '../db/schema.js';
+import { eq } from 'drizzle-orm';
+
+const dbHolder = { db: null };
+
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  isPostgresConfigured: true,
+  pool: null,
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+// Airtable layer — premade bouquet table operations stay on Airtable; only
+// stub deleteRecord + getById since those are the only premade-side calls
+// the return-to-stock flow makes.
+vi.mock('../services/airtable.js', () => ({
+  create: vi.fn(),
+  update: vi.fn(),
+  deleteRecord: vi.fn().mockResolvedValue({ deleted: true }),
+  getById: vi.fn(),
+  list: vi.fn(),
+  atomicStockAdjust: vi.fn(),
+}));
+
+vi.mock('../config/airtable.js', () => ({
+  default: {},
+  TABLES: {
+    PREMADE_BOUQUETS: 'tblPremadeBouquets',
+    PREMADE_BOUQUET_LINES: 'tblPremadeBouquetLines',
+    STOCK: 'tblStock',
+  },
+}));
+
+vi.mock('../utils/batchQuery.js', () => ({ listByIds: vi.fn() }));
+vi.mock('../services/notifications.js', () => ({ broadcast: vi.fn() }));
+vi.mock('../services/orderService.js', () => ({
+  autoMatchStock: vi.fn().mockResolvedValue(0),
+  createOrder: vi.fn(),
+}));
+
+import * as airtable from '../services/airtable.js';
+import { listByIds } from '../utils/batchQuery.js';
+import * as stockRepo from '../repos/stockRepo.js';
+import {
+  returnPremadeBouquetToStock,
+  createPremadeBouquet,
+} from '../services/premadeBouquetService.js';
+
+let harness;
+
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+  vi.clearAllMocks();
+  airtable.deleteRecord.mockResolvedValue({ deleted: true });
+  stockRepo._setMode('postgres');
+});
+
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+async function seedStockRow(displayName, qty) {
+  const [row] = await harness.db.insert(stock).values({
+    airtableId: `recStock_${displayName}`,
+    displayName,
+    category: 'Test',
+    currentQuantity: qty,
+    currentCostPrice: '1',
+    currentSellPrice: '5',
+  }).returning();
+  return row;
+}
+
+describe('returnPremadeBouquetToStock — postgres mode (regression for 2026-05-04 bug)', () => {
+  it('increments PG stock quantities, not Airtable', async () => {
+    // Seed two stock rows in PG with the qty AFTER the premade was created
+    // (i.e. already deducted by 3 and 2 stems respectively).
+    const rose = await seedStockRow('Rose', 7);        // started at 10, 3 in bouquet
+    const euca = await seedStockRow('Eucalyptus', 8);  // started at 10, 2 in bouquet
+
+    airtable.getById.mockResolvedValue({
+      id: 'recBouquet1',
+      Name: 'Spring Pink',
+      Lines: ['recLine1', 'recLine2'],
+    });
+    listByIds.mockResolvedValue([
+      { id: 'recLine1', 'Stock Item': [rose.airtableId], 'Flower Name': 'Rose', Quantity: 3 },
+      { id: 'recLine2', 'Stock Item': [euca.airtableId], 'Flower Name': 'Eucalyptus', Quantity: 2 },
+    ]);
+
+    const result = await returnPremadeBouquetToStock('recBouquet1');
+
+    // PG rows should be back to their pre-bouquet quantities.
+    const [roseAfter] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
+    const [eucaAfter] = await harness.db.select().from(stock).where(eq(stock.id, euca.id));
+    expect(roseAfter.currentQuantity).toBe(10);
+    expect(eucaAfter.currentQuantity).toBe(10);
+
+    // Airtable stock-adjust must NOT have fired — Airtable Stock is the
+    // frozen legacy snapshot post-cutover. Bypassing the repo here was the
+    // exact bug owner hit on 2026-05-04.
+    expect(airtable.atomicStockAdjust).not.toHaveBeenCalled();
+
+    // Service still reports per-line summary so the toast can name what came back.
+    expect(result.returnedItems).toHaveLength(2);
+    expect(result.returnedItems[0]).toMatchObject({ flowerName: 'Rose', quantityReturned: 3, newStockQty: 10 });
+  });
+
+  it('handles a line whose Stock Item link is missing without aborting other returns', async () => {
+    const rose = await seedStockRow('Rose', 7);
+
+    airtable.getById.mockResolvedValue({
+      id: 'recBouquet2',
+      Name: 'Mixed',
+      Lines: ['recLine1', 'recLine2'],
+    });
+    listByIds.mockResolvedValue([
+      { id: 'recLine1', 'Stock Item': [rose.airtableId], 'Flower Name': 'Rose', Quantity: 3 },
+      { id: 'recLine2', 'Stock Item': [], 'Flower Name': 'Mystery', Quantity: 2 },
+    ]);
+
+    const result = await returnPremadeBouquetToStock('recBouquet2');
+
+    const [roseAfter] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
+    expect(roseAfter.currentQuantity).toBe(10);
+    expect(result.returnedItems).toHaveLength(1);
+    expect(result.returnedItems[0].flowerName).toBe('Rose');
+  });
+});
+
+describe('createPremadeBouquet — postgres mode', () => {
+  it('decrements PG stock when the bouquet is composed', async () => {
+    const rose = await seedStockRow('Rose', 10);
+
+    airtable.create
+      .mockResolvedValueOnce({ id: 'recBouquet1', Name: 'Solo' })
+      .mockResolvedValueOnce({ id: 'recLine1' });
+    airtable.getById.mockResolvedValue({
+      id: 'recBouquet1', Name: 'Solo', Lines: ['recLine1'],
+    });
+    listByIds.mockResolvedValue([
+      { id: 'recLine1', 'Flower Name': 'Rose', Quantity: 4, 'Sell Price Per Unit': 10, 'Cost Price Per Unit': 4 },
+    ]);
+
+    await createPremadeBouquet({
+      name: 'Solo',
+      lines: [
+        { stockItemId: rose.airtableId, flowerName: 'Rose', quantity: 4, costPricePerUnit: 4, sellPricePerUnit: 10 },
+      ],
+      createdBy: 'Florist',
+    });
+
+    const [roseAfter] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
+    expect(roseAfter.currentQuantity).toBe(6);
+    expect(airtable.atomicStockAdjust).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/__tests__/premadeBouquetService.test.js
+++ b/backend/src/__tests__/premadeBouquetService.test.js
@@ -31,6 +31,11 @@ vi.mock('../services/airtable.js', () => ({
   atomicStockAdjust: vi.fn(),
 }));
 
+// ── Mock stockRepo (post-cutover stock adjustments route through here) ──
+vi.mock('../repos/stockRepo.js', () => ({
+  adjustQuantity: vi.fn(),
+}));
+
 // ── Mock batchQuery (listByIds) ──
 vi.mock('../utils/batchQuery.js', () => ({
   listByIds: vi.fn(),
@@ -48,6 +53,7 @@ vi.mock('../services/orderService.js', () => ({
 }));
 
 import * as db from '../services/airtable.js';
+import * as stockRepo from '../repos/stockRepo.js';
 import { listByIds } from '../utils/batchQuery.js';
 import { broadcast } from '../services/notifications.js';
 import { createOrder } from '../services/orderService.js';
@@ -69,7 +75,7 @@ describe('createPremadeBouquet', () => {
       .mockResolvedValueOnce({ id: 'recBouquet1', Name: 'Spring Pink' })   // parent
       .mockResolvedValueOnce({ id: 'recLine1' })                            // line 1
       .mockResolvedValueOnce({ id: 'recLine2' });                           // line 2
-    db.atomicStockAdjust.mockResolvedValue({ stockId: 'x', previousQty: 10, newQty: 7 });
+    stockRepo.adjustQuantity.mockResolvedValue({ stockId: 'x', previousQty: 10, newQty: 7 });
     db.getById.mockResolvedValue({
       id: 'recBouquet1', Name: 'Spring Pink', Lines: ['recLine1', 'recLine2'],
     });
@@ -89,9 +95,11 @@ describe('createPremadeBouquet', () => {
 
     // Parent + 2 lines created
     expect(db.create).toHaveBeenCalledTimes(3);
-    // Stock deducted twice, with negative deltas
-    expect(db.atomicStockAdjust).toHaveBeenCalledWith('recStock1', -3);
-    expect(db.atomicStockAdjust).toHaveBeenCalledWith('recStock2', -2);
+    // Stock deducted twice via stockRepo, with negative deltas
+    expect(stockRepo.adjustQuantity).toHaveBeenCalledWith('recStock1', -3);
+    expect(stockRepo.adjustQuantity).toHaveBeenCalledWith('recStock2', -2);
+    // Legacy direct-Airtable path must NOT fire post-cutover
+    expect(db.atomicStockAdjust).not.toHaveBeenCalled();
     // Broadcast fired
     expect(broadcast).toHaveBeenCalledWith(expect.objectContaining({
       type: 'premade_bouquet_created',
@@ -131,7 +139,7 @@ describe('createPremadeBouquet', () => {
       .mockResolvedValueOnce({ id: 'recBouquet1' })  // parent created
       .mockResolvedValueOnce({ id: 'recLine1' })     // line 1 created
       .mockRejectedValueOnce(new Error('airtable exploded')); // line 2 fails
-    db.atomicStockAdjust.mockResolvedValue({ stockId: 'x', previousQty: 10, newQty: 9 });
+    stockRepo.adjustQuantity.mockResolvedValue({ stockId: 'x', previousQty: 10, newQty: 9 });
 
     await expect(createPremadeBouquet({
       name: 'Boom',
@@ -158,13 +166,15 @@ describe('returnPremadeBouquetToStock', () => {
       { id: 'recLine1', 'Stock Item': ['recStock1'], 'Flower Name': 'Rose', Quantity: 3 },
       { id: 'recLine2', 'Stock Item': ['recStock2'], 'Flower Name': 'Eucalyptus', Quantity: 2 },
     ]);
-    db.atomicStockAdjust.mockResolvedValue({ stockId: 'x', previousQty: 0, newQty: 3 });
+    stockRepo.adjustQuantity.mockResolvedValue({ stockId: 'x', previousQty: 0, newQty: 3 });
 
     const result = await returnPremadeBouquetToStock('recBouquet1');
 
-    // Stock adjusted with POSITIVE deltas (returning to inventory)
-    expect(db.atomicStockAdjust).toHaveBeenCalledWith('recStock1', 3);
-    expect(db.atomicStockAdjust).toHaveBeenCalledWith('recStock2', 2);
+    // Stock adjusted with POSITIVE deltas (returning to inventory) via stockRepo
+    expect(stockRepo.adjustQuantity).toHaveBeenCalledWith('recStock1', 3);
+    expect(stockRepo.adjustQuantity).toHaveBeenCalledWith('recStock2', 2);
+    // Must not bypass the repo — that was the 2026-05-04 bug.
+    expect(db.atomicStockAdjust).not.toHaveBeenCalled();
     // Lines deleted
     expect(db.deleteRecord).toHaveBeenCalledWith(expect.anything(), 'recLine1');
     expect(db.deleteRecord).toHaveBeenCalledWith(expect.anything(), 'recLine2');
@@ -229,6 +239,7 @@ describe('matchPremadeBouquetToOrder', () => {
 
     // No stock adjustments made directly from match flow
     expect(db.atomicStockAdjust).not.toHaveBeenCalled();
+    expect(stockRepo.adjustQuantity).not.toHaveBeenCalled();
 
     // Broadcast fired
     expect(broadcast).toHaveBeenCalledWith(expect.objectContaining({

--- a/backend/src/services/premadeBouquetService.js
+++ b/backend/src/services/premadeBouquetService.js
@@ -16,6 +16,7 @@
 //     from every order query across the whole app.
 
 import * as db from './airtable.js';
+import * as stockRepo from '../repos/stockRepo.js';
 import { TABLES } from '../config/airtable.js';
 import { broadcast } from './notifications.js';
 import { listByIds } from '../utils/batchQuery.js';
@@ -158,10 +159,10 @@ export async function createPremadeBouquet(params) {
       createdLineIds.push(created.id);
     }
 
-    // 3. Deduct stock (serialized through stockQueue)
+    // 3. Deduct stock via stockRepo (routes to current STOCK_BACKEND).
     for (const line of lines) {
       if (line.stockItemId) {
-        await db.atomicStockAdjust(line.stockItemId, -line.quantity);
+        await stockRepo.adjustQuantity(line.stockItemId, -line.quantity);
         stockAdjustments.push({ stockId: line.stockItemId, delta: -line.quantity });
       }
     }
@@ -179,7 +180,7 @@ export async function createPremadeBouquet(params) {
     const rollbackErrors = [];
 
     for (const adj of stockAdjustments) {
-      try { await db.atomicStockAdjust(adj.stockId, -adj.delta); }
+      try { await stockRepo.adjustQuantity(adj.stockId, -adj.delta); }
       catch (e) { rollbackErrors.push(`stock ${adj.stockId}: ${e.message}`); }
     }
     for (const lineId of createdLineIds) {
@@ -225,7 +226,7 @@ export async function editPremadeBouquetLines(id, { lines = [], removedLines = [
   // 1. Handle removed lines — always return to stock (no writeoff for premade)
   for (const rem of removedLines) {
     if (rem.stockItemId && rem.quantity > 0) {
-      await db.atomicStockAdjust(rem.stockItemId, rem.quantity);
+      await stockRepo.adjustQuantity(rem.stockItemId, rem.quantity);
     }
     if (rem.lineId) {
       await db.deleteRecord(TABLES.PREMADE_BOUQUET_LINES, rem.lineId).catch(err =>
@@ -260,7 +261,7 @@ export async function editPremadeBouquetLines(id, { lines = [], removedLines = [
       if (line._originalQty != null && line.quantity !== line._originalQty) {
         const delta = line._originalQty - line.quantity;
         if (line.stockItemId && delta !== 0) {
-          await db.atomicStockAdjust(line.stockItemId, delta);
+          await stockRepo.adjustQuantity(line.stockItemId, delta);
         }
         await db.update(TABLES.PREMADE_BOUQUET_LINES, line.id, { Quantity: line.quantity });
       }
@@ -276,7 +277,7 @@ export async function editPremadeBouquetLines(id, { lines = [], removedLines = [
       });
       createdLines.push(created);
       if (line.stockItemId) {
-        await db.atomicStockAdjust(line.stockItemId, -line.quantity);
+        await stockRepo.adjustQuantity(line.stockItemId, -line.quantity);
       }
     }
   }
@@ -300,7 +301,7 @@ export async function returnPremadeBouquetToStock(id) {
       const stockId = line['Stock Item']?.[0];
       const qty = Number(line.Quantity || 0);
       if (stockId && qty > 0) {
-        const { newQty } = await db.atomicStockAdjust(stockId, qty);
+        const { newQty } = await stockRepo.adjustQuantity(stockId, qty);
         returnedItems.push({
           stockId,
           flowerName: line['Flower Name'] || '?',


### PR DESCRIPTION
## Summary
- Owner returned a premade bouquet to stock; NewOrder step 2 then refused to show those flowers as available. Root cause: `premadeBouquetService` was calling `airtable.atomicStockAdjust` directly, which after the 2026-05-02 `STOCK_BACKEND=postgres` cutover writes to the frozen Airtable snapshot only — Postgres (the live store) never saw the increment.
- Switched all six call sites to `stockRepo.adjustQuantity` so writes route to whichever backend `STOCK_BACKEND` selects. Same pattern `orderService.js` already follows.
- Sites: `createPremadeBouquet` deduct + rollback, `editPremadeBouquetLines` removed/qty-delta/new-line paths, `returnPremadeBouquetToStock` increment.

## Verification
- `cd backend && npx vitest run` — 257/257 pass (24 files), including:
  - existing `premadeBouquetService.test.js` (9 tests, mocks updated to assert `stockRepo.adjustQuantity` and that the legacy path is NOT called)
  - new `premadeBouquetService.integration.test.js` (3 tests, exercises pglite-backed `stockRepo` in postgres mode — proves return-to-stock and create both land in PG, not Airtable)
- E2E suite (`npm run test:e2e`) skipped: harness boots fine but exits when launched as a background shell from this session. The integration test against pglite covers the exact regression — same `stockRepo` PG path the harness would exercise.

## Follow-up (separate PR)
Audit found three other files with the same anti-pattern post-cutover (writes to migrated tables that bypass the repo):
- `backend/src/routes/stockOrders.js` — line 665 (`atomicStockAdjust`) + lines 198, 402, 618, 668, 683 (`db.create/update STOCK`)
- `backend/src/routes/stockLoss.js` — lines 150–151 and 177–178 (`db.update STOCK` for `Dead/Unsold Stems`)
- `backend/src/routes/webhook.js` — lines 201, 206, 212 (reprocess endpoint deletes from ORDERS / ORDER_LINES / DELIVERIES via `db.deleteRecord`)

These are queued as task #5 in this session — will land separately.

## Data remediation
This PR fixes the code. The owner's already-returned premade(s) are still divergent in PG (Airtable went up, PG didn't). Need `CLAUDE_RO_URL` to identify which stock_ids drifted, then a small idempotent script to apply the missed `stockRepo.adjustQuantity` calls. Pending owner approval to run.

## Test plan
- [ ] Owner reviews diff
- [ ] Merge → Railway redeploys → next return-to-stock action will increment PG
- [ ] Run remediation script for already-returned premade(s) once owner shares the PG read DSN

🤖 Generated with [Claude Code](https://claude.com/claude-code)