### PR TITLE
fix(cutover): route all customer lookups through customerRepo after Phase 5

### DIFF
--- a/backend/src/__tests__/customerRepo.test.js
+++ b/backend/src/__tests__/customerRepo.test.js
@@ -25,15 +25,16 @@ vi.mock('../db/schema.js', () => ({
 
 // Mock drizzle-orm operators.
 vi.mock('drizzle-orm', () => ({
-  eq:     vi.fn((a, b) => ({ eq: [a, b] })),
-  and:    vi.fn((...args) => ({ and: args })),
-  or:     vi.fn((...args) => ({ or: args })),
-  ilike:  vi.fn((col, pat) => ({ ilike: [col, pat] })),
-  like:   vi.fn((col, pat) => ({ like: [col, pat] })),
-  isNull: vi.fn((col) => ({ isNull: col })),
-  asc:    vi.fn((col) => ({ asc: col })),
-  desc:   vi.fn((col) => ({ desc: col })),
-  sql:    vi.fn((s) => s),
+  eq:      vi.fn((a, b) => ({ eq: [a, b] })),
+  and:     vi.fn((...args) => ({ and: args })),
+  or:      vi.fn((...args) => ({ or: args })),
+  ilike:   vi.fn((col, pat) => ({ ilike: [col, pat] })),
+  like:    vi.fn((col, pat) => ({ like: [col, pat] })),
+  isNull:  vi.fn((col) => ({ isNull: col })),
+  inArray: vi.fn((col, vals) => ({ inArray: [col, vals] })),
+  asc:     vi.fn((col) => ({ asc: col })),
+  desc:    vi.fn((col) => ({ desc: col })),
+  sql:     vi.fn((s) => s),
 }));
 
 import { db } from '../db/index.js';
@@ -175,6 +176,35 @@ describe('repo.getById', () => {
   it('throws 404-shaped error when customer not found', async () => {
     db.select.mockReturnValue(makeChain([]));
     await expect(repo.getById('no-such-uuid')).rejects.toMatchObject({ statusCode: 404 });
+  });
+});
+
+// ── findMany ──
+describe('repo.findMany', () => {
+  it('returns empty array for empty input', async () => {
+    const result = await repo.findMany([]);
+    expect(result).toEqual([]);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('returns slim wire objects (id, airtableId, Name, Nickname, Phone)', async () => {
+    const row = makeRow();
+    db.select.mockReturnValue(makeChain([row]));
+    const result = await repo.findMany(['uuid-cust-1']);
+    expect(result).toEqual([{
+      id:         'uuid-cust-1',
+      airtableId: 'recC1',
+      Name:       'Alice Kowalska',
+      Nickname:   'Ala',
+      Phone:      '+48 555 000 001',
+    }]);
+  });
+
+  it('returns null Nickname/Phone when absent', async () => {
+    db.select.mockReturnValue(makeChain([makeRow({ nickname: null, phone: null })]));
+    const [c] = await repo.findMany(['uuid-cust-1']);
+    expect(c.Nickname).toBeNull();
+    expect(c.Phone).toBeNull();
   });
 });
 

--- a/backend/src/repos/customerRepo.js
+++ b/backend/src/repos/customerRepo.js
@@ -9,7 +9,7 @@
 
 import { db } from '../db/index.js';
 import { customers, keyPeople, legacyOrders, orders } from '../db/schema.js';
-import { eq, and, or, ilike, like, isNull, asc, desc, sql } from 'drizzle-orm';
+import { eq, and, or, ilike, like, isNull, inArray, asc, desc, sql } from 'drizzle-orm';
 
 // ── Field mapping: request body → PG column ──
 const PATCH_MAP = {
@@ -140,6 +140,70 @@ export async function list({ search, withAggregates = true } = {}) {
     [],
     withAggregates ? (aggMap[row.id] ?? EMPTY_AGG) : null,
   ));
+}
+
+export async function findMany(ids) {
+  if (!ids || ids.length === 0) return [];
+  const safeIds = ids.filter(Boolean);
+  if (safeIds.length === 0) return [];
+
+  // orders.customer_id is text holding either a PG UUID (post-Phase-5 backfill)
+  // or a legacy recXXX Airtable ID. Match whichever column applies.
+  const recIds  = safeIds.filter(id => id.startsWith('rec'));
+  const uuidIds = safeIds.filter(id => !id.startsWith('rec'));
+
+  const orParts = [];
+  if (recIds.length)  orParts.push(inArray(customers.airtableId, recIds));
+  if (uuidIds.length) orParts.push(inArray(customers.id, uuidIds));
+  if (orParts.length === 0) return [];
+
+  const rows = await db
+    .select({
+      id:         customers.id,
+      airtableId: customers.airtableId,
+      name:       customers.name,
+      nickname:   customers.nickname,
+      phone:      customers.phone,
+    })
+    .from(customers)
+    .where(and(
+      isNull(customers.deletedAt),
+      orParts.length === 1 ? orParts[0] : or(...orParts),
+    ));
+
+  return rows.map(row => ({
+    id:         row.id,
+    airtableId: row.airtableId,
+    Name:       row.name,
+    Nickname:   row.nickname ?? null,
+    Phone:      row.phone ?? null,
+  }));
+}
+
+export async function findByPhoneOrEmail(phone, email) {
+  const orParts = [];
+  if (phone) {
+    const clean = phone.replace(/\s/g, '');
+    orParts.push(sql`REPLACE(${customers.phone}, ' ', '') LIKE ${'%' + clean + '%'}`);
+  }
+  if (email) {
+    orParts.push(sql`LOWER(${customers.email}) LIKE ${('%' + email + '%').toLowerCase()}`);
+  }
+  if (orParts.length === 0) return null;
+  const rows = await db.select().from(customers)
+    .where(and(isNull(customers.deletedAt), or(...orParts)))
+    .limit(1);
+  return rows.length > 0 ? _pgCustomerToResponse(rows[0]) : null;
+}
+
+export async function findByExactName(name) {
+  const rows = await db.select().from(customers)
+    .where(and(
+      isNull(customers.deletedAt),
+      sql`LOWER(${customers.name}) = LOWER(${name})`,
+    ))
+    .limit(1);
+  return rows.length > 0 ? _pgCustomerToResponse(rows[0]) : null;
 }
 
 export async function getById(id) {

--- a/backend/src/routes/deliveries.js
+++ b/backend/src/routes/deliveries.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { authorize } from '../middleware/auth.js';
 import * as db from '../services/airtable.js';
 import * as orderRepo from '../repos/orderRepo.js';
+import * as customerRepo from '../repos/customerRepo.js';
 import * as productRepo from '../repos/productRepo.js';
 import { actorFromReq } from '../utils/actor.js';
 import { TABLES } from '../config/airtable.js';
@@ -72,15 +73,13 @@ router.get('/', async (req, res, next) => {
         fields: ['Customer', 'Customer Request', 'Payment Status', 'Notes Translated', 'Greeting Card Text', 'App Order ID', 'Wix Product ID', 'Image URL'],
       });
       const customerIds = [...new Set(orders.flatMap(o => o.Customer || []))];
-      const customers = customerIds.length > 0
-        ? await db.list(TABLES.CUSTOMERS, {
-            filterByFormula: `OR(${customerIds.map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-            fields: ['Name', 'Nickname', 'Phone'],
-          })
-        : [];
+      const customers = await customerRepo.findMany(customerIds);
 
       const custMap = {};
-      for (const c of customers) custMap[c.id] = c;
+      for (const c of customers) {
+        custMap[c.id] = c;
+        if (c.airtableId) custMap[c.airtableId] = c;
+      }
       for (const o of orders) orderMap[o.id] = o;
 
       for (const d of deliveries) {

--- a/backend/src/routes/intake.js
+++ b/backend/src/routes/intake.js
@@ -7,6 +7,7 @@ import { authorize } from '../middleware/auth.js';
 import * as db from '../services/airtable.js';
 import { TABLES } from '../config/airtable.js';
 import { sanitizeFormulaValue } from '../utils/sanitize.js';
+import * as customerRepo from '../repos/customerRepo.js';
 import { parseRawText, parseFlowwowEmail, matchStockItems } from '../services/intake-parser.js';
 import { PAYMENT_STATUS } from '../constants/statuses.js';
 
@@ -56,18 +57,7 @@ router.post('/parse', async (req, res, next) => {
     for (const query of searchFields) {
       if (!query || query.length < 2) continue;
       try {
-        const q = sanitizeFormulaValue(query);
-        const matches = await db.list(TABLES.CUSTOMERS, {
-          filterByFormula: `OR(
-            SEARCH(LOWER('${q}'), LOWER({Name})),
-            SEARCH(LOWER('${q}'), LOWER({Nickname})),
-            SEARCH('${q}', {Phone}),
-            SEARCH(LOWER('${q}'), LOWER({Link})),
-            SEARCH(LOWER('${q}'), LOWER({Email}))
-          )`,
-          maxRecords: 3,
-          fields: ['Name', 'Nickname', 'Phone', 'Link', 'Email', 'Segment', 'Language'],
-        });
+        const matches = await customerRepo.list({ search: query, withAggregates: false });
         if (matches.length > 0) {
           suggestedMatch = {
             id: matches[0].id,

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -4,6 +4,7 @@ import * as db from '../services/airtable.js';
 import * as stockRepo from '../repos/stockRepo.js';
 import * as orderRepo from '../repos/orderRepo.js';
 import * as productRepo from '../repos/productRepo.js';
+import * as customerRepo from '../repos/customerRepo.js';
 import { actorFromReq } from '../utils/actor.js';
 import { TABLES } from '../config/airtable.js';
 import { sanitizeFormulaValue } from '../utils/sanitize.js';
@@ -161,9 +162,7 @@ router.get('/', async (req, res, next) => {
             fields: ['Order', 'Sell Price Per Unit', 'Cost Price Per Unit', 'Quantity', 'Flower Name'],
             maxRecords: 1000,
           }),
-      listByIds(TABLES.CUSTOMERS, uniqueCustomerIds, {
-        fields: ['Name', 'Nickname', 'Phone'],
-      }),
+      customerRepo.findMany(uniqueCustomerIds),
       pgEmbeds
         ? Promise.resolve(orders.map(o => o._delivery).filter(Boolean))
         : listByIds(TABLES.DELIVERIES, allDeliveryIds, {
@@ -173,7 +172,10 @@ router.get('/', async (req, res, next) => {
 
     // Index customers and deliveries by ID
     const customerMap = {};
-    for (const c of allCustomers) customerMap[c.id] = c;
+    for (const c of allCustomers) {
+      customerMap[c.id] = c;
+      if (c.airtableId) customerMap[c.airtableId] = c;
+    }
 
     const deliveryMap = {};
     for (const d of allDeliveries) deliveryMap[d.id] = d;
@@ -289,7 +291,7 @@ router.get('/:id', async (req, res, next) => {
         ? Promise.resolve(order._lines)
         : listByIds(TABLES.ORDER_LINES, lineIds),
       custId
-        ? db.getById(TABLES.CUSTOMERS, custId).catch(() => null)
+        ? customerRepo.findMany([custId]).then(r => r[0] ?? null).catch(() => null)
         : Promise.resolve(null),
       hasPgEmbeds
         ? Promise.resolve(order._delivery)

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -285,7 +285,7 @@ router.get('/pending-po', async (req, res, next) => {
             filterByFormula: `AND({Display Name} = '${safe}', {Active} = TRUE())`,
             fields: ['Display Name', 'Current Cost Price', 'Current Sell Price'],
             maxRecords: 1,
-            pg: { active: true, includeEmpty: true },  // PG-mode falls back to JS-side name match
+            pg: { active: true, includeEmpty: true, displayName: name },
           });
           if (matches.length > 0) {
             nameToId[name] = matches[0].id;

--- a/backend/src/services/orderService.js
+++ b/backend/src/services/orderService.js
@@ -4,6 +4,7 @@
 import * as db from './airtable.js';
 import * as stockRepo from '../repos/stockRepo.js';
 import * as orderRepo from '../repos/orderRepo.js';
+import * as customerRepo from '../repos/customerRepo.js';
 import { TABLES } from '../config/airtable.js';
 import { broadcast } from './notifications.js';
 import { notifyNewOrder, notifyDeliveryComplete } from './telegram.js';
@@ -440,14 +441,14 @@ export async function transitionStatus(orderId, newStatus, otherFields = {}) {
  */
 export async function sendDeliveryCompleteAlert(orderId) {
   try {
-    const order = await db.getById(TABLES.ORDERS, orderId);
+    const order = await orderRepo.getById(orderId);
     const customerId = order.Customer?.[0];
     const deliveryId = order.Deliveries?.[0];
     const lineIds = order['Order Lines'] || [];
 
     const [customer, delivery, lineRecords] = await Promise.all([
       customerId
-        ? db.getById(TABLES.CUSTOMERS, customerId).catch(() => null)
+        ? customerRepo.findMany([customerId]).then(r => r[0] ?? null).catch(() => null)
         : Promise.resolve(null),
       deliveryId
         ? db.getById(TABLES.DELIVERIES, deliveryId).catch(() => null)

--- a/backend/src/services/wix.js
+++ b/backend/src/services/wix.js
@@ -8,6 +8,7 @@
 
 import * as db from './airtable.js';
 import * as orderRepo from '../repos/orderRepo.js';
+import * as customerRepo from '../repos/customerRepo.js';
 import { TABLES } from '../config/airtable.js';
 import { sanitizeFormulaValue } from '../utils/sanitize.js';
 import { broadcast } from './notifications.js';
@@ -202,21 +203,10 @@ export async function processWixOrder(payload) {
     // damaging than the silent duplication we saw when phone/email miss.
     let customerId = null;
     if (customerPhone || customerEmail) {
-      const searchFilters = [];
-      if (customerPhone) {
-        const cleanPhone = sanitizeFormulaValue(customerPhone.replace(/\s/g, ''));
-        searchFilters.push(`SEARCH('${cleanPhone}', SUBSTITUTE({Phone}, ' ', ''))`);
-      }
-      if (customerEmail) {
-        searchFilters.push(`SEARCH(LOWER('${sanitizeFormulaValue(customerEmail)}'), LOWER({Email}))`);
-      }
-      const matches = await db.list(TABLES.CUSTOMERS, {
-        filterByFormula: `OR(${searchFilters.join(',')})`,
-        maxRecords: 1,
-      });
-      if (matches.length > 0) {
-        customerId = matches[0].id;
-        log('5-MATCH', `Found existing customer by phone/email: ${matches[0].Name || matches[0].id}`);
+      const match = await customerRepo.findByPhoneOrEmail(customerPhone, customerEmail);
+      if (match) {
+        customerId = match.id;
+        log('5-MATCH', `Found existing customer by phone/email: ${match.Name || match.id}`);
       }
     }
     // Pass 2: name fallback. Only run if we actually have a composed
@@ -224,28 +214,25 @@ export async function processWixOrder(payload) {
     // name, which could merge unrelated records.
     if (!customerId && firstName && lastName) {
       const fullName = `${firstName} ${lastName}`.trim();
-      const nameMatches = await db.list(TABLES.CUSTOMERS, {
-        filterByFormula: `LOWER({Name}) = LOWER('${sanitizeFormulaValue(fullName)}')`,
-        maxRecords: 1,
-      });
-      if (nameMatches.length > 0) {
-        customerId = nameMatches[0].id;
-        log('5-MATCH', `Found existing customer by name: ${nameMatches[0].Name || nameMatches[0].id}`);
+      const nameMatch = await customerRepo.findByExactName(fullName);
+      if (nameMatch) {
+        customerId = nameMatch.id;
+        log('5-MATCH', `Found existing customer by name: ${nameMatch.Name || nameMatch.id}`);
         // Patch email/phone onto the matched record if we have new data Wix
         // provided and the existing fields are empty — so the next order
         // matches on the stronger signal.
         const patch = {};
-        if (customerEmail && !nameMatches[0].Email) patch.Email = customerEmail;
-        if (customerPhone && !nameMatches[0].Phone) patch.Phone = customerPhone;
+        if (customerEmail && !nameMatch.Email) patch.Email = customerEmail;
+        if (customerPhone && !nameMatch.Phone) patch.Phone = customerPhone;
         if (Object.keys(patch).length > 0) {
-          db.update(TABLES.CUSTOMERS, customerId, patch).catch(err => {
+          customerRepo.update(customerId, patch).catch(err => {
             console.error('[WIX] Customer enrich failed:', err.message);
           });
         }
       }
     }
     if (!customerId) {
-      const newCustomer = await db.create(TABLES.CUSTOMERS, {
+      const newCustomer = await customerRepo.create({
         Name: customerName,
         Phone: customerPhone || '',
         Email: customerEmail || '',


### PR DESCRIPTION
## Summary

- After Phase 5 (customers → Postgres), `orders.customer_id` stores PG UUIDs. Six routes/services still queried Airtable via `RECORD_ID()` — returns nothing for UUIDs, so customer names were blank in every view.
- `stock.js` pending-po route was missing `pg.displayName` — in PG mode it returned all active stock items and matched the wrong one (Paeonia sarah bernhardt invisible in bouquet picker).

## Changes

**`customerRepo.js`** — three new exports:
- `findMany(ids)` — batch lookup supporting both PG UUIDs and legacy `recXXX` Airtable IDs
- `findByPhoneOrEmail(phone, email)` — Wix customer dedup via phone/email
- `findByExactName(name)` — Wix customer dedup via exact name match

**Routes/services fixed:**
- `orders.js` — list + detail customer lookup via `customerRepo.findMany`
- `orderService.js` — `sendDeliveryCompleteAlert` uses `orderRepo.getById` + `customerRepo.findMany`
- `deliveries.js` — driver app customer names via `customerRepo.findMany`
- `wix.js` — all 4 customer operations (match/enrich/create) via `customerRepo`; stops creating duplicate customers on every Wix order post-Phase-5
- `intake.js` — AI parser customer search via `customerRepo.list`
- `stock.js` — pending-po name resolution passes `pg.displayName` so PG mode filters correctly

## Test plan

- [ ] 260/260 backend unit tests pass (`cd backend && npx vitest run`)
- [ ] Order list shows customer names again
- [ ] Delivery list shows customer names in driver app
- [ ] Wix webhook matches existing customers instead of creating duplicates
- [ ] "Paeonia sarah bernhardt" appears in bouquet editor picker when searching "Sarah"

## Remaining (filed as issues)

- #227 — dashboard reads frozen Airtable orders
- #228 — analytics reads frozen Airtable orders  
- #229 — stock committed/usage reads frozen Airtable orders

🤖 Generated with [Claude Code](https://claude.com/claude-code)