### PR TITLE
fix(stock-orders): prevent ghost Airtable records on PO line auto-link

### DIFF
--- a/backend/scripts/backfill-po-stock-items.js
+++ b/backend/scripts/backfill-po-stock-items.js
@@ -1,0 +1,224 @@
+// backend/scripts/backfill-po-stock-items.js
+// Category: DESTRUCTIVE
+//
+// Ensures every stock item referenced by active PO lines exists in Postgres.
+//
+// Two failure modes this fixes:
+//   A. Unlinked PO line (Flower Name only, no Stock Item) — stock card never
+//      existed anywhere. Creates a new PG row from the flower name.
+//   B. Linked PO line (has Stock Item recXXX) where the Airtable stock item
+//      was created AFTER the Phase 3 stock backfill (2026-05-02) and was
+//      therefore never synced to Postgres. The pending-po response keys off
+//      the recXXX but the stock list returns nothing → item hidden in picker.
+//
+// Idempotent: only creates rows that don't exist yet (checks by airtable_id
+// for case B, case-insensitive display_name for case A).
+// Usage: APPROVE=yes node backend/scripts/backfill-po-stock-items.js
+
+import 'dotenv/config';
+import Airtable from 'airtable';
+import pg from 'pg';
+
+if (process.env.APPROVE !== 'yes') {
+  console.error('Set APPROVE=yes to confirm you want to write to production Postgres.');
+  process.exit(1);
+}
+
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY })
+  .base(process.env.AIRTABLE_BASE_ID);
+
+const STOCK_ORDERS_TABLE      = process.env.AIRTABLE_STOCK_ORDERS_TABLE;
+const STOCK_ORDER_LINES_TABLE = process.env.AIRTABLE_STOCK_ORDER_LINES_TABLE;
+const STOCK_TABLE             = process.env.AIRTABLE_STOCK_TABLE;
+
+// ── 1. Fetch active POs ──────────────────────────────────────────────────────
+
+console.log('Fetching active POs from Airtable…');
+const activePOs = await new Promise((resolve, reject) => {
+  const recs = [];
+  base(STOCK_ORDERS_TABLE).select({
+    filterByFormula: `OR(
+      {Status} = 'Sent',
+      {Status} = 'Shopping',
+      {Status} = 'Reviewing',
+      {Status} = 'Evaluating',
+      {Status} = 'Draft'
+    )`,
+    fields: ['Stock Order ID', 'Status', 'Order Lines'],
+  }).eachPage(
+    (records, next) => { recs.push(...records); next(); },
+    err => err ? reject(err) : resolve(recs),
+  );
+});
+console.log(`Found ${activePOs.length} active PO(s).`);
+
+const allLineIds = activePOs.flatMap(po => po.fields['Order Lines'] || []);
+if (allLineIds.length === 0) {
+  console.log('No PO lines. Nothing to do.');
+  await pool.end();
+  process.exit(0);
+}
+
+// ── 2. Fetch all PO lines ────────────────────────────────────────────────────
+
+console.log(`Fetching ${allLineIds.length} PO line(s)…`);
+const CHUNK = 100;
+const allLines = [];
+for (let i = 0; i < allLineIds.length; i += CHUNK) {
+  const chunk = allLineIds.slice(i, i + CHUNK);
+  const formula = `OR(${chunk.map(id => `RECORD_ID()="${id}"`).join(',')})`;
+  const recs = await new Promise((resolve, reject) => {
+    const rows = [];
+    base(STOCK_ORDER_LINES_TABLE).select({
+      filterByFormula: formula,
+      fields: ['Flower Name', 'Stock Item', 'Cost Price', 'Sell Price', 'Supplier'],
+    }).eachPage(
+      (records, next) => { rows.push(...records); next(); },
+      err => err ? reject(err) : resolve(rows),
+    );
+  });
+  allLines.push(...recs);
+}
+
+// ── Case A: unlinked lines (Flower Name, no Stock Item) ──────────────────────
+
+const unlinked = allLines.filter(l =>
+  (l.fields['Flower Name'] || '').trim() &&
+  !(l.fields['Stock Item']?.length > 0)
+);
+const uniqueNames = [...new Set(unlinked.map(l => l.fields['Flower Name'].trim()).filter(Boolean))];
+
+// ── Case B: linked lines whose Airtable recXXX is missing from Postgres ──────
+
+const linkedRecIds = [...new Set(
+  allLines
+    .filter(l => l.fields['Stock Item']?.length > 0)
+    .map(l => l.fields['Stock Item'][0])
+)];
+
+let missingRecIds = [];
+if (linkedRecIds.length > 0) {
+  // Find which recXXX values are NOT in Postgres stock
+  const { rows: pgRows } = await pool.query(
+    `SELECT airtable_id FROM stock WHERE airtable_id = ANY($1) AND deleted_at IS NULL`,
+    [linkedRecIds],
+  );
+  const existingInPg = new Set(pgRows.map(r => r.airtable_id));
+  missingRecIds = linkedRecIds.filter(id => !existingInPg.has(id));
+}
+
+console.log(`\nCase A — unlinked lines:   ${uniqueNames.length} unique name(s)`);
+console.log(`Case B — linked but missing from PG: ${missingRecIds.length} item(s)`);
+
+if (uniqueNames.length === 0 && missingRecIds.length === 0) {
+  console.log('\nAll PO stock items already exist in Postgres. Nothing to create.');
+  await pool.end();
+  process.exit(0);
+}
+
+let created = 0;
+let alreadyExisted = 0;
+
+// ── Fix Case A: create from flower name ──────────────────────────────────────
+
+for (const name of uniqueNames) {
+  const { rows } = await pool.query(
+    `SELECT id FROM stock WHERE LOWER(display_name) = LOWER($1) AND deleted_at IS NULL LIMIT 1`,
+    [name],
+  );
+  if (rows.length > 0) {
+    console.log(`  A ✓ Already exists: "${name}"`);
+    alreadyExisted++;
+    continue;
+  }
+  const srcLine = unlinked.find(l => l.fields['Flower Name'].trim() === name);
+  const costPrice = Number(srcLine?.fields['Cost Price']) || null;
+  const sellPrice = Number(srcLine?.fields['Sell Price']) || null;
+  const supplier  = srcLine?.fields['Supplier'] || null;
+  const { rows: ins } = await pool.query(
+    `INSERT INTO stock (display_name, purchase_name, current_quantity, current_cost_price, current_sell_price, supplier, category, active)
+     VALUES ($1, $2, 0, $3, $4, $5, 'Other', true) RETURNING id`,
+    [name, name, costPrice, sellPrice, supplier],
+  );
+  console.log(`  A + Created: "${name}" → ${ins[0].id}`);
+  created++;
+}
+
+// ── Fix Case B: fetch Airtable stock item and create in PG with airtable_id ──
+
+if (missingRecIds.length > 0) {
+  console.log('\nFetching missing stock items from Airtable…');
+  const atItems = [];
+  for (let i = 0; i < missingRecIds.length; i += CHUNK) {
+    const chunk = missingRecIds.slice(i, i + CHUNK);
+    const formula = `OR(${chunk.map(id => `RECORD_ID()="${id}"`).join(',')})`;
+    const recs = await new Promise((resolve, reject) => {
+      const rows = [];
+      base(STOCK_TABLE).select({
+        filterByFormula: formula,
+        fields: [
+          'Display Name', 'Purchase Name', 'Category', 'Current Quantity',
+          'Current Cost Price', 'Current Sell Price', 'Supplier', 'Unit',
+          'Lot Size', 'Active',
+        ],
+      }).eachPage(
+        (records, next) => { rows.push(...records); next(); },
+        err => err ? reject(err) : resolve(rows),
+      );
+    });
+    atItems.push(...recs);
+  }
+
+  for (const item of atItems) {
+    const f = item.fields;
+    const name = (f['Display Name'] || '').trim();
+    if (!name) { console.log(`  B ⚠ Skipping ${item.id} — no Display Name`); continue; }
+
+    const { rows: ins } = await pool.query(
+      `INSERT INTO stock
+         (airtable_id, display_name, purchase_name, category, current_quantity,
+          current_cost_price, current_sell_price, supplier, unit, lot_size, active)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+       ON CONFLICT (airtable_id) DO NOTHING
+       RETURNING id`,
+      [
+        item.id,
+        name,
+        f['Purchase Name'] || name,
+        f['Category'] || 'Other',
+        Number(f['Current Quantity']) || 0,
+        f['Current Cost Price'] != null ? String(f['Current Cost Price']) : null,
+        f['Current Sell Price'] != null ? String(f['Current Sell Price']) : null,
+        f['Supplier'] || null,
+        f['Unit'] || null,
+        f['Lot Size'] != null ? Number(f['Lot Size']) : null,
+        f['Active'] !== false,
+      ],
+    );
+    if (ins.length > 0) {
+      console.log(`  B + Created: "${name}" (airtable_id=${item.id}) → pg_id=${ins[0].id}`);
+      created++;
+    } else {
+      console.log(`  B ✓ Already existed (ON CONFLICT): "${name}"`);
+      alreadyExisted++;
+    }
+  }
+
+  // Report any missing recIds that weren't found in Airtable
+  const foundIds = new Set(atItems.map(i => i.id));
+  for (const id of missingRecIds) {
+    if (!foundIds.has(id)) {
+      console.log(`  B ⚠ Airtable record ${id} not found (deleted?)`);
+    }
+  }
+}
+
+// ── Summary ──────────────────────────────────────────────────────────────────
+
+console.log(`\nDone. Created ${created} stock card(s), ${alreadyExisted} already existed.`);
+if (created > 0) {
+  console.log('These items will now appear in the bouquet picker (open/reopen the editor).');
+}
+
+await pool.end();

