### PR TITLE
perf(frontends): shared cachedGet + per-tab lazy mount

### DIFF
--- a/apps/dashboard/src/api/client.js
+++ b/apps/dashboard/src/api/client.js
@@ -1,2 +1,2 @@
-export { setClientPin, getClientPin } from '@flower-studio/shared';
+export { setClientPin, getClientPin, cachedGet, clearCachedGetCache } from '@flower-studio/shared';
 export { apiClient as default } from '@flower-studio/shared';

--- a/apps/dashboard/src/components/DayToDayTab.jsx
+++ b/apps/dashboard/src/components/DayToDayTab.jsx
@@ -3,8 +3,8 @@
 // what needs attention, and key metrics at a glance.
 // Every widget is clickable — navigates to the relevant tab with filters.
 
-import { useState, useEffect, useCallback } from 'react';
-import client from '../api/client.js';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import client, { cachedGet } from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import t from '../translations.js';
 import SummaryCard from './SummaryCard.jsx';
@@ -109,7 +109,7 @@ function TomorrowSection({ orders, onNavigate }) {
   );
 }
 
-export default function DayToDayTab({ onNavigate }) {
+export default function DayToDayTab({ onNavigate, isActive = true }) {
   const [data, setData]           = useState(null);
   const [analytics, setAnalytics] = useState(null);
   const [loading, setLoading]     = useState(true);
@@ -120,6 +120,7 @@ export default function DayToDayTab({ onNavigate }) {
   const [driverSectionOpen, setDriverSectionOpen] = useState(false);
   const [wixProducts, setWixProducts] = useState([]);
   const { showToast } = useToast();
+  const loadedRef = useRef(false);
 
   const fetchData = useCallback(async (silent = false) => {
     try {
@@ -129,8 +130,8 @@ export default function DayToDayTab({ onNavigate }) {
       const [dashRes, analyticsRes, settingsRes, productsRes] = await Promise.all([
         client.get('/dashboard', { params: { date: today } }),
         client.get('/analytics', { params: { from: firstOfMonth, to: today } }).catch(() => ({ data: null })),
-        client.get('/settings').catch(() => ({ data: {} })),
-        client.get('/public/products').catch(() => ({ data: { products: [] } })),
+        cachedGet('/settings').catch(() => ({ data: {} })),
+        cachedGet('/public/products').catch(() => ({ data: { products: [] } })),
       ]);
       setData(dashRes.data);
       setAnalytics(analyticsRes.data);
@@ -146,6 +147,7 @@ export default function DayToDayTab({ onNavigate }) {
       );
       setWixProducts(available);
       setFetchError(false);
+      loadedRef.current = true;
     } catch {
       if (!silent) {
         setFetchError(true);
@@ -157,7 +159,8 @@ export default function DayToDayTab({ onNavigate }) {
   }, [showToast]);
 
   useEffect(() => {
-    fetchData();
+    if (!isActive) return undefined;
+    fetchData(loadedRef.current);
 
     // Silent poll every 120s — updates data without disrupting UI.
     // Low cadence because visibility-change refresh + SSE cover active use;
@@ -175,7 +178,7 @@ export default function DayToDayTab({ onNavigate }) {
       clearInterval(interval);
       document.removeEventListener('visibilitychange', handleVisibility);
     };
-  }, [fetchData]);
+  }, [fetchData, isActive]);
 
   if (loading) return <DashboardSkeleton />;
 

--- a/apps/dashboard/src/components/NewOrderTab.jsx
+++ b/apps/dashboard/src/components/NewOrderTab.jsx
@@ -2,7 +2,7 @@
 // Renders as tab content (not a separate page). After submit, navigates to Orders tab.
 
 import { useState, useEffect } from 'react';
-import client from '../api/client.js';
+import client, { cachedGet } from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import t from '../translations.js';
 
@@ -33,8 +33,8 @@ export default function NewOrderTab({ onNavigate, initialFilter }) {
   const [premadeBouquets, setPremadeBouquets] = useState([]);
 
   useEffect(() => {
-    client.get('/stock?includeEmpty=true&includeInactive=true').then(r => setStock(r.data)).catch(console.error);
-    client.get('/premade-bouquets').then(r => setPremadeBouquets(r.data || [])).catch(() => {});
+    cachedGet('/stock?includeEmpty=true&includeInactive=true').then(r => setStock(r.data)).catch(console.error);
+    cachedGet('/premade-bouquets').then(r => setPremadeBouquets(r.data || [])).catch(() => {});
   }, []);
 
   // Path A: owner clicked "Sold" on a premade from the Orders tab — arrives with

--- a/apps/dashboard/src/components/OrdersTab.jsx
+++ b/apps/dashboard/src/components/OrdersTab.jsx
@@ -63,7 +63,7 @@ function monthStart() {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`;
 }
 
-export default function OrdersTab({ initialFilter, onNavigate }) {
+export default function OrdersTab({ initialFilter, onNavigate, isActive = true }) {
   const STATUS_OPTIONS = getStatusOptions();
   // Initialize state from initialFilter to avoid double-fetch race condition.
   // If a filter is passed from another tab (e.g., Financial), use it from the start.
@@ -99,6 +99,7 @@ export default function OrdersTab({ initialFilter, onNavigate }) {
   const { showToast }             = useToast();
 
   const initialLoaded = useRef(false);
+  const fetchKeyRef = useRef('');
 
   const fetchOrders = useCallback(async (silent = false) => {
     if (!silent) setLoading(true);
@@ -137,14 +138,32 @@ export default function OrdersTab({ initialFilter, onNavigate }) {
     }
   }, [statusFilter, dateFrom, dateTo, upcomingMode, unpaidOnly, paidOnly, deliveryTypeFilter, sourceFilter, paymentMethodFilter, excludeCancelled, showToast]);
 
+  const fetchKey = JSON.stringify({
+    statusFilter,
+    dateFrom,
+    dateTo,
+    upcomingMode,
+    unpaidOnly,
+    paidOnly,
+    deliveryTypeFilter,
+    sourceFilter,
+    paymentMethodFilter,
+    excludeCancelled,
+  });
+
   useEffect(() => {
-    initialLoaded.current = false;
-    fetchOrders();
+    if (!isActive) return undefined;
+    const queryChanged = fetchKeyRef.current !== fetchKey;
+    if (queryChanged) {
+      fetchKeyRef.current = fetchKey;
+      initialLoaded.current = false;
+    }
+    fetchOrders(!queryChanged && initialLoaded.current);
     const interval = setInterval(() => { if (!document.hidden) fetchOrders(true); }, 60000);
     function onVisible() { if (!document.hidden) fetchOrders(true); }
     document.addEventListener('visibilitychange', onVisible);
     return () => { clearInterval(interval); document.removeEventListener('visibilitychange', onVisible); };
-  }, [fetchOrders]);
+  }, [fetchOrders, fetchKey, isActive]);
 
   // Orders with no delivery/pickup date — these get sorted to the bottom of
   // every default view and become "lost". Counted from the unfiltered list so

--- a/apps/dashboard/src/components/ProductsTab.jsx
+++ b/apps/dashboard/src/components/ProductsTab.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { WixPushModal } from '@flower-studio/shared';
-import client from '../api/client.js';
+import client, { cachedGet } from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import { useNotifications } from '../hooks/useNotifications.js';
 import t from '../translations.js';
@@ -42,9 +42,9 @@ export default function ProductsTab() {
     try {
       const [prodRes, stockRes, logRes, catRes] = await Promise.all([
         client.get('/products'),
-        client.get('/stock?includeEmpty=true'),
+        cachedGet('/stock?includeEmpty=true'),
         client.get('/products/sync-log'),
-        client.get('/public/categories').catch(() => ({ data: { allCategories: [] } })),
+        cachedGet('/public/categories').catch(() => ({ data: { allCategories: [] } })),
       ]);
       setProducts(prodRes.data);
       setStock(stockRes.data);

--- a/apps/dashboard/src/components/SettingsTab.jsx
+++ b/apps/dashboard/src/components/SettingsTab.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import t from '../translations.js';
-import client from '../api/client.js';
+import client, { cachedGet } from '../api/client.js';
 import { ConfigRow, ListEditor, Section } from './settings/SettingsPrimitives.jsx';
 import { RateTypesEditor, FloristRatesEditor } from './settings/RateEditors.jsx';
 import DriverSettingsSection from './settings/DriverSettingsSection.jsx';
@@ -18,7 +18,7 @@ export default function SettingsTab() {
   const [toast, setToast] = useState('');
 
   useEffect(() => {
-    client.get('/settings')
+    cachedGet('/settings')
       .then(r => {
         setConfig(r.data.config);
         setDrivers(r.data.drivers || []);

--- a/apps/dashboard/src/components/StockTab.jsx
+++ b/apps/dashboard/src/components/StockTab.jsx
@@ -3,7 +3,7 @@
 // receive deliveries, track waste. All fields inline-editable.
 
 import { useState, useEffect, useCallback, useRef, Fragment, useMemo } from 'react';
-import client from '../api/client.js';
+import client, { cachedGet } from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import t from '../translations.js';
 import { stockBaseName, renderDateTag, parseBatchName, LOSS_REASONS, reasonLabel } from '@flower-studio/shared';
@@ -31,7 +31,7 @@ function formatDateTag(dateStr, color = 'gray') {
   );
 }
 
-export default function StockTab({ initialFilter, onNavigate }) {
+export default function StockTab({ initialFilter, onNavigate, isActive = true }) {
   const [stock, setStock]           = useState([]);
   const [loading, setLoading]       = useState(true);
   const [search, setSearch]         = useState('');
@@ -70,7 +70,7 @@ export default function StockTab({ initialFilter, onNavigate }) {
         client.get('/stock/pending-po'),
         client.get('/stock/committed'),
         client.get('/stock/premade-committed').catch(() => ({ data: {} })),
-        client.get('/settings').catch(() => ({ data: { config: {} } })),
+        cachedGet('/settings').catch(() => ({ data: { config: {} } })),
       ]);
       setStock(prev => {
         if (!stockLoaded.current) return stockRes.data;
@@ -95,13 +95,13 @@ export default function StockTab({ initialFilter, onNavigate }) {
   }, [showToast]);
 
   useEffect(() => {
-    stockLoaded.current = false;
-    fetchStock();
+    if (!isActive) return undefined;
+    fetchStock(stockLoaded.current);
     const interval = setInterval(() => { if (!document.hidden) fetchStock(true); }, 120000);
     function onVisible() { if (!document.hidden) fetchStock(true); }
     document.addEventListener('visibilitychange', onVisible);
     return () => { clearInterval(interval); document.removeEventListener('visibilitychange', onVisible); };
-  }, [fetchStock]);
+  }, [fetchStock, isActive]);
 
   const [lossLog, setLossLog] = useState([]);
 

--- a/apps/dashboard/src/hooks/useConfigLists.js
+++ b/apps/dashboard/src/hooks/useConfigLists.js
@@ -4,7 +4,7 @@
 // Module-level cache ensures only 1 API call per session.
 
 import { useState, useEffect } from 'react';
-import client from '../api/client.js';
+import { cachedGet } from '../api/client.js';
 
 const DEFAULTS = {
   suppliers:      ['4f', 'Mateusz', 'Other', 'Stefan', 'Stojek'],
@@ -24,8 +24,8 @@ export default function useConfigLists() {
   useEffect(() => {
     if (cached) return;
     Promise.all([
-      client.get('/settings/lists').catch(() => ({ data: {} })),
-      client.get('/settings').catch(() => ({ data: {} })),
+      cachedGet('/settings/lists').catch(() => ({ data: {} })),
+      cachedGet('/settings').catch(() => ({ data: {} })),
     ]).then(([listsRes, settingsRes]) => {
       const merged = {
         ...DEFAULTS,

--- a/apps/dashboard/src/pages/DashboardPage.jsx
+++ b/apps/dashboard/src/pages/DashboardPage.jsx
@@ -3,22 +3,28 @@
 // monitoring screen (orders, inventory, customers, operations).
 // Cross-tab navigation: clicking a widget on Today navigates to the relevant tab with filters.
 
-import { useState, useCallback, lazy, Suspense } from 'react';
+import { useState, useCallback, useEffect, lazy, Suspense } from 'react';
 import t from '../translations.js';
 import { LangToggle } from '../context/LanguageContext.jsx';
 import HelpPanel from '../components/HelpPanel.jsx';
 
-import OrdersTab from '../components/OrdersTab.jsx';
-import StockTab from '../components/StockTab.jsx';
-import CustomersTab from '../components/CustomersTab.jsx';
-import DayToDayTab from '../components/DayToDayTab.jsx';
-import NewOrderTab from '../components/NewOrderTab.jsx';
-import SettingsTab from '../components/SettingsTab.jsx';
-import ProductsTab from '../components/ProductsTab.jsx';
-import AdminTab from '../components/AdminTab.jsx';
-
-// Lazy-load FinancialTab so Recharts (~160KB) isn't bundled until the tab is first opened
+const DayToDayTab = lazy(() => import('../components/DayToDayTab.jsx'));
+const OrdersTab = lazy(() => import('../components/OrdersTab.jsx'));
+const NewOrderTab = lazy(() => import('../components/NewOrderTab.jsx'));
+const StockTab = lazy(() => import('../components/StockTab.jsx'));
+const CustomersTab = lazy(() => import('../components/CustomersTab.jsx'));
+const ProductsTab = lazy(() => import('../components/ProductsTab.jsx'));
+const AdminTab = lazy(() => import('../components/AdminTab.jsx'));
+const SettingsTab = lazy(() => import('../components/SettingsTab.jsx'));
 const FinancialTab = lazy(() => import('../components/FinancialTab.jsx'));
+
+function TabFallback() {
+  return (
+    <div className="flex justify-center py-16">
+      <div className="w-8 h-8 border-2 border-brand-300 border-t-brand-600 rounded-full animate-spin" />
+    </div>
+  );
+}
 
 export default function DashboardPage() {
   // TABS defined inside component so the Proxy reads the current language on each render
@@ -36,6 +42,10 @@ export default function DashboardPage() {
   const [activeTab, setActiveTab] = useState(() => {
     try { return localStorage.getItem('dashboard_tab') || 'today'; } catch { return 'today'; }
   });
+  const [mountedTabs, setMountedTabs] = useState(() => {
+    try { return new Set([localStorage.getItem('dashboard_tab') || 'today']); }
+    catch { return new Set(['today']); }
+  });
   const [tabFilter, setTabFilter] = useState(null);
   // Track whether the financial tab has ever been opened, so we only mount
   // the lazy-loaded Recharts bundle on first visit (not on initial page load).
@@ -46,6 +56,15 @@ export default function DashboardPage() {
   // Think of it like resetting a workstation between different job orders.
   const [filterKey, setFilterKey] = useState(0);
   const [showHelp, setShowHelp] = useState(false);
+
+  useEffect(() => {
+    setMountedTabs(prev => {
+      if (prev.has(activeTab)) return prev;
+      const next = new Set(prev);
+      next.add(activeTab);
+      return next;
+    });
+  }, [activeTab]);
 
   // Called by DayToDayTab / FinancialTab when user clicks a widget
   const navigateTo = useCallback(({ tab, filter }) => {
@@ -64,6 +83,17 @@ export default function DashboardPage() {
     setTabFilter(null);
     if (key === 'financial') setFinancialMounted(true);
     try { localStorage.setItem('dashboard_tab', key); } catch {}
+  }
+
+  function renderMountedTab(key, children) {
+    if (!mountedTabs.has(key)) return null;
+    return (
+      <div style={{ display: activeTab === key ? 'block' : 'none' }}>
+        <Suspense fallback={activeTab === key ? <TabFallback /> : null}>
+          {children}
+        </Suspense>
+      </div>
+    );
   }
 
   return (
@@ -110,48 +140,45 @@ export default function DashboardPage() {
         </div>
       </header>
 
-      {/* Tab content — all tabs stay mounted (CSS hiding) to preserve state across switches.
-           OrdersTab and CustomersTab use key={filterKey} so they remount when
-           cross-tab navigation passes a new filter (e.g., clicking a widget on Today). */}
+      {/* Tab content mounts on first visit, then stays alive to preserve local state.
+           Hidden polling tabs receive isActive=false so they pause background intervals. */}
       <main className="max-w-7xl mx-auto px-6 py-6">
-        <div style={{ display: activeTab === 'today' ? 'block' : 'none' }}>
-          <DayToDayTab onNavigate={navigateTo} />
-        </div>
-        <div style={{ display: activeTab === 'orders' ? 'block' : 'none' }}>
-          <OrdersTab key={filterKey} initialFilter={tabFilter} onNavigate={navigateTo} />
-        </div>
-        <div style={{ display: activeTab === 'newOrder' ? 'block' : 'none' }}>
-          {/* No key={filterKey}: the wizard must NOT remount when an unrelated
-              tab triggers a cross-tab navigation, otherwise an in-progress
-              order is wiped. The matchPremadeId effect inside NewOrderTab
-              handles Match-Premade re-entries without a remount. */}
-          <NewOrderTab
-            onNavigate={navigateTo}
-            initialFilter={activeTab === 'newOrder' ? tabFilter : null}
-          />
-        </div>
-        <div style={{ display: activeTab === 'stock' ? 'block' : 'none' }}>
-          <StockTab key={filterKey} initialFilter={tabFilter} onNavigate={navigateTo} />
-        </div>
-        <div style={{ display: activeTab === 'customers' ? 'block' : 'none' }}>
+        {renderMountedTab('today',
+          <DayToDayTab isActive={activeTab === 'today'} onNavigate={navigateTo} />
+        )}
+        {renderMountedTab('orders',
+          <OrdersTab key={filterKey} isActive={activeTab === 'orders'} initialFilter={tabFilter} onNavigate={navigateTo} />
+        )}
+        {renderMountedTab('newOrder',
+          <>
+            {/* No key={filterKey}: the wizard must NOT remount when an unrelated
+                tab triggers a cross-tab navigation, otherwise an in-progress
+                order is wiped. The matchPremadeId effect inside NewOrderTab
+                handles Match-Premade re-entries without a remount. */}
+            <NewOrderTab
+              onNavigate={navigateTo}
+              initialFilter={activeTab === 'newOrder' ? tabFilter : null}
+            />
+          </>
+        )}
+        {renderMountedTab('stock',
+          <StockTab key={filterKey} isActive={activeTab === 'stock'} initialFilter={tabFilter} onNavigate={navigateTo} />
+        )}
+        {renderMountedTab('customers',
           <CustomersTab key={filterKey} initialFilter={tabFilter} onNavigate={navigateTo} />
-        </div>
-        <div style={{ display: activeTab === 'products' ? 'block' : 'none' }}>
+        )}
+        {renderMountedTab('products',
           <ProductsTab />
-        </div>
-        <div style={{ display: activeTab === 'admin' ? 'block' : 'none' }}>
+        )}
+        {renderMountedTab('admin',
           <AdminTab />
-        </div>
-        <div style={{ display: activeTab === 'settings' ? 'block' : 'none' }}>
+        )}
+        {renderMountedTab('settings',
           <SettingsTab />
-        </div>
+        )}
         {financialMounted && (
           <div style={{ display: activeTab === 'financial' ? 'block' : 'none' }}>
-            <Suspense fallback={
-              <div className="flex justify-center py-16">
-                <div className="w-8 h-8 border-2 border-brand-300 border-t-brand-600 rounded-full animate-spin" />
-              </div>
-            }>
+            <Suspense fallback={<TabFallback />}>
               <FinancialTab onNavigate={navigateTo} />
             </Suspense>
           </div>

--- a/apps/delivery/src/api/client.js
+++ b/apps/delivery/src/api/client.js
@@ -1,2 +1,2 @@
-export { setClientPin, getClientPin } from '@flower-studio/shared';
+export { setClientPin, getClientPin, cachedGet, clearCachedGetCache } from '@flower-studio/shared';
 export { apiClient as default } from '@flower-studio/shared';

--- a/apps/florist/src/App.jsx
+++ b/apps/florist/src/App.jsx
@@ -3,31 +3,40 @@
 // is the corridor that sends staff to the right room based on the URL.
 
 import { Routes, Route, Navigate } from 'react-router-dom';
-import { useEffect } from 'react';
+import { useEffect, lazy, Suspense } from 'react';
 import { useAuth } from './context/AuthContext.jsx';
 import { LanguageProvider } from './context/LanguageContext.jsx';
 import { ThemeProvider } from './context/ThemeContext.jsx';
 import { setClientPin } from './api/client.js';
 import { useNotifications } from './hooks/useNotifications.js';
 
-import LoginPage        from './pages/LoginPage.jsx';
-import OrderListPage    from './pages/OrderListPage.jsx';
-import OrderDetailPage  from './pages/OrderDetailPage.jsx';
-import NewOrderPage     from './pages/NewOrderPage.jsx';
-import PremadeBouquetCreatePage from './pages/PremadeBouquetCreatePage.jsx';
-import StockPanelPage       from './pages/StockPanelPage.jsx';
-import StockEvaluationPage  from './pages/StockEvaluationPage.jsx';
-import SubstituteReconciliationPage from './pages/SubstituteReconciliationPage.jsx';
-import DaySummaryPage          from './pages/DaySummaryPage.jsx';
-import ShoppingSupportPage     from './pages/ShoppingSupportPage.jsx';
-import PurchaseOrderPage       from './pages/PurchaseOrderPage.jsx';
-import FloristHoursPage        from './pages/FloristHoursPage.jsx';
-import BouquetsPage            from './pages/BouquetsPage.jsx';
-import WasteLogPage            from './pages/WasteLogPage.jsx';
-import CustomerListPage        from './pages/CustomerListPage.jsx';
-import CustomerDetailPage      from './pages/CustomerDetailPage.jsx';
 import Toast                   from './components/Toast.jsx';
 import BottomNav               from './components/BottomNav.jsx';
+
+const LoginPage = lazy(() => import('./pages/LoginPage.jsx'));
+const OrderListPage = lazy(() => import('./pages/OrderListPage.jsx'));
+const OrderDetailPage = lazy(() => import('./pages/OrderDetailPage.jsx'));
+const NewOrderPage = lazy(() => import('./pages/NewOrderPage.jsx'));
+const PremadeBouquetCreatePage = lazy(() => import('./pages/PremadeBouquetCreatePage.jsx'));
+const StockPanelPage = lazy(() => import('./pages/StockPanelPage.jsx'));
+const StockEvaluationPage = lazy(() => import('./pages/StockEvaluationPage.jsx'));
+const SubstituteReconciliationPage = lazy(() => import('./pages/SubstituteReconciliationPage.jsx'));
+const DaySummaryPage = lazy(() => import('./pages/DaySummaryPage.jsx'));
+const ShoppingSupportPage = lazy(() => import('./pages/ShoppingSupportPage.jsx'));
+const PurchaseOrderPage = lazy(() => import('./pages/PurchaseOrderPage.jsx'));
+const FloristHoursPage = lazy(() => import('./pages/FloristHoursPage.jsx'));
+const BouquetsPage = lazy(() => import('./pages/BouquetsPage.jsx'));
+const WasteLogPage = lazy(() => import('./pages/WasteLogPage.jsx'));
+const CustomerListPage = lazy(() => import('./pages/CustomerListPage.jsx'));
+const CustomerDetailPage = lazy(() => import('./pages/CustomerDetailPage.jsx'));
+
+function PageFallback() {
+  return (
+    <div className="min-h-screen flex items-center justify-center dark:bg-dark-bg">
+      <div className="w-8 h-8 border-2 border-brand-200 border-t-brand-600 rounded-full animate-spin" />
+    </div>
+  );
+}
 
 // PrivateRoute — like a badge-reader gate. Redirects to /login if no PIN in context.
 function PrivateRoute({ children }) {
@@ -75,8 +84,9 @@ export default function App() {
     <ThemeProvider>
     <LanguageProvider>
       <Toast />
-      <Routes>
-        <Route path="/login" element={<LoginPage />} />
+      <Suspense fallback={<PageFallback />}>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
 
         <Route path="/orders" element={
           <PrivateRoute><Layout><OrderListPage /></Layout></PrivateRoute>
@@ -145,10 +155,11 @@ export default function App() {
         } />
 
         {/* Default: send logged-in users to orders, others to login */}
-        <Route path="*" element={
-          pin ? <Navigate to="/orders" replace /> : <Navigate to="/login" replace />
-        } />
-      </Routes>
+          <Route path="*" element={
+            pin ? <Navigate to="/orders" replace /> : <Navigate to="/login" replace />
+          } />
+        </Routes>
+      </Suspense>
     </LanguageProvider>
     </ThemeProvider>
   );

--- a/apps/florist/src/api/client.js
+++ b/apps/florist/src/api/client.js
@@ -1,2 +1,2 @@
-export { setClientPin, getClientPin } from '@flower-studio/shared';
+export { setClientPin, getClientPin, cachedGet, clearCachedGetCache } from '@flower-studio/shared';
 export { apiClient as default } from '@flower-studio/shared';

--- a/apps/florist/src/hooks/useConfigLists.js
+++ b/apps/florist/src/hooks/useConfigLists.js
@@ -5,7 +5,7 @@
 // components use the hook — like a shared parts catalog for the whole factory floor.
 
 import { useState, useEffect } from 'react';
-import client from '../api/client.js';
+import { cachedGet } from '../api/client.js';
 
 const DEFAULTS = {
   suppliers:      ['4f', 'Mateusz', 'Other', 'Stefan', 'Stojek'],
@@ -29,8 +29,8 @@ export default function useConfigLists() {
     if (cached) return;
     // Fetch both endpoints in parallel — lists + config (for time slots)
     Promise.all([
-      client.get('/settings/lists').catch(() => ({ data: {} })),
-      client.get('/settings').catch(() => ({ data: {} })),
+      cachedGet('/settings/lists').catch(() => ({ data: {} })),
+      cachedGet('/settings').catch(() => ({ data: {} })),
     ]).then(([listsRes, settingsRes]) => {
       const merged = {
         ...DEFAULTS,

--- a/apps/florist/src/pages/NewOrderPage.jsx
+++ b/apps/florist/src/pages/NewOrderPage.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import client from '../api/client.js';
+import client, { cachedGet } from '../api/client.js';
 import { useAuth } from '../context/AuthContext.jsx';
 import { useToast } from '../context/ToastContext.jsx';
 import t from '../translations.js';
@@ -41,7 +41,7 @@ export default function NewOrderPage() {
   const [premadeBouquets, setPremadeBouquets] = useState([]);
 
   useEffect(() => {
-    client.get('/stock?includeEmpty=true&includeInactive=true')
+    cachedGet('/stock?includeEmpty=true&includeInactive=true')
       .then(r => { setStock(r.data); setStockError(false); })
       .catch(err => {
         console.error('Failed to load stock:', err);
@@ -51,7 +51,7 @@ export default function NewOrderPage() {
     // Fetch available premade bouquets so Step 2 can offer them as selectable
     // compositions. Non-critical — if this fails, the wizard still works as a
     // normal new-order flow.
-    client.get('/premade-bouquets')
+    cachedGet('/premade-bouquets')
       .then(r => setPremadeBouquets(r.data || []))
       .catch(() => {});
   }, []);

--- a/apps/florist/src/pages/OrderListPage.jsx
+++ b/apps/florist/src/pages/OrderListPage.jsx
@@ -4,7 +4,7 @@ import { useAuth } from '../context/AuthContext.jsx';
 import { LangToggle } from '../context/LanguageContext.jsx';
 import { useToast } from '../context/ToastContext.jsx';
 import { getEffectiveStock } from '@flower-studio/shared';
-import client from '../api/client.js';
+import client, { cachedGet } from '../api/client.js';
 import OrderCard from '../components/OrderCard.jsx';
 import PremadeBouquetCard from '../components/PremadeBouquetCard.jsx';
 import DatePicker from '../components/DatePicker.jsx';
@@ -88,6 +88,7 @@ export default function OrderListPage() {
   const [orders, setOrders]         = useState([]);
   const [premadeBouquets, setPremadeBouquets] = useState([]);
   const [loading, setLoading]       = useState(true);
+  const [ordersReady, setOrdersReady] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [viewMode, setViewMode]     = useState(VIEW_MODES.ACTIVE);
   const [date, setDate]             = useState(''); // only used in completed view
@@ -125,6 +126,7 @@ export default function OrderListPage() {
         const res = await client.get('/premade-bouquets');
         setPremadeBouquets(res.data);
         initialLoaded.current = true;
+        setOrdersReady(true);
         return;
       }
 
@@ -153,6 +155,7 @@ export default function OrderListPage() {
         return merged;
       });
       initialLoaded.current = true;
+      setOrdersReady(true);
     } catch (err) {
       console.error(err);
       // Re-throw so the manual refresh handler can surface a toast.
@@ -192,24 +195,26 @@ export default function OrderListPage() {
   // Premade count — shown as a badge on the filter chip even when not in premade view.
   const [premadeCount, setPremadeCount] = useState(0);
   useEffect(() => {
+    if (!ordersReady) return undefined;
     let cancelled = false;
     async function fetchCount() {
       try {
-        const res = await client.get('/premade-bouquets');
+        const res = await cachedGet('/premade-bouquets');
         if (!cancelled) setPremadeCount(res.data.length);
       } catch {
         // Non-critical — badge just won't appear
       }
     }
-    fetchCount();
+    const timeout = setTimeout(fetchCount, 250);
     // Premade inventory changes rarely — 60s is plenty. The main order poll
     // stays at 30s below so florists still see new incoming orders quickly.
     const interval = setInterval(fetchCount, 60000);
-    return () => { cancelled = true; clearInterval(interval); };
-  }, [orders.length, premadeBouquets.length]);
+    return () => { cancelled = true; clearTimeout(timeout); clearInterval(interval); };
+  }, [ordersReady, orders.length, premadeBouquets.length]);
 
   useEffect(() => {
     initialLoaded.current = false;
+    setOrdersReady(false);
     // Background fetches swallow errors — fetchOrders now throws so the
     // manual Refresh handler can toast, but polls stay quiet.
     fetchOrders().catch(() => {});
@@ -223,11 +228,14 @@ export default function OrderListPage() {
 
   // Owner: fetch dashboard data for today's summary + stock alerts
   useEffect(() => {
-    if (!isOwner) return;
-    client.get('/dashboard', { params: { date: todayISO() } })
-      .then(r => setDashData(r.data))
-      .catch(() => {}); // non-critical — silently ignore
-  }, [isOwner]);
+    if (!isOwner || !ordersReady) return undefined;
+    const timeout = setTimeout(() => {
+      client.get('/dashboard', { params: { date: todayISO() } })
+        .then(r => setDashData(r.data))
+        .catch(() => {}); // non-critical — silently ignore
+    }, 300);
+    return () => clearTimeout(timeout);
+  }, [isOwner, ordersReady]);
 
   // Shared editor stock fetch — fires once on mount instead of once per
   // OrderCard the first time each is expanded-and-edited. `refreshEditorStock`
@@ -236,8 +244,8 @@ export default function OrderListPage() {
   const refreshEditorStock = useCallback(async () => {
     try {
       const [stockRes, premadeRes] = await Promise.all([
-        client.get('/stock?includeEmpty=true&includeInactive=true'),
-        client.get('/stock/premade-committed').catch(() => ({ data: {} })),
+        cachedGet('/stock?includeEmpty=true&includeInactive=true'),
+        cachedGet('/stock/premade-committed').catch(() => ({ data: {} })),
       ]);
       setEditorStockItems(stockRes.data);
       setEditorPremadeMap(premadeRes.data || {});
@@ -246,16 +254,23 @@ export default function OrderListPage() {
       // will surface a backend error if something is genuinely wrong.
     }
   }, []);
-  useEffect(() => { refreshEditorStock(); }, [refreshEditorStock]);
+  useEffect(() => {
+    if (!ordersReady) return undefined;
+    const timeout = setTimeout(refreshEditorStock, 350);
+    return () => clearTimeout(timeout);
+  }, [ordersReady, refreshEditorStock]);
 
   // Fetch committed stock data for shortfall warnings
   useEffect(() => {
+    if (!ordersReady) return undefined;
+    let cancelled = false;
     async function fetchShortfalls() {
       try {
         const [stockRes, committedRes] = await Promise.all([
-          client.get('/stock'),
+          cachedGet('/stock'),
           client.get('/stock/committed'),
         ]);
+        if (cancelled) return;
         const stockMap = {};
         for (const s of stockRes.data) stockMap[s.id] = s;
 
@@ -281,25 +296,30 @@ export default function OrderListPage() {
         // non-critical
       }
     }
-    fetchShortfalls();
-  }, [orders]); // re-fetch when orders change
+    const timeout = setTimeout(fetchShortfalls, 450);
+    return () => { cancelled = true; clearTimeout(timeout); };
+  }, [ordersReady, orders]); // re-fetch when orders change
 
   // Check for pending stock evaluations (florist) or active shopping POs (owner)
   useEffect(() => {
-    if (isOwner) {
-      // Owner sees shopping support banner
-      Promise.all([
-        client.get('/stock-orders?status=Sent'),
-        client.get('/stock-orders?status=Shopping'),
-      ]).then(([s, sh]) => setShoppingCount(s.data.length + sh.data.length))
-        .catch(() => {});
-    } else {
-      // Florist sees evaluation banner
-      client.get('/stock-orders?status=Evaluating')
-        .then(r => setEvalCount(r.data.length))
-        .catch(() => {});
-    }
-  }, [isOwner]);
+    if (!ordersReady) return undefined;
+    const timeout = setTimeout(() => {
+      if (isOwner) {
+        // Owner sees shopping support banner
+        Promise.all([
+          client.get('/stock-orders?status=Sent'),
+          client.get('/stock-orders?status=Shopping'),
+        ]).then(([s, sh]) => setShoppingCount(s.data.length + sh.data.length))
+          .catch(() => {});
+      } else {
+        // Florist sees evaluation banner
+        client.get('/stock-orders?status=Evaluating')
+          .then(r => setEvalCount(r.data.length))
+          .catch(() => {});
+      }
+    }, 550);
+    return () => clearTimeout(timeout);
+  }, [ordersReady, isOwner]);
 
   return (
     <div className="min-h-screen dark:bg-dark-bg dark:text-dark-label">

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -5,7 +5,7 @@ Cross-app utilities shared by all three frontend apps. Anything used by 2+ apps 
 ## Structure
 ```
 api/
-  client.js                   → Axios instance with auto-attached PIN header (VITE_BACKEND_URL)
+  client.js                   → Axios instance with auto-attached PIN header + opt-in cachedGet/in-flight GET dedupe helper
   uploadImage.js              → uploadBouquetImage / removeBouquetImage (products) + uploadOrderImage / removeOrderImage (per-order override) — multipart wrappers
 context/
   AuthContext.jsx             → PIN, role, login/logout — wraps all apps

--- a/packages/shared/api/client.js
+++ b/packages/shared/api/client.js
@@ -1,8 +1,10 @@
 import axios from 'axios';
 
 let _pin = null;
+let clearCachedGetStore = null;
 
 export function setClientPin(pin) {
+  if (_pin !== pin) clearCachedGetStore?.();
   _pin = pin;
 }
 
@@ -31,5 +33,87 @@ client.interceptors.response.use(
     return Promise.reject(error);
   }
 );
+
+const DEFAULT_GET_CACHE_TTL_MS = 15_000;
+
+function stableSerialize(value) {
+  if (value == null) return '';
+  if (value instanceof URLSearchParams) {
+    return stableSerialize(Object.fromEntries(value.entries()));
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableSerialize).join(',')}]`;
+  }
+  if (typeof value === 'object') {
+    return `{${Object.keys(value).sort().map(key => `${key}:${stableSerialize(value[key])}`).join(',')}}`;
+  }
+  return String(value);
+}
+
+export function createCachedGet(requestGet, { getScope = () => '', now = () => Date.now() } = {}) {
+  const cache = new Map();
+  const inFlight = new Map();
+
+  function makeKey(url, config = {}, options = {}) {
+    if (options.cacheKey) return `${getScope()}::${options.cacheKey}`;
+    return [
+      getScope(),
+      url,
+      stableSerialize(config.params),
+    ].join('::');
+  }
+
+  function clear(prefix = '') {
+    if (!prefix) {
+      cache.clear();
+      inFlight.clear();
+      return;
+    }
+    for (const key of [...cache.keys()]) {
+      if (key.includes(prefix)) cache.delete(key);
+    }
+    for (const key of [...inFlight.keys()]) {
+      if (key.includes(prefix)) inFlight.delete(key);
+    }
+  }
+
+  async function cachedGet(url, config = {}, options = {}) {
+    const ttlMs = options.ttlMs ?? DEFAULT_GET_CACHE_TTL_MS;
+    const key = makeKey(url, config, options);
+
+    if (!options.force && ttlMs > 0) {
+      const hit = cache.get(key);
+      if (hit && hit.expiresAt > now()) return hit.response;
+    }
+
+    if (!options.force && inFlight.has(key)) return inFlight.get(key);
+
+    const request = requestGet(url, config)
+      .then(response => {
+        if (ttlMs > 0) {
+          cache.set(key, { response, expiresAt: now() + ttlMs });
+        }
+        return response;
+      })
+      .finally(() => {
+        inFlight.delete(key);
+      });
+
+    inFlight.set(key, request);
+    return request;
+  }
+
+  return { cachedGet, clear };
+}
+
+const cachedGetStore = createCachedGet(
+  (url, config) => client.get(url, config),
+  { getScope: () => _pin || '' },
+);
+
+clearCachedGetStore = cachedGetStore.clear;
+
+export const cachedGet = cachedGetStore.cachedGet;
+export const clearCachedGetCache = cachedGetStore.clear;
 
 export default client;

--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -10,7 +10,7 @@ export { default as Toast } from './components/Toast.jsx';
 export { default as ErrorBoundary } from './components/ErrorBoundary.jsx';
 export { default as DissolvePremadesDialog } from './components/DissolvePremadesDialog.jsx';
 export { computePremadeShortfalls } from './utils/dissolvePremades.js';
-export { default as apiClient, setClientPin, getClientPin } from './api/client.js';
+export { default as apiClient, setClientPin, getClientPin, cachedGet, clearCachedGetCache } from './api/client.js';
 export { LanguageProvider, useLanguage, LangToggle } from './context/LanguageContext.jsx';
 export { AuthProvider, useAuth } from './context/AuthContext.jsx';
 export { default as CallButton } from './components/CallButton.jsx';

--- a/packages/shared/test/apiClientCache.test.js
+++ b/packages/shared/test/apiClientCache.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createCachedGet } from '../api/client.js';
+
+describe('createCachedGet', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('deduplicates matching in-flight GET requests', async () => {
+    let resolveRequest;
+    const requestGet = vi.fn(() => new Promise(resolve => {
+      resolveRequest = resolve;
+    }));
+    const { cachedGet } = createCachedGet(requestGet);
+
+    const first = cachedGet('/stock', { params: { includeEmpty: true } });
+    const second = cachedGet('/stock', { params: { includeEmpty: true } });
+
+    expect(requestGet).toHaveBeenCalledTimes(1);
+    resolveRequest({ data: ['roses'] });
+
+    await expect(first).resolves.toEqual({ data: ['roses'] });
+    await expect(second).resolves.toEqual({ data: ['roses'] });
+  });
+
+  it('serves a fulfilled response from cache within the TTL', async () => {
+    const requestGet = vi.fn()
+      .mockResolvedValueOnce({ data: ['first'] })
+      .mockResolvedValueOnce({ data: ['second'] });
+    const { cachedGet } = createCachedGet(requestGet);
+
+    await expect(cachedGet('/settings', {}, { ttlMs: 1000 })).resolves.toEqual({ data: ['first'] });
+    await expect(cachedGet('/settings', {}, { ttlMs: 1000 })).resolves.toEqual({ data: ['first'] });
+
+    expect(requestGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches after the TTL expires', async () => {
+    const requestGet = vi.fn()
+      .mockResolvedValueOnce({ data: ['first'] })
+      .mockResolvedValueOnce({ data: ['second'] });
+    const { cachedGet } = createCachedGet(requestGet);
+
+    await cachedGet('/settings', {}, { ttlMs: 1000 });
+    vi.advanceTimersByTime(1001);
+    await expect(cachedGet('/settings', {}, { ttlMs: 1000 })).resolves.toEqual({ data: ['second'] });
+
+    expect(requestGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache rejected requests', async () => {
+    const requestGet = vi.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ data: ['recovered'] });
+    const { cachedGet } = createCachedGet(requestGet);
+
+    await expect(cachedGet('/stock')).rejects.toThrow('boom');
+    await expect(cachedGet('/stock')).resolves.toEqual({ data: ['recovered'] });
+
+    expect(requestGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('separates cache entries by scope and sorted params', async () => {
+    let scope = 'owner';
+    const requestGet = vi.fn()
+      .mockResolvedValueOnce({ data: 'owner' })
+      .mockResolvedValueOnce({ data: 'florist' });
+    const { cachedGet } = createCachedGet(requestGet, { getScope: () => scope });
+
+    await expect(cachedGet('/stock', { params: { b: 2, a: 1 } })).resolves.toEqual({ data: 'owner' });
+    await expect(cachedGet('/stock', { params: { a: 1, b: 2 } })).resolves.toEqual({ data: 'owner' });
+    scope = 'florist';
+    await expect(cachedGet('/stock', { params: { a: 1, b: 2 } })).resolves.toEqual({ data: 'florist' });
+
+    expect(requestGet).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- New shared `cachedGet` helper in `packages/shared/api/client.js`: in-flight GET dedupe + 15s TTL cache, PIN-scoped, auto-cleared on PIN change. Routes the high-traffic, low-volatility endpoints (`/settings`, `/settings/lists`, `/stock`, `/public/products`, `/public/categories`, `/premade-bouquets`, `/stock/premade-committed`) through it across florist + dashboard + delivery.
- Dashboard tabs are now `React.lazy`-split and mount on first visit (set-tracked). `isActive` propagates to `DayToDayTab` / `OrdersTab` / `StockTab` so background polling pauses on hidden tabs. Florist routes are likewise `React.lazy`-split (one chunk per page).
- `OrderListPage` staggers secondary fetches (premade count, dashboard summary, editor stock, shortfalls, eval/shopping banners) behind an `ordersReady` gate so the initial paint isn't blocked by a fan-out of parallel GETs.

## What changed (file map)
- `packages/shared/api/client.js` — `createCachedGet` factory + module-level `cachedGet` / `clearCachedGetCache` exports
- `packages/shared/index.js` + `packages/shared/CLAUDE.md` — export the new helpers, doc the API surface
- `packages/shared/test/apiClientCache.test.js` — new vitest suite (5 cases): in-flight dedupe, TTL hit, TTL expiry, no-cache-on-reject, scope/param-key isolation
- `apps/{florist,dashboard,delivery}/src/api/client.js` — re-export `cachedGet` / `clearCachedGetCache`
- `apps/{florist,dashboard}/src/hooks/useConfigLists.js` — switch `/settings` + `/settings/lists` to `cachedGet`
- `apps/dashboard/src/pages/DashboardPage.jsx` — lazy-load all tabs, mount on first visit, pass `isActive`
- `apps/dashboard/src/components/{DayToDayTab,OrdersTab,StockTab}.jsx` — accept `isActive`, pause polling when hidden, route stable endpoints through `cachedGet`
- `apps/dashboard/src/components/{NewOrderTab,ProductsTab,SettingsTab}.jsx` — switch stable GETs to `cachedGet`
- `apps/florist/src/App.jsx` — lazy-load every page route, single `Suspense` fallback
- `apps/florist/src/pages/{NewOrderPage,OrderListPage}.jsx` — `cachedGet` for stable endpoints + `ordersReady`-gated staggered secondary fetches

## Test plan
- [x] `cd packages/shared && ../../backend/node_modules/.bin/vitest run` — 110/110 green (incl. new `apiClientCache.test.js`)
- [x] `cd apps/florist && ./node_modules/.bin/vite build` — green; per-route chunks visible in output
- [x] `cd apps/dashboard && ./node_modules/.bin/vite build` — green; per-tab chunks visible (`OrdersTab`, `StockTab`, `DayToDayTab`, etc.)
- [x] `cd apps/delivery && ./node_modules/.bin/vite build` — green
- [ ] Smoke in browser: dashboard tab switching (state preserved, hidden tabs don't poll), florist route nav, owner login on florist (PIN scope cache clear)

## Why
Initial paint on both apps was blocked by a fan-out of duplicate GETs to slow Airtable-backed endpoints (multiple consumers of `/settings`, `/stock`, etc.). The `cachedGet` helper deduplicates in-flight calls and short-circuits repeats inside a 15s window. Per-tab/route lazy splitting also trims the initial JS bundle — dashboard's `FinancialTab` was already lazy; this extends the same pattern to every other tab and to all florist pages.

## Notes
- Cache is **PIN-scoped** (cleared automatically on PIN change in `setClientPin`) — owner→florist PIN switching does not leak cached responses across roles.
- 15s default TTL applies to the high-traffic stable endpoints listed above. Anything that mutates (POST/PATCH/DELETE) or reads volatile data (orders, deliveries) still goes through the raw axios `client.get` so it stays uncached.
- Previous branch `codex/Codex_Performance_optimization` had three stale ExpandableTextarea commits already squash-merged via PR #184 — this PR is rebased onto current master with only the perf commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)