### PR TITLE
fix(deploy): drop --prefix backend from preDeployCommand

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -8,7 +8,7 @@ builder = "NIXPACKS"
 # an advisory lock so concurrent boots are safe. Boot also retries via
 # connectPostgres() in db/index.js as a belt-and-suspenders fallback (e.g. for
 # manual restarts that bypass the release pipeline).
-preDeployCommand = "npm --prefix backend run db:migrate:prod"
+preDeployCommand = "npm run db:migrate:prod"
 startCommand = "node src/index.js"
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Hotfix — prod has been stuck on #174 for 14h

Railway service config has \`rootDirectory: /backend\`, so the build container CWD is \`/app\` (= contents of \`backend/\`). The \`preDeployCommand\` introduced in PR #179 (\`npm --prefix backend run db:migrate:prod\`) looks for \`/app/backend/package.json\` which doesn't exist → ENOENT → release fails.

Three deploys all crashed at this step:
- #179 (commit \`c1ce361\`) — FAILED
- #180 (commit \`7a43460\`) — FAILED
- #181 (commit \`98d8e7f\`) — FAILED

So the premade + PO stockRepo fixes that already merged aren't live yet — owner is still on the buggy code from #174.

## Failure log
\`\`\`
npm error path /app/backend/package.json
npm error syscall open
npm error errno -2
npm error enoent Could not read package.json
Stopping Container
\`\`\`

## Fix
Drop \`--prefix backend\`. The service runs in \`backend/\` already (the \`startCommand: node src/index.js\` works because \`src/index.js\` exists there). The \`db:migrate:prod\` script lives in \`backend/package.json\`, which is the package.json visible at the runtime CWD.

## Verification
Local equivalent:
\`\`\`
cd backend && npm run db:migrate:prod
\`\`\`
runs the same migrator the owner ran manually on 2026-05-04 to unblock orders. Idempotent — Drizzle's \`__drizzle_migrations\` journal skips already-applied files.

After merge, Railway redeploys this commit with the fixed preDeploy. Watch for \`[PG] Migrations up to date.\` in the deploy log → backend boots → premade + PO fixes from #180 + #181 finally take effect.

## Test plan
- [ ] Merge → watch Railway deploy log
- [ ] Confirm \`[PG] Migrations applied.\` or \`up to date\`
- [ ] Confirm backend boots and SSE clients reconnect
- [ ] Confirm next premade return-to-stock and PO receive land in PG

🤖 Generated with [Claude Code](https://claude.com/claude-code)