### PR TITLE
fix(po): route PO stock writes through stockRepo post-cutover

### DIFF
--- a/backend/src/routes/stockOrders.js
+++ b/backend/src/routes/stockOrders.js
@@ -8,6 +8,7 @@
 import { Router } from 'express';
 import { authorize } from '../middleware/auth.js';
 import * as db from '../services/airtable.js';
+import * as stockRepo from '../repos/stockRepo.js';
 import { TABLES } from '../config/airtable.js';
 import { broadcast } from '../services/notifications.js';
 import { sanitizeFormulaValue } from '../utils/sanitize.js';
@@ -195,7 +196,7 @@ router.post('/', authorize('stock-orders', ['owner']), async (req, res, next) =>
             resolvedStockItemId = matches[0].id;
           } else {
             // Create a new stock item so the flower appears in the stock picker
-            const newItem = await db.create(TABLES.STOCK, {
+            const newItem = await stockRepo.create({
               'Display Name': line.flowerName.trim(),
               'Purchase Name': line.flowerName.trim(),
               'Current Quantity': 0,
@@ -399,7 +400,7 @@ router.post('/:id/lines', authorize('stock-orders', ['owner']), async (req, res,
         if (matches.length > 0) {
           resolvedStockItemId = matches[0].id;
         } else {
-          const newItem = await db.create(TABLES.STOCK, {
+          const newItem = await stockRepo.create({
             'Display Name': flowerName.trim(),
             'Purchase Name': flowerName.trim(),
             'Current Quantity': 0,
@@ -601,7 +602,7 @@ async function findOrCreateSubstituteStock(altFlowerName, altSupplier, costPerSt
     if (originalStockId) {
       const currentLinks = Array.isArray(found['Substitute For']) ? found['Substitute For'] : [];
       if (!currentLinks.includes(originalStockId)) {
-        await db.update(TABLES.STOCK, found.id, {
+        await stockRepo.update(found.id, {
           'Substitute For': [...currentLinks, originalStockId],
         });
       }
@@ -615,7 +616,7 @@ async function findOrCreateSubstituteStock(altFlowerName, altSupplier, costPerSt
   const markup = Number(getConfig('targetMarkup')) || 1;
   const sellPerStem = Math.round(costPerStem * markup * 100) / 100;
 
-  const created = await db.create(TABLES.STOCK, {
+  const created = await stockRepo.create({
     'Display Name':       trimmedName,
     'Purchase Name':      trimmedName,
     Category:             originalStockItem?.Category || 'Other',
@@ -662,10 +663,10 @@ async function receiveIntoStock(stockItemId, qty, costPrice, sellPrice, supplier
   if (existingQty < 0) {
     batchQty = qty + existingQty; // e.g. 25 + (-5) = 20
     if (batchQty < 0) batchQty = 0; // edge: received less than deficit
-    await db.atomicStockAdjust(stockItemId, -existingQty); // zero it out
+    await stockRepo.adjustQuantity(stockItemId, -existingQty); // zero it out
   }
 
-  const newBatch = await db.create(TABLES.STOCK, {
+  const newBatch = await stockRepo.create({
     'Display Name':       `${baseName} (${batchLabel})`,
     'Purchase Name':      stockItem['Purchase Name'] || baseName,
     Category:             stockItem.Category || 'Other',
@@ -680,7 +681,7 @@ async function receiveIntoStock(stockItemId, qty, costPrice, sellPrice, supplier
   });
 
   // Update prices on the original record too so the "template" stays current
-  await db.update(TABLES.STOCK, stockItemId, {
+  await stockRepo.update(stockItemId, {
     'Current Cost Price': costPrice || stockItem['Current Cost Price'],
     'Current Sell Price': sellPrice || stockItem['Current Sell Price'],
     'Last Restocked': today,
@@ -762,7 +763,7 @@ router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), as
             // Create a new stock item so the line can be received
             const markup = Number(getConfig('targetMarkup')) || 1;
             const autoSell = sellPrice || Math.round(costPrice * markup * 100) / 100;
-            const created = await db.create(TABLES.STOCK, {
+            const created = await stockRepo.create({
               'Display Name': flowerName,
               'Purchase Name': flowerName,
               Category: 'Other',


### PR DESCRIPTION
## Summary
Follow-up to PR #180. Same anti-pattern, different file: `routes/stockOrders.js` had 8 direct calls to `airtable.atomicStockAdjust` / `db.create(TABLES.STOCK, ...)` / `db.update(TABLES.STOCK, ...)`. After 2026-05-02 STOCK_BACKEND=postgres cutover all 8 wrote to the frozen Airtable snapshot only — Postgres (the live store) silently missed every PO-created stock card and every batch receive.

## Sites swapped
| Line | Path | Op |
|---|---|---|
| 199 | PO create — auto-create stock from line | `db.create` → `stockRepo.create` |
| 403 | PO add-line — auto-create stock | `db.create` → `stockRepo.create` |
| 605 | substitute card — stack new original link | `db.update` → `stockRepo.update` |
| 619 | substitute card — new creation | `db.create` → `stockRepo.create` |
| 666 | receive — zero out original on negative | `atomicStockAdjust` → `stockRepo.adjustQuantity` |
| 669 | receive — create dated batch | `db.create` → `stockRepo.create` |
| 684 | receive — refresh original prices | `db.update` → `stockRepo.update` |
| 766 | evaluate — auto-create stock for unmatched | `db.create` → `stockRepo.create` |

All field shapes pass `STOCK_WRITE_ALLOWED` whitelist. No schema changes.

## Verification
- `cd backend && npx vitest run` — **254/254 pass**.
- `npm run harness` + `npm run test:e2e` — **162/168 pass**. Failures are pre-existing in section 25 (Bouquet image upload), which requires `HARNESS_MOCK_WIX=1` env var that wasn't set in this run — not a regression. Stock-relevant sections all green: 13 (negative stock drives PO demand), 14 (stock loss + PG decrement, 8/8), 20 (swap-bouquet-line substitute, 7/7), 22 (parity recheck, 6/6).

## Follow-up still open
Audit (saved to memory at `project_post_cutover_repo_bypasses.md`) found two more files with the same anti-pattern, lower priority:
- `routes/stockLoss.js` — `Dead/Unsold Stems` field write at lines 150–151, 177–178 (qty already routes correctly via `stockRepo`; only the dead-stems counter drifts).
- `routes/webhook.js` — `/wix-order/:id/reprocess` admin endpoint at lines 201, 206, 212 (deletes from migrated tables; rarely fired manually).

Defer to next week — together these are ~20% of total impact.

## Test plan
- [ ] Owner reviews diff (very mechanical — same 8 swaps as PR #180)
- [ ] Merge → Railway redeploys → next PO that lands creates stock cards in PG, dashboard sees them
- [ ] Watch first PO-evaluate after merge for any unexpected behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)