### PR TITLE
fix(harness): add HARNESS_MOCK_WIX=1 to npm run harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "florist": "npm run dev --workspace=apps/florist",
     "delivery": "npm run dev --workspace=apps/delivery",
     "dashboard": "npm run dev --workspace=apps/dashboard",
-    "harness": "node backend/scripts/start-test-backend.js",
+    "harness": "HARNESS_MOCK_WIX=1 node backend/scripts/start-test-backend.js",
     "test:e2e": "node scripts/e2e-test.js",
     "test:e2e:ui": "playwright test"
   },


### PR DESCRIPTION
## Summary

- `npm run harness` was missing `HARNESS_MOCK_WIX=1`, so local E2E runs hit real `wixapis.com` and got 502 on every bouquet image upload/delete (section 25: 6 failures locally, 0 failures in CI)
- CI already sets `HARNESS_MOCK_WIX: '1'` in `.github/workflows/test.yml` — baking it into the npm script makes local runs match CI behavior

## Verification

`npm run harness & sleep 5 && node scripts/e2e-test.js` → **186/186 passing** (all sections including 25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)