--- a/backend/scripts/fix-po-stock-names.js
+++ b/backend/scripts/fix-po-stock-names.js
@@ -1,0 +1,60 @@
+// backend/scripts/fix-po-stock-names.js
+// Category: DESTRUCTIVE
+// One-shot: fixes 5 Postgres stock rows that were created with UUID display
+// names (ghost records from broken Airtable backfill) and patches the
+// corresponding Airtable ghost records with the real flower names sourced
+// from the PO lines that reference them.
+//
+// Usage: APPROVE=yes node backend/scripts/fix-po-stock-names.js
+
+import 'dotenv/config';
+import Airtable from 'airtable';
+import pg from 'pg';
+
+if (process.env.APPROVE !== 'yes') {
+  console.error('Set APPROVE=yes to run.');
+  process.exit(1);
+}
+
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY })
+  .base(process.env.AIRTABLE_BASE_ID);
+
+// Sourced from PO lines: airtable_id → [displayName, costPrice, sellPrice, supplier]
+const FIXES = {
+  rec2woJHkTjjM1lPv: ['Paeonia sarah bernhardt',             '8.58',  '25',  '4f'],
+  recmZqmrpmg1Ggmya: ['Matthiola white',                     '4.62',  '11',  'OZ'],
+  recodfjwc3AiLBMPO: ['Hydrangea my beautiful akito (White)', '20.9',  '55',  'OZ'],
+  recrhgmSsWm6NfiYY: ['Matthiola pink light',                '3.81',  '11',  'OZ'],
+  rectLctpKxh1fKwNH: ['Hydrangea verena (Pink)',             '23.33', '60',  'OZ'],
+};
+
+// 1. Fix Postgres rows
+console.log('Fixing Postgres rows…');
+for (const [atId, [name, cost, sell, supplier]] of Object.entries(FIXES)) {
+  const { rowCount } = await pool.query(
+    `UPDATE stock
+     SET display_name=$1, purchase_name=$1, current_cost_price=$2, current_sell_price=$3, supplier=$4
+     WHERE airtable_id=$5`,
+    [name, cost, sell, supplier, atId],
+  );
+  console.log(`  PG (${rowCount} row updated): ${atId} → "${name}"`);
+}
+
+// 2. Patch Airtable ghost records with real names
+console.log('\nPatching Airtable ghost records…');
+for (const [atId, [name, cost, sell]] of Object.entries(FIXES)) {
+  try {
+    await base(process.env.AIRTABLE_STOCK_TABLE).update(atId, {
+      'Display Name': name,
+      'Current Cost Price': Number(cost),
+      'Current Sell Price': Number(sell),
+    });
+    console.log(`  AT updated: ${atId} → "${name}"`);
+  } catch (err) {
+    console.error(`  AT FAILED ${atId}: ${err.message}`);
+  }
+}
+
+console.log('\nDone. Reopen bouquet editor — these items will now appear.');
+await pool.end();

