### PR TITLE
fix(stock): case-insensitive displayName match in pending-po resolution

### DIFF
--- a/backend/src/repos/stockRepo.js
+++ b/backend/src/repos/stockRepo.js
@@ -36,7 +36,7 @@ import { pickAllowed } from '../utils/fields.js';
 import { db } from '../db/index.js';
 import { stock, parityLog } from '../db/schema.js';
 import { recordAudit } from '../db/audit.js';
-import { and, eq, isNull, inArray, gt, sql } from 'drizzle-orm';
+import { and, eq, ilike, isNull, inArray, gt, sql } from 'drizzle-orm';
 
 // ── Backend mode ──
 const VALID_MODES = new Set(['airtable', 'shadow', 'postgres']);
@@ -198,7 +198,7 @@ async function listFromPg(options = {}) {
   if (pg.includeInactive !== true) filters.push(eq(stock.active, true));
   if (pg.includeEmpty !== true)    filters.push(gt(stock.currentQuantity, 0));
   if (pg.category)                 filters.push(eq(stock.category, String(pg.category)));
-  if (pg.displayName)              filters.push(eq(stock.displayName, String(pg.displayName)));
+  if (pg.displayName)              filters.push(ilike(stock.displayName, String(pg.displayName)));
   if (Array.isArray(pg.ids) && pg.ids.length) {
     // Accept either airtable ids or uuids in the same array.
     const recs = pg.ids.filter(x => typeof x === 'string' && x.startsWith('rec'));


### PR DESCRIPTION
## Summary

- `stockRepo.js:201` used `eq()` for `displayName` filter — case-sensitive `=` in Postgres
- PO line "Flower Name" and stock "Display Name" can differ in capitalisation (e.g. "Paeonia Sarah Bernhardt" vs "paeonia sarah bernhardt")
- Mismatch → `matches = 0` → auto-create triggered a duplicate zero-qty row
- Duplicate had no PO entry → filtered out of bouquet picker (`qty=0`, no `pendingPO`) → item invisible even when searching by name

Changed `eq` → `ilike` so name matching is case-insensitive.

## Test plan

- [ ] 260/260 backend tests pass
- [ ] "Paeonia sarah bernhardt" appears in bouquet editor picker after deploy
- [ ] +PO quantity shows correctly for the item

🤖 Generated with [Claude Code](https://claude.com/claude-code)