### PR TITLE
fix(stock): hide received date on negative stock; derive committed from negative qty

### DIFF
--- a/apps/dashboard/src/components/StockTab.jsx
+++ b/apps/dashboard/src/components/StockTab.jsx
@@ -261,13 +261,20 @@ export default function StockTab({ initialFilter, onNavigate, isActive = true })
   // Planned rows — flowers arriving from pending POs, cross-referenced with committed orders
   const plannedRows = useMemo(() => {
     const nameMap = {};
-    for (const s of stock) nameMap[s.id] = stockBaseName(s['Display Name']) || s['Purchase Name'] || '';
+    const stockQtyMap = {};
+    for (const s of stock) {
+      nameMap[s.id] = stockBaseName(s['Display Name']) || s['Purchase Name'] || '';
+      stockQtyMap[s.id] = Number(s['Current Quantity']) || 0;
+    }
     let rows = Object.keys(pendingPO).map(stockId => {
       const po = pendingPO[stockId] || { ordered: 0, pos: [], flowerName: '' };
       const com = committedMap[stockId] || { committed: 0, orders: [] };
       // Only count "New" orders as committed — Ready orders already have flowers composed
       const newOrders = (com.orders || []).filter(o => o.status === 'New');
-      const committedQty = newOrders.reduce((sum, o) => sum + (o.qty || 0), 0);
+      const fromEndpoint = newOrders.reduce((sum, o) => sum + (o.qty || 0), 0);
+      // Negative qty = demand baked into Current Quantity (CLAUDE.md pitfall #7).
+      // /stock/committed reads Airtable (frozen — issue #229). Use negative qty as fallback.
+      const committedQty = Math.max(fromEndpoint, Math.max(0, -(stockQtyMap[stockId] || 0)));
       const stockName = nameMap[stockId] || '';
       const poName = stockBaseName(po.flowerName) || '';
       return {
@@ -814,7 +821,7 @@ export default function StockTab({ initialFilter, onNavigate, isActive = true })
 }
 
 // Inline date editor — click the tag to reveal a date input, blur to save.
-function InlineDate({ value, displayName, onSave }) {
+function InlineDate({ value, displayName, onSave, hideTag = false }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState('');
 
@@ -844,7 +851,7 @@ function InlineDate({ value, displayName, onSave }) {
     );
   }
 
-  const dateTag = renderDateTag(displayName || null, value);
+  const dateTag = hideTag ? null : renderDateTag(displayName || null, value);
   return (
     <span onClick={startEdit} className="cursor-pointer" title={t.edit || 'Edit'}>
       {dateTag || <span className="text-xs text-ios-tertiary/40">—</span>}
@@ -890,7 +897,7 @@ function StockRow({ item, premade, showRepairTools, onAdjust, onWriteOff, onPatc
       <tr className={`border-b border-gray-100 ${rowColor} hover:bg-gray-50/50`}>
         <td className="px-2 py-1.5 text-ios-label font-medium text-sm">{stockBaseName(item['Display Name'])}</td>
         <td className="px-2 py-1.5">
-          <InlineDate value={lastRestocked} displayName={item['Display Name']} onSave={v => onPatch(item.id, { 'Last Restocked': v || null })} />
+          <InlineDate value={lastRestocked} displayName={item['Display Name']} onSave={v => onPatch(item.id, { 'Last Restocked': v || null })} hideTag={isNegative} />
         </td>
         <td className={`px-2 py-1.5 text-right tabular-nums text-base font-bold ${
           isNegative ? 'text-red-600' : isZero ? 'text-ios-red' : isLow ? 'text-ios-orange' : 'text-ios-label'

--- a/apps/florist/src/components/PendingArrivalsSection.jsx
+++ b/apps/florist/src/components/PendingArrivalsSection.jsx
@@ -24,19 +24,29 @@ export default function PendingArrivalsSection({ stock, committedMap, onOrderCli
     return m;
   }, [stock]);
 
+  const stockQtyMap = useMemo(() => {
+    const m = {};
+    for (const s of (stock || [])) m[s.id] = Number(s['Current Quantity']) || 0;
+    return m;
+  }, [stock]);
+
   const rows = useMemo(() => {
     const ids = new Set(Object.keys(pendingPO));
     return [...ids].map(stockId => {
       const po = pendingPO[stockId] || { ordered: 0, pos: [] };
       const com = (committedMap || {})[stockId] || { committed: 0, orders: [] };
-      const net = po.ordered - com.committed;
+      // Negative qty = demand already baked in (CLAUDE.md pitfall #7).
+      // /stock/committed returns the same number but reads Airtable (broken until #229).
+      // Use whichever is larger — they should match once #229 is fixed.
+      const committed = Math.max(com.committed, Math.max(0, -(stockQtyMap[stockId] || 0)));
+      const net = po.ordered - committed;
       return {
         stockId,
         // Prefer PO line flower name (user-entered) over stock Display Name
         name: ((po.flowerName || '').length >= (nameMap[stockId] || '').length
           ? po.flowerName : nameMap[stockId]) || po.flowerName || '—',
         ordered: po.ordered,
-        committed: com.committed,
+        committed,
         net,
         pos: po.pos || [],
         orders: com.orders || [],
@@ -44,7 +54,7 @@ export default function PendingArrivalsSection({ stock, committedMap, onOrderCli
       };
     }).filter(r => r.ordered > 0)
       .sort((a, b) => a.net - b.net);
-  }, [pendingPO, committedMap, nameMap]);
+  }, [pendingPO, committedMap, nameMap, stockQtyMap]);
 
   if (loading || rows.length === 0) return null;
 

--- a/apps/florist/src/components/StockItem.jsx
+++ b/apps/florist/src/components/StockItem.jsx
@@ -110,7 +110,7 @@ export default function StockItem({ item, editMode, onAdjust, onWriteOff, onPatc
                 setDateDraft(item['Last Restocked'] ? item['Last Restocked'].split('T')[0] : '');
                 setEditingDate(true);
               }}>
-                {renderDateTag(item['Display Name'], item['Last Restocked'])}
+                {!isNeg && renderDateTag(item['Display Name'], item['Last Restocked'])}
               </span>
             )}
           </div>


### PR DESCRIPTION
## Changes

### Bug 1 — Received date shown on negative-stock items

Negative qty means the physical batch is gone (consumed by orders). The last-received date is stale/misleading when `qty < 0`.

- `StockItem.jsx` — guard `renderDateTag` with `!isNeg`
- `StockTab.jsx` (dashboard) — added `hideTag` prop to `InlineDate`, passed `hideTag={isNegative}` from `StockRow`

### Bug 2 — Committed column always "—" in Pending Arrivals

`GET /stock/committed` reads `db.list(TABLES.ORDERS)` — Airtable, frozen since Phase 4 cutover (2026-05-02). Returns `{}` → `committedMap` always empty → column shows "—" → Net = Ordered (wrong).

Per CLAUDE.md pitfall #7: `Current Quantity` already has all demand baked in. Negative qty IS the committed shortfall. Derive: `committed = max(endpoint_value, max(0, -qty))`. Takes max so it stays correct once issue #229 fixes the backend endpoint.

Result: Rosa garden salvia pink (qty=-3, ordered=12) → Committed=3, Net=+9 ✓

Both changes applied to florist app and dashboard (parity).

## Test plan

- [ ] Negative-stock items show no date badge in Received column (florist + dashboard)
- [ ] Pending Arrivals Committed column shows the negative qty as shortfall
- [ ] Net column = Ordered − Committed
- [ ] Both apps build clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)