--- a/backend/src/routes/stockOrders.js
+++ b/backend/src/routes/stockOrders.js
@@ -18,6 +18,40 @@ import { listByIds } from '../utils/batchQuery.js';
 
 const VALID_STATUSES = VALID_PO_STATUSES;
 
+// Resolve a flower name to an Airtable-safe stock item ID.
+// Uses stockRepo (Postgres) not Airtable — the stock table is frozen in AT.
+// Returns the Airtable recXXX if the item was backfilled, or null for
+// PG-only items (no recXXX means passing the UUID to AT's linked field
+// would auto-create a ghost record with the UUID as Display Name).
+// Auto-creates a Postgres stock card if none found, so the item appears
+// in the bouquet picker immediately after the PO is saved.
+async function resolveOrCreateStockItem(flowerName, { costPrice = 0, sellPrice = 0, supplier = '' } = {}) {
+  const name = flowerName.trim();
+  const matches = await stockRepo.list({
+    filterByFormula: '', // ignored in PG mode
+    maxRecords: 1,
+    pg: { displayName: name, active: true, includeEmpty: true },
+  });
+  if (matches.length > 0) {
+    // id is airtableId || uuid — only safe to link in AT if it starts with 'rec'
+    return matches[0].id.startsWith('rec') ? matches[0].id : null;
+  }
+  // Not found — create a zero-qty stock card so it shows in the picker
+  const newItem = await stockRepo.create({
+    'Display Name': name,
+    'Purchase Name': name,
+    'Current Quantity': 0,
+    'Current Cost Price': Number(costPrice) || 0,
+    'Current Sell Price': Number(sellPrice) || 0,
+    Supplier: supplier || '',
+    Category: 'Other',
+    Active: true,
+  });
+  console.log(`[STOCK-ORDER] Auto-created stock item "${name}" (${newItem.id}) from PO line`);
+  // New PG-only item — no Airtable ID, don't link in AT
+  return null;
+}
+
 // Airtable may return Flower Name as an array (lookup field) or a string
 // (text field). Normalise to a plain string so downstream code (.trim(),
 // template literals, formula values) never receives an array.
