### PR TITLE
fix(feedback): language detection, modal redesign, clipboard paste, markdown fence fix

### DIFF
--- a/backend/src/__tests__/feedbackService.test.js
+++ b/backend/src/__tests__/feedbackService.test.js
@@ -35,7 +35,7 @@ function doneResponse(overrides = {}) {
       englishDescription: 'The save button on the Order edit screen does nothing when tapped.',
       acceptanceCriteria: ['Tapping Save on the Order edit screen saves changes'],
       originalQuote: 'кнопка не работает',
-      russianSummary: 'Кнопка сохранения на экране редактирования заказа не работает.',
+      summary: 'Кнопка сохранения на экране редактирования заказа не работает.',
       ...overrides,
     }) }],
   };
@@ -110,7 +110,7 @@ describe('startSession', () => {
         englishDescription: 'Add date range filter for delivery/pickup dates.',
         acceptanceCriteria: ['Orders tab has delivery date filter'],
         originalQuote: 'filter by delivery date',
-        russianSummary: 'Добавить фильтр по дате доставки.',
+        summary: 'Добавить фильтр по дате доставки.',
       }) + '\n```' }],
     });
     const result = await startSession({ text: 'filter by delivery date', reporterRole: 'owner', reporterName: 'Owner' });
@@ -199,7 +199,7 @@ describe('continueSession', () => {
 // ── previewSession ────────────────────────────────────────────────────────────
 
 describe('previewSession', () => {
-  it('returns russianSummary from completed session', async () => {
+  it('returns summary from completed session', async () => {
     const { sessionId } = await startSession({
       text: 'кнопка не работает',
       reporterRole: 'florist',

--- a/backend/src/__tests__/feedbackService.test.js
+++ b/backend/src/__tests__/feedbackService.test.js
@@ -102,13 +102,28 @@ describe('startSession', () => {
     expect(sessions.get(sessionId).appArea).toBe('dashboard');
   });
 
-  it('falls back to done:false + Russian error on malformed AI JSON', async () => {
+  it('strips markdown fences and parses JSON correctly', async () => {
     mockCreate.mockResolvedValueOnce({
-      content: [{ text: '```json\n{"done": true}\n```' }],  // markdown fences break parse
+      content: [{ text: '```json\n' + JSON.stringify({
+        done: true, type: 'feature',
+        englishTitle: 'Filter orders by delivery date',
+        englishDescription: 'Add date range filter for delivery/pickup dates.',
+        acceptanceCriteria: ['Orders tab has delivery date filter'],
+        originalQuote: 'filter by delivery date',
+        russianSummary: 'Добавить фильтр по дате доставки.',
+      }) + '\n```' }],
+    });
+    const result = await startSession({ text: 'filter by delivery date', reporterRole: 'owner', reporterName: 'Owner' });
+    expect(result.done).toBe(true);
+    expect(sessions.get(result.sessionId).type).toBe('feature');
+  });
+
+  it('falls back to Russian error only on truly unparseable response', async () => {
+    mockCreate.mockResolvedValueOnce({
+      content: [{ text: 'Sorry, I cannot help with that.' }], // plain prose — not JSON at all
     });
     const result = await startSession({ text: 'x', reporterRole: 'driver', reporterName: 'Timur' });
     expect(result.done).toBe(false);
-    expect(typeof result.question).toBe('string');
     expect(result.question).toMatch(/Извините/);
   });
 });

--- a/backend/src/services/feedbackService.js
+++ b/backend/src/services/feedbackService.js
@@ -64,10 +64,18 @@ async function callAI(messages) {
     messages,
   });
 
-  const text = res.content[0]?.text || '{}';
+  const raw = res.content[0]?.text || '{}';
+  // Haiku occasionally wraps JSON in ```json ... ``` despite instructions — strip fences.
+  const fenceMatch = raw.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+  const text = fenceMatch ? fenceMatch[1] : raw;
   try {
     return JSON.parse(text);
   } catch {
+    // Last resort: find the outermost JSON object in the response
+    const objMatch = raw.match(/\{[\s\S]*\}/);
+    if (objMatch) {
+      try { return JSON.parse(objMatch[0]); } catch {}
+    }
     return { done: false, question: 'Извините, что-то пошло не так. Пожалуйста, опишите проблему ещё раз.' };
   }
 }

--- a/backend/src/services/feedbackService.js
+++ b/backend/src/services/feedbackService.js
@@ -44,16 +44,17 @@ Domain glossary (use exact terms in issue bodies — never use the "Avoid" alter
 For BUG reports, you need: which screen, what action was taken, what actually happened, what should have happened.
 For FEATURE REQUESTS, you need: what problem needs solving, what success looks like.
 
-Ask ONE clarifying question at a time in plain Russian. Keep questions short with a concrete example.
+Ask ONE clarifying question at a time. Keep questions short with a concrete example.
+IMPORTANT: Respond in the SAME language the reporter used. If they write in Russian, respond in Russian. If English, respond in English. Match their language exactly.
 When you have enough information, respond with done:true and all fields.
 
 ALWAYS respond with valid JSON only — no markdown fences, no extra text:
 
 If more info needed:
-{"done": false, "question": "Russian question string"}
+{"done": false, "question": "question in reporter's language"}
 
 When complete:
-{"done": true, "type": "bug", "englishTitle": "Short English title under 70 chars", "englishDescription": "Clear English description of the problem and context", "acceptanceCriteria": ["English criterion 1", "English criterion 2"], "originalQuote": "reporter's exact words", "russianSummary": "Plain Russian summary of what will be submitted — 2-3 sentences"}
+{"done": true, "type": "bug", "englishTitle": "Short English title under 70 chars", "englishDescription": "Clear English description of the problem and context", "acceptanceCriteria": ["English criterion 1", "English criterion 2"], "originalQuote": "reporter's exact words", "summary": "Plain summary in reporter's language — 2-3 sentences"}
 Note: "type" must be exactly "bug" or "feature" — no other values.`;
 
 async function callAI(messages) {
@@ -106,7 +107,7 @@ export async function startSession({ text, appArea, reporterRole, reporterName }
       englishDescription: aiResult.englishDescription || text,
       acceptanceCriteria: aiResult.acceptanceCriteria || [],
       originalQuote: aiResult.originalQuote || text,
-      russianSummary: aiResult.russianSummary || text,
+      summary: (aiResult.summary ?? aiResult.russianSummary) || text,
       type: aiResult.type || 'bug',
     });
     sessions.set(sessionId, session);
@@ -148,7 +149,7 @@ export async function continueSession(sessionId, message) {
       englishDescription: aiResult.englishDescription || message,
       acceptanceCriteria: aiResult.acceptanceCriteria || [],
       originalQuote: aiResult.originalQuote || nextMessages[0]?.content || message,
-      russianSummary: aiResult.russianSummary || message,
+      summary: (aiResult.summary ?? aiResult.russianSummary) || message,
       type: aiResult.type || 'bug',
     });
     return { done: true };
@@ -165,7 +166,7 @@ export async function previewSession(sessionId) {
   const session = sessions.get(sessionId);
   if (!session) throw new Error('Session not found or expired');
   if (!session.done) throw new Error('Session not complete yet');
-  return { summary: session.russianSummary };
+  return { summary: session.summary };
 }
 
 /**

--- a/packages/shared/components/FeedbackModal.jsx
+++ b/packages/shared/components/FeedbackModal.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import client from '../api/client.js';
 
 /*
@@ -152,137 +152,132 @@ export default function FeedbackModal({ t, reporterRole, reporterName, appArea, 
     }
   }
 
+  // Clipboard paste — picks up images pasted anywhere in the modal
+  const handlePaste = useCallback((e) => {
+    const item = Array.from(e.clipboardData?.items || []).find(i => i.type.startsWith('image/'));
+    if (item) {
+      const file = item.getAsFile();
+      if (file) setImageFile(file);
+    }
+  }, []);
+
+  const inputCls = `w-full rounded-2xl border border-gray-100 dark:border-gray-700 p-3 text-sm
+                    bg-gray-50 dark:bg-dark-elevated text-ios-label dark:text-dark-label
+                    focus:outline-none focus:ring-2 focus:ring-brand-400 resize-none`;
+  const btnPrimary = `w-full bg-brand-600 active:bg-brand-700 disabled:opacity-40 text-white
+                      font-semibold rounded-2xl py-3 text-sm flex items-center justify-center gap-2`;
+  const btnSecondary = `flex-1 bg-gray-100 dark:bg-dark-elevated active:bg-gray-200
+                        dark:active:bg-dark-card text-ios-label dark:text-dark-label
+                        font-semibold rounded-2xl py-3 text-sm`;
+
   return (
-    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
-      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
-      <div className="relative z-10 w-full max-w-md bg-white dark:bg-gray-800 rounded-t-2xl sm:rounded-2xl shadow-xl p-5 mx-2 mb-0 sm:mb-4">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-4">
-          <div className="flex items-center gap-2">
-            <IconFlag size={20} className="text-brand-600" />
-            <h2 className="font-semibold text-ios-label dark:text-dark-label">{t.reportTitle}</h2>
-          </div>
-          <button onClick={onClose} className="text-ios-tertiary hover:text-ios-label p-1">
-            <IconX size={20} />
-          </button>
+    <div className="fixed inset-0 z-50 flex items-end justify-center" onPaste={handlePaste}>
+      <div className="absolute inset-0 bg-black/30" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-lg bg-white dark:bg-dark-card
+                      rounded-t-3xl shadow-2xl animate-slide-up safe-area-bottom">
+        {/* Drag handle */}
+        <div className="flex justify-center pt-3 pb-1">
+          <div className="w-10 h-1 rounded-full bg-ios-separator dark:bg-dark-separator" />
         </div>
 
-        {/* Phase: input */}
-        {phase === 'input' && (
-          <div className="space-y-3">
-            <textarea
-              className="w-full rounded-xl border border-gray-200 dark:border-gray-600 p-3 text-sm
-                         bg-white dark:bg-gray-700 text-ios-label dark:text-dark-label
-                         focus:outline-none focus:ring-2 focus:ring-brand-400 resize-none"
-              rows={4}
-              placeholder={t.reportPlaceholder}
-              value={text}
-              onChange={e => setText(e.target.value)}
-              autoFocus
-            />
+        <div className="px-5 pb-6 pt-2">
+          {/* Header */}
+          <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-2">
+              <IconFlag size={18} className="text-brand-600" />
+              <h2 className="font-semibold text-ios-label dark:text-dark-label">{t.reportTitle}</h2>
+            </div>
+            <button onClick={onClose}
+              className="w-8 h-8 rounded-full bg-gray-100 dark:bg-dark-elevated
+                         flex items-center justify-center text-ios-tertiary dark:text-dark-tertiary
+                         active:bg-gray-200">
+              <IconX size={16} />
+            </button>
+          </div>
+
+          {/* Phase: input */}
+          {phase === 'input' && (
+            <div className="space-y-3">
+              <textarea className={inputCls} rows={4}
+                placeholder={t.reportPlaceholder} value={text}
+                onChange={e => setText(e.target.value)} autoFocus />
               <button
                 onClick={() => fileRef.current?.click()}
-                className="flex items-center gap-1.5 text-xs text-ios-secondary dark:text-gray-400
-                           border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-2"
+                className="flex items-center gap-1.5 text-xs text-ios-secondary dark:text-dark-secondary
+                           bg-gray-100 dark:bg-dark-elevated rounded-xl px-3 py-2 active:opacity-70"
               >
                 <IconImagePlus size={14} />
-                {imageFile ? imageFile.name.slice(0, 20) : t.reportAddScreenshot}
+                {imageFile ? `📎 ${imageFile.name.slice(0, 25)}` : t.reportAddScreenshot}
               </button>
               <input ref={fileRef} type="file" accept="image/*" className="hidden"
                 onChange={e => setImageFile(e.target.files[0] || null)} />
-            </div>
-            <button
-              onClick={handleStart}
-              disabled={loading || !text.trim()}
-              className="w-full bg-brand-600 hover:bg-brand-700 disabled:opacity-50 text-white
-                         font-medium rounded-xl py-3 text-sm flex items-center justify-center gap-2"
-            >
-              {loading && <IconSpinner size={16} className="animate-spin" />}
-              {loading ? t.reportThinking : t.reportSend}
-            </button>
-          </div>
-        )}
-
-        {/* Phase: asking (follow-up question) */}
-        {phase === 'asking' && (
-          <div className="space-y-3">
-            <p className="text-sm text-ios-label dark:text-dark-label bg-gray-50 dark:bg-gray-700
-                          rounded-xl p-3">{question}</p>
-            <textarea
-              className="w-full rounded-xl border border-gray-200 dark:border-gray-600 p-3 text-sm
-                         bg-white dark:bg-gray-700 text-ios-label dark:text-dark-label
-                         focus:outline-none focus:ring-2 focus:ring-brand-400 resize-none"
-              rows={3}
-              placeholder={t.reportPlaceholder}
-              value={answer}
-              onChange={e => setAnswer(e.target.value)}
-              autoFocus
-            />
-            <button
-              onClick={handleContinue}
-              disabled={loading || !answer.trim()}
-              className="w-full bg-brand-600 hover:bg-brand-700 disabled:opacity-50 text-white
-                         font-medium rounded-xl py-3 text-sm flex items-center justify-center gap-2"
-            >
-              {loading && <IconSpinner size={16} className="animate-spin" />}
-              {loading ? t.reportThinking : t.reportSend}
-            </button>
-          </div>
-        )}
-
-        {/* Phase: preview */}
-        {phase === 'preview' && (
-          <div className="space-y-3">
-            <p className="text-xs font-medium text-ios-secondary dark:text-gray-400 uppercase tracking-wide">
-              {t.reportPreviewTitle}
-            </p>
-            <p className="text-sm text-ios-label dark:text-dark-label bg-gray-50 dark:bg-gray-700
-                          rounded-xl p-3">{summary}</p>
-            <div className="flex gap-2">
-              <button
-                onClick={() => { setPhase('input'); setAnswer(''); }}
-                className="flex-1 border border-gray-200 dark:border-gray-600 text-ios-label
-                           dark:text-dark-label font-medium rounded-xl py-3 text-sm"
-              >
-                {t.reportCorrect}
-              </button>
-              <button
-                onClick={handlePublish}
-                disabled={loading}
-                className="flex-1 bg-brand-600 hover:bg-brand-700 disabled:opacity-50 text-white
-                           font-medium rounded-xl py-3 text-sm flex items-center justify-center gap-2"
-              >
+              <button onClick={handleStart} disabled={loading || !text.trim()} className={btnPrimary}>
                 {loading && <IconSpinner size={16} className="animate-spin" />}
-                {loading ? t.reportThinking : t.reportConfirm}
+                {loading ? t.reportThinking : t.reportSend}
               </button>
             </div>
-          </div>
-        )}
+          )}
 
-        {/* Phase: done */}
-        {phase === 'done' && (
-          <div className="space-y-3 text-center py-2">
-            <IconCheckCircle size={40} className="text-green-500 mx-auto" />
-            <p className="text-sm font-medium text-ios-label dark:text-dark-label">{t.reportSuccess}</p>
-            <button onClick={onClose}
-              className="w-full bg-brand-600 text-white font-medium rounded-xl py-3 text-sm">
-              OK
-            </button>
-          </div>
-        )}
+          {/* Phase: asking */}
+          {phase === 'asking' && (
+            <div className="space-y-3">
+              <div className="bg-brand-50 dark:bg-brand-900/20 rounded-2xl p-3">
+                <p className="text-sm text-ios-label dark:text-dark-label">{question}</p>
+              </div>
+              <textarea className={inputCls} rows={3}
+                placeholder={t.reportPlaceholder} value={answer}
+                onChange={e => setAnswer(e.target.value)} autoFocus />
+              <button onClick={handleContinue} disabled={loading || !answer.trim()} className={btnPrimary}>
+                {loading && <IconSpinner size={16} className="animate-spin" />}
+                {loading ? t.reportThinking : t.reportSend}
+              </button>
+            </div>
+          )}
 
-        {/* Phase: error */}
-        {phase === 'error' && (
-          <div className="space-y-3">
-            <p className="text-sm text-red-500">{t.reportError}</p>
-            <button onClick={() => { setPhase('input'); setSessionId(null); setQuestion(''); setAnswer(''); setSummary(''); setIssueUrl(''); }}
-              className="w-full border border-gray-200 dark:border-gray-600 text-ios-label
-                         dark:text-dark-label font-medium rounded-xl py-3 text-sm">
-              {t.reportRetry}
-            </button>
-          </div>
-        )}
+          {/* Phase: preview */}
+          {phase === 'preview' && (
+            <div className="space-y-3">
+              <p className="text-xs font-semibold text-ios-tertiary dark:text-dark-tertiary uppercase tracking-wider">
+                {t.reportPreviewTitle}
+              </p>
+              <div className="bg-gray-50 dark:bg-dark-elevated rounded-2xl p-4">
+                <p className="text-sm text-ios-label dark:text-dark-label leading-relaxed">{summary}</p>
+              </div>
+              <div className="flex gap-2">
+                <button onClick={() => { setPhase('input'); setAnswer(''); }} className={btnSecondary}>
+                  {t.reportCorrect}
+                </button>
+                <button onClick={handlePublish} disabled={loading}
+                  className="flex-1 bg-brand-600 active:bg-brand-700 disabled:opacity-40 text-white
+                             font-semibold rounded-2xl py-3 text-sm flex items-center justify-center gap-2">
+                  {loading && <IconSpinner size={16} className="animate-spin" />}
+                  {loading ? t.reportThinking : t.reportConfirm}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Phase: done */}
+          {phase === 'done' && (
+            <div className="space-y-4 text-center py-3">
+              <IconCheckCircle size={44} className="text-green-500 mx-auto" />
+              <p className="text-sm font-medium text-ios-label dark:text-dark-label">{t.reportSuccess}</p>
+              <button onClick={onClose} className={btnPrimary}>OK</button>
+            </div>
+          )}
+
+          {/* Phase: error */}
+          {phase === 'error' && (
+            <div className="space-y-3">
+              <p className="text-sm text-red-500 dark:text-red-400">{t.reportError}</p>
+              <button
+                onClick={() => { setPhase('input'); setSessionId(null); setQuestion(''); setAnswer(''); setSummary(''); setIssueUrl(''); }}
+                className={btnSecondary + ' w-full'}>
+                {t.reportRetry}
+              </button>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Post-merge fixes for the Report system (#245):

- **Language**: AI now responds in the reporter's language (English input → English questions/summary). Was hardcoded Russian.
- **Modal design**: matches the rest of the apps — `dark:bg-dark-card`, `rounded-t-3xl`, `animate-slide-up`, drag handle, same button/card styles as `Sheet.jsx`
- **Clipboard paste**: Cmd+V anywhere in the modal attaches a screenshot (no need to click the file button)
- **Markdown fences**: `callAI` now strips ` ```json ``` ` wrappers before parsing — Haiku wraps JSON despite instructions; this caused the "Извините" fallback on first submit

## Verification

- ✅ `cd backend && npx vitest run src/__tests__/feedbackService.test.js` — 19/19 pass
- ✅ All 3 apps build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)