@@ -187,28 +221,9 @@ router.post('/', authorize('stock-orders', ['owner']), async (req, res, next) =>
       let resolvedStockItemId = line.stockItemId || null;
       if (!resolvedStockItemId && line.flowerName) {
         try {
-          const safe = sanitizeFormulaValue(line.flowerName.trim());
-          const matches = await db.list(TABLES.STOCK, {
-            filterByFormula: `AND({Display Name} = '${safe}', {Active} = TRUE())`,
-            maxRecords: 1,
+          resolvedStockItemId = await resolveOrCreateStockItem(line.flowerName, {
+            costPrice: line.costPrice, sellPrice: line.sellPrice, supplier: line.supplier,
           });
-          if (matches.length > 0) {
-            resolvedStockItemId = matches[0].id;
-          } else {
-            // Create a new stock item so the flower appears in the stock picker
-            const newItem = await stockRepo.create({
-              'Display Name': line.flowerName.trim(),
-              'Purchase Name': line.flowerName.trim(),
-              'Current Quantity': 0,
-              'Current Cost Price': Number(line.costPrice) || 0,
-              'Current Sell Price': Number(line.sellPrice) || 0,
-              Supplier: line.supplier || '',
-              Category: 'Other',
-              Active: true,
-            });
-            resolvedStockItemId = newItem.id;
-            console.log(`[STOCK-ORDER] Auto-created stock item "${line.flowerName}" (${newItem.id}) from PO line`);
-          }
         } catch (err) {
           console.error(`[STOCK-ORDER] Auto-link/create failed for "${line.flowerName}":`, err.message);
         }
@@ -392,27 +407,10 @@ router.post('/:id/lines', authorize('stock-orders', ['owner']), async (req, res,
     let resolvedStockItemId = rawStockItemId || null;
     if (!resolvedStockItemId && flowerName) {
       try {
-        const safe = sanitizeFormulaValue(flowerName.trim());
-        const matches = await db.list(TABLES.STOCK, {
-          filterByFormula: `AND({Display Name} = '${safe}', {Active} = TRUE())`,
-          maxRecords: 1,
-        });
-        if (matches.length > 0) {
-          resolvedStockItemId = matches[0].id;
-        } else {
-          const newItem = await stockRepo.create({
-            'Display Name': flowerName.trim(),
-            'Purchase Name': flowerName.trim(),
-            'Current Quantity': 0,
-            'Current Cost Price': Number(costPrice) || 0,
-            'Current Sell Price': Number(sellPrice) || 0,
-            Supplier: supplier || '',
-            Category: 'Other',
-            Active: true,
-          });
-          resolvedStockItemId = newItem.id;
-        }
-      } catch { /* best effort */ }
+        resolvedStockItemId = await resolveOrCreateStockItem(flowerName, { costPrice, sellPrice, supplier });
+      } catch (err) {
+        console.error(`[STOCK-ORDER] Auto-link/create failed for "${flowerName}":`, err.message);
+      }
     }
     const line = await db.create(TABLES.STOCK_ORDER_LINES, {
       'Stock Orders': [req.params.id],


### PR DESCRIPTION
## Root cause

`POST /stock-orders` and `POST /stock-orders/:id/lines` both resolved a flower name to a stock item via `db.list(TABLES.STOCK)` — Airtable, frozen since Phase 3 cutover. When not found there, `stockRepo.create()` returned a PG UUID. That UUID was written to Airtable's `Stock Item` linked field, causing Airtable to auto-create a stub stock record with the UUID as its Display Name (ghost record). This is how 5 PO flowers got ghost Airtable records and broken PG rows.

## Changes

**`stockOrders.js`** — extracts `resolveOrCreateStockItem()`:
- Queries `stockRepo` (Postgres) with ilike name match instead of frozen Airtable
- Returns the Airtable `recXXX` only if the item was backfilled (safe to link in AT)
- Returns `null` for PG-only items → no `Stock Item` set in AT → pending-po resolves by name
- Auto-creates a PG stock card immediately when not found → item appears in bouquet picker on next open (no longer requires pending-po lazy trigger)

**`stock.js`** — pending-po silent catch now logs errors so failures are visible in Railway logs

**Scripts (run already against prod)**:
- `backfill-po-stock-items.js` — finds PO lines whose AT stock item is missing from PG and creates the PG rows (Case B was the real issue — 5 items found and fixed)
- `fix-po-stock-names.js` — one-shot fix for the 5 ghost records: updated PG display_name + Airtable Display Name from UUID → real flower name ("Paeonia sarah bernhardt" etc.)

## Test plan

- [x] 260/260 backend tests pass
- [ ] "Paeonia sarah bernhardt" visible in bouquet picker after deploy
- [ ] New PO lines with unrecognised flower names create PG stock cards (no ghost AT records)

🤖 Generated with [Claude Code](https://claude.com/claude-code)