### PR TITLE
refactor(backend): service-layer cleanup — 4 architectural depth improvements

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -63,7 +63,6 @@ scripts/           → Backfill, shadow-health, start-test-backend, etc.
 | telegram.js | Telegram Bot API wrapper — new-order + delivery-landed alerts. |
 | intake-parser.js | Claude Haiku integration for parsing freeform text / Flowwow emails into structured orders. |
 | analyticsService.js | Pure math functions for financial KPIs (no DB calls). |
-| webhookLog.js | Persists webhook events to Webhook Log table. |
 | driverState.js | In-memory backup driver state (resets daily at midnight). |
 
 ## Database (in transition — Phase 3+ SQL migration)

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -31,7 +31,7 @@ scripts/           → Backfill, shadow-health, start-test-backend, etc.
 | premadeBouquets.js | CRUD /premade-bouquets | Premade bouquet templates (composed of stock items) |
 | dashboard.js | GET /dashboard | Today's operational summary for owner |
 | analytics.js | GET /analytics | Financial KPIs with period comparison |
-| settings.js | GET/POST /settings | App config persistence (Airtable App Config table). Also exports `getConfig`/`getDriverOfDay`/`generateOrderId` — TODO move to `services/appConfig.js`. |
+| settings.js | GET/POST /settings | Thin HTTP layer for app config. State lives in `services/configService.js`. Re-exports its getters for backward compat — callers should migrate to importing from configService directly. |
 | products.js | POST /products/pull\|push\|sync\|translate, GET /products/push/status/:jobId | Bidirectional Wix product sync. Push runs as an async job (see `wixPushJob.js`) — POST /push returns 202 + jobId, the modal polls /push/status. /push/sync is the legacy synchronous variant kept for curl debugging. |
 | productImages.js | POST/DELETE /products/:wixProductId/image | Bouquet image upload (florist+owner) and removal (owner only). Orchestrates Wix Media upload + Wix Stores attach via `wixMediaClient.js`, persists URL via `productRepo`, audits as `image_set` / `image_remove`, broadcasts SSE `product_image_changed`. |
 | orderImages.js | POST/DELETE /orders/:orderId/image | Per-order bouquet image override. Florist+owner upload, owner-only remove. Uploads to Wix Media, writes `Image URL` on the order via `orderRepo.updateOrder`, reaps the previous Wix file via `deleteFiles`, audits as `image_set`/`image_remove` (entityType `order`), broadcasts SSE `order_image_changed`. Mounted before orders.js so it bypasses any future role gating there. |
@@ -63,6 +63,7 @@ scripts/           → Backfill, shadow-health, start-test-backend, etc.
 | telegram.js | Telegram Bot API wrapper — new-order + delivery-landed alerts. |
 | intake-parser.js | Claude Haiku integration for parsing freeform text / Flowwow emails into structured orders. |
 | analyticsService.js | Pure math functions for financial KPIs (no DB calls). |
+| configService.js | App config singleton — DEFAULTS, in-memory config state, loadConfig/saveConfig, migrations, driver-of-day daily state, cutoff reminder interval. Exports: `getConfig`, `updateConfig`, `generateOrderId`, `getDriverOfDay`, `isPastCutoff`, `getActiveSeasonalCategory`. Import from here, not from routes/settings.js. |
 | driverState.js | In-memory backup driver state (resets daily at midnight). |
 
 ## Database (in transition — Phase 3+ SQL migration)

--- a/backend/src/repos/stockLossRepo.js
+++ b/backend/src/repos/stockLossRepo.js
@@ -21,27 +21,34 @@ function toWire(row) {
   };
 }
 
+const JOINED_FIELDS = {
+  id:               stockLossLog.id,
+  date:             stockLossLog.date,
+  stockId:          stockLossLog.stockId,
+  quantity:         stockLossLog.quantity,
+  reason:           stockLossLog.reason,
+  notes:            stockLossLog.notes,
+  displayName:      stock.displayName,
+  purchaseName:     stock.purchaseName,
+  supplier:         stock.supplier,
+  costPrice:        stock.currentCostPrice,
+  lastRestocked:    stock.lastRestocked,
+  stockAirtableId:  stock.airtableId,
+};
+
+async function enrichById(id) {
+  const [row] = await db.select(JOINED_FIELDS).from(stockLossLog)
+    .leftJoin(stock, eq(stockLossLog.stockId, stock.id))
+    .where(eq(stockLossLog.id, id));
+  return row ? toWire(row) : null;
+}
+
 export async function list({ from, to } = {}) {
   const conditions = [isNull(stockLossLog.deletedAt)];
   if (from) conditions.push(gte(stockLossLog.date, from));
   if (to)   conditions.push(lte(stockLossLog.date, to));
 
-  const rows = await db
-    .select({
-      id:               stockLossLog.id,
-      date:             stockLossLog.date,
-      stockId:          stockLossLog.stockId,
-      quantity:         stockLossLog.quantity,
-      reason:           stockLossLog.reason,
-      notes:            stockLossLog.notes,
-      displayName:      stock.displayName,
-      purchaseName:     stock.purchaseName,
-      supplier:         stock.supplier,
-      costPrice:        stock.currentCostPrice,
-      lastRestocked:    stock.lastRestocked,
-      stockAirtableId:  stock.airtableId,
-    })
-    .from(stockLossLog)
+  const rows = await db.select(JOINED_FIELDS).from(stockLossLog)
     .leftJoin(stock, eq(stockLossLog.stockId, stock.id))
     .where(and(...conditions))
     .orderBy(desc(stockLossLog.date));
@@ -64,28 +71,7 @@ export async function create({ date, stockId, quantity, reason, notes }) {
   if (stockId) values.stockId = stockId;
 
   const [row] = await db.insert(stockLossLog).values(values).returning();
-
-  // Enrich response via a JOIN so the mobile UI can render immediately
-  const [enriched] = await db
-    .select({
-      id:           stockLossLog.id,
-      date:         stockLossLog.date,
-      stockId:      stockLossLog.stockId,
-      quantity:     stockLossLog.quantity,
-      reason:       stockLossLog.reason,
-      notes:        stockLossLog.notes,
-      displayName:      stock.displayName,
-      purchaseName:     stock.purchaseName,
-      supplier:         stock.supplier,
-      costPrice:        stock.currentCostPrice,
-      lastRestocked:    stock.lastRestocked,
-      stockAirtableId:  stock.airtableId,
-    })
-    .from(stockLossLog)
-    .leftJoin(stock, eq(stockLossLog.stockId, stock.id))
-    .where(eq(stockLossLog.id, row.id));
-
-  return enriched ? toWire(enriched) : toWire(row);
+  return (await enrichById(row.id)) ?? toWire(row);
 }
 
 export async function update(id, { quantity, reason, notes, date }) {
@@ -96,26 +82,7 @@ export async function update(id, { quantity, reason, notes, date }) {
   if (date     != null) updates.date     = date;
   const [row] = await db.update(stockLossLog).set(updates).where(eq(stockLossLog.id, id)).returning();
   if (!row) throw Object.assign(new Error('Not found'), { status: 404 });
-  // Re-fetch with JOIN so enrichment fields (flowerName, supplier, etc.) are populated.
-  const [enriched] = await db
-    .select({
-      id:               stockLossLog.id,
-      date:             stockLossLog.date,
-      stockId:          stockLossLog.stockId,
-      quantity:         stockLossLog.quantity,
-      reason:           stockLossLog.reason,
-      notes:            stockLossLog.notes,
-      displayName:      stock.displayName,
-      purchaseName:     stock.purchaseName,
-      supplier:         stock.supplier,
-      costPrice:        stock.currentCostPrice,
-      lastRestocked:    stock.lastRestocked,
-      stockAirtableId:  stock.airtableId,
-    })
-    .from(stockLossLog)
-    .leftJoin(stock, eq(stockLossLog.stockId, stock.id))
-    .where(eq(stockLossLog.id, row.id));
-  return enriched ? toWire(enriched) : toWire(row);
+  return (await enrichById(row.id)) ?? toWire(row);
 }
 
 export async function remove(id) {

--- a/backend/src/repos/webhookLogRepo.js
+++ b/backend/src/repos/webhookLogRepo.js
@@ -15,6 +15,8 @@ export async function listRecent(limit = 20) {
   }));
 }
 
+// rawPayload is intentionally not persisted — too large for a DB column;
+// Railway logs capture it via console.log in wix.js.
 export async function logEvent({ status, wixOrderId, appOrderId, errorMessage }) {
   try {
     await db.insert(webhookLog).values({

--- a/backend/src/routes/settings.js
+++ b/backend/src/routes/settings.js
@@ -1,363 +1,28 @@
-// Settings routes — config persisted to Airtable, daily settings in memory.
-// Like a factory config binder stored in the central filing cabinet (Airtable)
-// instead of on a whiteboard that gets erased when the lights go off.
-// Daily preferences (driver-of-day) still reset at midnight — that's intentional.
-
+// Settings routes — HTTP layer for app configuration.
+// State + business logic lives in services/configService.js.
 import { Router } from 'express';
 import { authorize } from '../middleware/auth.js';
 import { getBackupDriverName, setBackupDriverName } from '../services/driverState.js';
-import * as db from '../services/airtable.js';
-import { TABLES } from '../config/airtable.js';
-import { sendAlert } from '../services/telegram.js';
 import { DELIVERY_STATUS } from '../constants/statuses.js';
-import * as appConfigRepo from '../repos/appConfigRepo.js';
-import * as productConfigRepo from '../repos/productConfigRepo.js';
 import * as orderRepo from '../repos/orderRepo.js';
+import {
+  getConfig, getAllConfig, updateConfigBulk,
+  getDriverOfDay, setDailyDriver, getDailyState,
+  driverNames, autoClearIfNewDay,
+} from '../services/configService.js';
+
+// Re-export for backward-compat with existing callers that haven't been updated yet.
+// TODO: remove once all callers import directly from configService.
+export { getConfig, updateConfig, generateOrderId, isPastCutoff, getActiveSeasonalCategory, getDriverOfDay } from '../services/configService.js';
 
 const router = Router();
-
-// ── Default configuration values ────────────────────────────
-// Used as fallback if Airtable config row doesn't exist yet or is empty.
-const DEFAULTS = {
-  defaultDeliveryFee: 35,
-  targetMarkup:       2.2,
-  suppliers:          ['Stojek', '4f', 'Stefan', 'Mateusz', 'Other'],
-  stockCategories:    ['Roses', 'Tulips', 'Seasonal', 'Greenery', 'Accessories', 'Other'],
-  paymentMethods:     ['Cash', 'Card', 'Mbank', 'Monobank', 'Revolut', 'PayPal', 'Wix Online'],
-  orderSources:       ['In-store', 'Instagram', 'WhatsApp', 'Telegram', 'Wix', 'Flowwow', 'Other'],
-  driverCostPerDelivery: 35,
-  driverCostPerPORun: 45,
-  floristNames: ['Anya', 'Daria'],
-  rateTypes: ['Standard', 'Wedding', 'Holidays'],
-  floristRates: {},
-  extraDrivers: [],
-  storefrontCategories: {
-    permanent: [
-      { name: 'All Bouquets', slug: 'all-bouquets', description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
-      { name: 'Bestsellers',  slug: 'bestsellers',  description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
-    ],
-    seasonal: [
-      { name: "Valentine's Day", slug: 'valentines-day', from: '01-25', to: '02-15', description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
-      { name: "Women's Day",     slug: 'womens-day',     from: '02-25', to: '03-10', description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
-      { name: "Mother's Day",    slug: 'mothers-day',    from: '04-20', to: '05-26', description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
-      { name: 'Easter',          slug: 'easter',         from: '03-28', to: '04-15', description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
-      { name: 'Christmas',       slug: 'christmas',      from: '12-01', to: '12-26', description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
-    ],
-    auto: [
-      {
-        name: 'Available Today',
-        slug: 'available-today',
-        description: 'Bouquets ready for same-day delivery or pickup.',
-        translations: {
-          en: { title: 'Available Today',   description: 'Bouquets ready for same-day delivery or pickup.' },
-          pl: { title: 'Dostępne dziś',     description: 'Bukiety gotowe do dostawy lub odbioru tego samego dnia.' },
-          ru: { title: 'Доступно сегодня',  description: 'Букеты, готовые к доставке или самовывозу сегодня.' },
-          uk: { title: 'Доступно сьогодні', description: 'Букети, готові до доставки або самовивозу сьогодні.' },
-        },
-      },
-    ],
-    autoSchedule: true,
-    manualOverride: null,
-    wixCategoryMap: {},
-  },
-  deliveryZones: [
-    { id: 1, name: 'Central Krakow', fee: 35, postcodes: ['30-0', '30-1', '31-0'] },
-    { id: 2, name: 'Suburbs',        fee: 50, postcodes: ['32-0'] },
-    { id: 3, name: 'Out of city',    fee: 80, postcodes: [] },
-  ],
-  freeDeliveryThreshold: 300,
-  expressSurcharge: 20,
-  deliveryTimeSlots: ['10:00-12:00', '12:00-14:00', '14:00-16:00', '16:00-18:00'],
-  availableTodayCutoff: '18:00',
-  availableTodayTimezone: 'Europe/Warsaw',
-  cutoffReminderLastDate: null,
-  slotLeadTimeMinutes: 30,
-  // Shows the per-row "Reconcile premade" action on stock rows in the dashboard.
-  // Off by default — it's admin tooling for fixing historical data mismatches,
-  // not something the florist should tap in daily use.
-  showStockRepairTools: false,
-};
-
-// ── In-memory config (loaded from Postgres on startup) ──────
-let config = structuredClone(DEFAULTS);
-let configLoaded = false;
-
-/**
- * Load config from Postgres App Config table.
- * Merges stored values over defaults so new keys auto-appear.
- */
-async function loadConfig() {
-  try {
-    const stored = await appConfigRepo.get('config');
-    if (stored) {
-      config = deepMerge(DEFAULTS, stored);
-      migrateSeasonalDates();
-      migrateCategoryObjects();
-      migrateAutoCategoryTranslations();
-      migrateFloristRates();
-      console.log('[SETTINGS] Config loaded from Postgres');
-    } else {
-      await appConfigRepo.set('config', DEFAULTS);
-      console.log('[SETTINGS] Config row created in Postgres with defaults');
-    }
-  } catch (err) {
-    console.error('[SETTINGS] Failed to load config from Postgres:', err.message);
-    console.warn('[SETTINGS] Using in-memory defaults');
-  }
-  configLoaded = true;
-}
-
-/**
- * Save current config to Postgres.
- */
-async function saveConfig() {
-  try {
-    await appConfigRepo.set('config', config);
-  } catch (err) {
-    console.error('[SETTINGS] Failed to save config to Postgres:', err.message);
-  }
-}
-
-/**
- * Deep merge: target gets source values, preserving nested structure.
- * Arrays are replaced (not merged) — source array wins entirely.
- */
-function deepMerge(target, source) {
-  const result = { ...target };
-  for (const key of Object.keys(source)) {
-    if (
-      source[key] !== null &&
-      typeof source[key] === 'object' &&
-      !Array.isArray(source[key]) &&
-      typeof target[key] === 'object' &&
-      !Array.isArray(target[key])
-    ) {
-      result[key] = deepMerge(target[key] || {}, source[key]);
-    } else {
-      result[key] = source[key];
-    }
-  }
-  return result;
-}
-
-/**
- * Normalize seasonal dates to MM-DD format.
- * Handles DD-MM, DD.MM, MM.DD — auto-detects by checking if first part > 12.
- */
-function normalizeMMDD(val) {
-  if (!val) return val;
-  const clean = val.replace(/\./g, '-');
-  const parts = clean.split('-');
-  if (parts.length !== 2) return clean;
-  const [a, b] = parts.map(p => p.trim().padStart(2, '0'));
-  if (Number(a) > 12) return `${b}-${a}`;
-  return `${a}-${b}`;
-}
-
-function migrateSeasonalDates() {
-  const sc = config.storefrontCategories;
-  if (!sc?.seasonal) return;
-  let changed = false;
-  for (const entry of sc.seasonal) {
-    const newFrom = normalizeMMDD(entry.from);
-    const newTo = normalizeMMDD(entry.to);
-    if (newFrom !== entry.from || newTo !== entry.to) {
-      console.log(`[SETTINGS] Migrating dates for "${entry.name}": ${entry.from}→${newFrom}, ${entry.to}→${newTo}`);
-      entry.from = newFrom;
-      entry.to = newTo;
-      changed = true;
-    }
-  }
-  if (changed) {
-    saveConfig().catch(err =>
-      console.error('[SETTINGS] Date migration save failed:', err.message)
-    );
-  }
-}
-
-/**
- * Migrate permanent and auto categories from plain string arrays to
- * object arrays with slug, description, and translations.
- * Backward-compat: stored Airtable config may still have the old format.
- */
-function migrateCategoryObjects() {
-  const sc = config.storefrontCategories;
-  if (!sc) return;
-  const emptyTranslations = { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } };
-  let changed = false;
-
-  // Permanent: string[] → object[]
-  if (Array.isArray(sc.permanent) && sc.permanent.length > 0 && typeof sc.permanent[0] === 'string') {
-    sc.permanent = sc.permanent.map(name => ({
-      name,
-      slug: name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-$/, ''),
-      description: '',
-      translations: JSON.parse(JSON.stringify(emptyTranslations)),
-    }));
-    changed = true;
-    console.log('[SETTINGS] Migrated permanent categories to object format');
-  }
-
-  // Auto: missing or string[]
-  if (!sc.auto) {
-    sc.auto = DEFAULTS.storefrontCategories.auto;
-    changed = true;
-  } else if (Array.isArray(sc.auto) && sc.auto.length > 0 && typeof sc.auto[0] === 'string') {
-    sc.auto = sc.auto.map(name => ({
-      name,
-      slug: name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-$/, ''),
-      description: '',
-      translations: JSON.parse(JSON.stringify(emptyTranslations)),
-    }));
-    changed = true;
-    console.log('[SETTINGS] Migrated auto categories to object format');
-  }
-
-  if (changed) {
-    saveConfig().catch(err =>
-      console.error('[SETTINGS] Category migration save failed:', err.message)
-    );
-  }
-}
-
-/**
- * Backfill default translations for auto categories (e.g. "Available Today")
- * when the stored config has empty title/description strings. The Wix site's
- * Velo code resolves menu labels by slug and falls through to the hardcoded
- * English `cat.name` when translations are empty — which is why the menu only
- * rendered in the English language. Filling in real EN/PL/RU/UK strings lets
- * the menu label translate automatically across all languages.
- */
-function migrateAutoCategoryTranslations() {
-  const sc = config.storefrontCategories;
-  if (!sc?.auto || !Array.isArray(sc.auto)) return;
-  let changed = false;
-
-  for (const stored of sc.auto) {
-    if (!stored || typeof stored !== 'object') continue;
-    const defaultEntry = (DEFAULTS.storefrontCategories.auto || [])
-      .find(d => d.slug === stored.slug);
-    if (!defaultEntry) continue;
-    if (!stored.translations) stored.translations = {};
-
-    for (const lang of ['en', 'pl', 'ru', 'uk']) {
-      const storedLang = stored.translations[lang] || {};
-      const defaultLang = defaultEntry.translations?.[lang] || {};
-      if (!storedLang.title && defaultLang.title) {
-        storedLang.title = defaultLang.title;
-        changed = true;
-      }
-      if (!storedLang.description && defaultLang.description) {
-        storedLang.description = defaultLang.description;
-        changed = true;
-      }
-      stored.translations[lang] = storedLang;
-    }
-
-    if (!stored.description && defaultEntry.description) {
-      stored.description = defaultEntry.description;
-      changed = true;
-    }
-  }
-
-  if (changed) {
-    console.log('[SETTINGS] Backfilled auto-category translations');
-    saveConfig().catch(err =>
-      console.error('[SETTINGS] Auto-category translation backfill save failed:', err.message)
-    );
-  }
-}
-
-/**
- * Migrate floristRates from flat format { name: number } to
- * per-type format { name: { type: number } }.
- * Old single rate becomes the first rateType (Standard).
- */
-function migrateFloristRates() {
-  const rates = config.floristRates;
-  if (!rates || typeof rates !== 'object') return;
-  let changed = false;
-  const defaultType = (config.rateTypes && config.rateTypes[0]) || 'Standard';
-  for (const name of Object.keys(rates)) {
-    if (typeof rates[name] === 'number') {
-      rates[name] = { [defaultType]: rates[name] };
-      changed = true;
-    }
-  }
-  if (changed) {
-    console.log('[SETTINGS] Migrated floristRates to per-type format');
-    saveConfig().catch(err =>
-      console.error('[SETTINGS] FloristRates migration save failed:', err.message)
-    );
-  }
-}
-
-// Load config on startup
-loadConfig();
-
-// ── Available Today cutoff reminder ─────────────────────────
-// Checks every minute. Once per day, after cutoff, if there are still
-// active Available Today products, sends a Telegram reminder to the owner.
-// Dedup date persisted in App Config so restarts don't re-fire the reminder.
-setInterval(async () => {
-  try {
-    if (!configLoaded) return;
-    const cutoff = config.availableTodayCutoff || '18:00';
-    const tz = config.availableTodayTimezone || 'Europe/Warsaw';
-    const now = new Date();
-    const timeStr = new Intl.DateTimeFormat('en-GB', {
-      hour: '2-digit', minute: '2-digit', hour12: false, timeZone: tz,
-    }).format(now);
-    const todayStr = new Intl.DateTimeFormat('en-CA', { timeZone: tz }).format(now);
-
-    if (timeStr < cutoff) return; // not past cutoff yet
-    if (config.cutoffReminderLastDate === todayStr) return; // already sent today
-
-    // Check if any active products with lead time 0 exist
-    const allActiveRows = await productConfigRepo.list({ activeOnly: true });
-    const zeroLeadRows = allActiveRows.filter(r => r['Lead Time Days'] === 0);
-
-    if (zeroLeadRows.length > 0) {
-      await sendAlert(
-        `⏰ Available Today reminder\n\n`
-        + `It's past ${cutoff} — you still have products marked as Available Today.\n`
-        + `Deactivate them in the dashboard if they're no longer available.`
-      );
-      config.cutoffReminderLastDate = todayStr;
-      saveConfig().catch(err => console.error('[SETTINGS] Failed to persist reminder date:', err.message));
-      console.log('[SETTINGS] Cutoff reminder sent');
-    }
-  } catch (err) {
-    console.error('[SETTINGS] Cutoff reminder error:', err.message);
-  }
-}, 60_000); // check every minute
-
-// ── Daily settings (auto-reset at midnight) ─────────────────
-const daily = {
-  driverOfDay:  null,
-  _lastSetDate: null,
-};
-
-// Build driver names from env vars (same pattern as auth.js)
-const driverNames = Object.entries(process.env)
-  .filter(([key]) => key.startsWith('PIN_DRIVER_'))
-  .map(([key]) =>
-    key.replace('PIN_DRIVER_', '').charAt(0).toUpperCase()
-    + key.replace('PIN_DRIVER_', '').slice(1).toLowerCase()
-  );
-
-function autoClearIfNewDay() {
-  const today = new Date().toISOString().split('T')[0];
-  if (daily._lastSetDate && daily._lastSetDate !== today) {
-    daily.driverOfDay = null;
-    daily._lastSetDate = null;
-  }
-}
 
 // ── GET /api/settings — read all settings + config ──
 router.get('/', authorize('orders'), (req, res) => {
   autoClearIfNewDay();
   const backupName = getBackupDriverName();
+  const daily = getDailyState();
+  const config = getAllConfig();
   const resolvedDrivers = [...new Set([...driverNames, ...config.extraDrivers])]
     .map(name => name === 'Backup' && backupName ? backupName : name);
   res.json({
@@ -371,12 +36,10 @@ router.get('/', authorize('orders'), (req, res) => {
 
 // ── PUT /api/settings/driver-of-day ──
 // When a driver-of-day is set, auto-assign them to all today's unassigned deliveries.
-// Like a shift supervisor assigning the day's driver to all open dispatches at once.
 router.put('/driver-of-day', authorize('admin'), async (req, res, next) => {
   try {
     const { driverName } = req.body;
-    daily.driverOfDay = driverName || null;
-    daily._lastSetDate = driverName ? new Date().toISOString().split('T')[0] : null;
+    setDailyDriver(driverName);
 
     let assignedCount = 0;
     if (driverName) {
@@ -391,7 +54,7 @@ router.put('/driver-of-day', authorize('admin'), async (req, res, next) => {
       }
     }
 
-    res.json({ driverOfDay: daily.driverOfDay, assignedCount });
+    res.json({ driverOfDay: getDriverOfDay(), assignedCount });
   } catch (err) {
     next(err);
   }
@@ -404,118 +67,23 @@ router.put('/backup-driver', authorize('admin'), (req, res) => {
   res.json({ backupDriverName: getBackupDriverName() });
 });
 
-// ── PUT /api/settings/config — update + persist to Airtable ──
+// ── PUT /api/settings/config — update + persist ──
 router.put('/config', authorize('admin'), async (req, res) => {
-  const allowed = Object.keys(config);
-  const updates = req.body;
-
-  for (const key of Object.keys(updates)) {
-    if (allowed.includes(key)) {
-      config[key] = updates[key];
-    }
-  }
-
-  // Persist to Airtable (fire-and-forget — don't block the response)
-  saveConfig().catch(err =>
-    console.error('[SETTINGS] Background save failed:', err.message)
-  );
-
-  res.json({ config });
+  updateConfigBulk(req.body);
+  res.json({ config: getAllConfig() });
 });
 
 // ── GET /api/settings/lists ──
 router.get('/lists', authorize('orders'), (req, res) => {
   res.json({
-    suppliers:      config.suppliers,
-    categories:     config.stockCategories,
-    paymentMethods: config.paymentMethods,
-    orderSources:   config.orderSources,
-    floristNames:   config.floristNames,
-    rateTypes:      config.rateTypes,
-    floristRates:   config.floristRates,
+    suppliers:      getConfig('suppliers'),
+    categories:     getConfig('stockCategories'),
+    paymentMethods: getConfig('paymentMethods'),
+    orderSources:   getConfig('orderSources'),
+    floristNames:   getConfig('floristNames'),
+    rateTypes:      getConfig('rateTypes'),
+    floristRates:   getConfig('floristRates'),
   });
 });
-
-// ── Exported getters for use by other modules ──
-
-export function getDriverOfDay() {
-  autoClearIfNewDay();
-  return daily.driverOfDay;
-}
-
-export function getConfig(key) {
-  return config[key];
-}
-
-export function updateConfig(key, value) {
-  config[key] = value;
-  saveConfig().catch(err =>
-    console.error('[SETTINGS] Background save failed:', err.message)
-  );
-}
-
-/**
- * Generate next App Order ID in YYYYMM-NNN format.
- * Counter stored in app_config Postgres table under key 'orderCounters'.
- * Like a sequential work order numbering system — each month resets the sequence.
- */
-export async function generateOrderId() {
-  const now      = new Date();
-  const monthKey = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}`;
-  try {
-    return await appConfigRepo.nextOrderId(monthKey);
-  } catch (err) {
-    console.error('[ORDER-ID] Counter error:', err.message);
-    return `${monthKey}-T${Date.now().toString().slice(-5)}`;
-  }
-}
-
-/**
- * Check if current time in the configured timezone is past the cutoff.
- * Used for reminder logic — NOT for auto-hiding (owner controls visibility).
- */
-export function isPastCutoff() {
-  const cutoff = config.availableTodayCutoff || '18:00';
-  const tz = config.availableTodayTimezone || 'Europe/Warsaw';
-  const now = new Date();
-  const timeStr = new Intl.DateTimeFormat('en-GB', {
-    hour: '2-digit', minute: '2-digit',
-    hour12: false, timeZone: tz,
-  }).format(now);
-  return timeStr >= cutoff;
-}
-
-/**
- * Returns the currently active seasonal category based on config rules.
- * Priority: manual override > auto-schedule by date > null (none active).
- */
-export function getActiveSeasonalCategory() {
-  const sc = config.storefrontCategories;
-
-  if (sc.manualOverride) {
-    const forced = sc.seasonal.find(s => s.slug === sc.manualOverride);
-    if (forced) return {
-      name: forced.name, slug: forced.slug,
-      description: forced.description || '',
-      translations: forced.translations || {},
-    };
-  }
-
-  if (sc.autoSchedule) {
-    const now = new Date();
-    const mmdd = `${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
-    for (const s of sc.seasonal) {
-      if (mmdd >= s.from && mmdd <= s.to) {
-        return {
-          name: s.name, slug: s.slug,
-          description: s.description || '',
-          translations: s.translations || {},
-        };
-      }
-    }
-  }
-
-  return null;
-}
 
 export default router;

--- a/backend/src/routes/webhook.js
+++ b/backend/src/routes/webhook.js
@@ -1,13 +1,9 @@
 import crypto from 'node:crypto';
 import { Router } from 'express';
-import { processWixOrder } from '../services/wix.js';
+import { processWixOrder, reprocessWixOrder } from '../services/wix.js';
 import { authenticate, authorize } from '../middleware/auth.js';
-import * as db from '../services/airtable.js';
-import * as orderRepo from '../repos/orderRepo.js';
 import * as webhookLogRepo from '../repos/webhookLogRepo.js';
 import { actorFromReq } from '../utils/actor.js';
-import { TABLES } from '../config/airtable.js';
-import { listByIds } from '../utils/batchQuery.js';
 import { db as pgDb } from '../db/index.js';
 import { feedbackReports } from '../db/schema.js';
 import { eq, and, ne } from 'drizzle-orm';
@@ -146,89 +142,16 @@ router.get('/wix-order/:id', authenticate, authorize('admin'), async (req, res) 
 //
 // SAFETY GATE: refuses to touch orders that look composed or edited —
 // any Order Line with a Stock Item link OR any Status other than 'New'.
-// Responds 409 with the reasons so the caller can see why it refused.
-// If you *really* need to reprocess a composed order (accepting data loss),
-// pass ?force=true.
+// Responds 409 with reasons if the order appears composed or edited.
+// Pass ?force=true to skip the safety check (accepts data loss).
 router.post('/wix-order/:id/reprocess', authenticate, authorize('admin'), async (req, res) => {
-  const wixOrderId = req.params.id;
   const force = req.query.force === 'true' || req.query.force === '1';
   try {
-    // 1. Find the App Order by Wix Order ID.
-    // orderRepo.findByWixOrderId handles both airtable + postgres modes and
-    // returns embedded _lines so we can skip a second Airtable roundtrip for
-    // the safety check.
-    const existing = await orderRepo.findByWixOrderId(wixOrderId);
-    if (!existing) {
-      return res.status(404).json({ error: `No App Order found with Wix Order ID ${wixOrderId}.` });
-    }
-    const lineIds = existing['Order Lines'] || [];
-    const deliveryIds = existing['Deliveries'] || [];
-
-    // 1b. SAFETY CHECK — refuse to delete anything that looks composed or
-    //     touched. Two independent signals: status beyond 'New', or any line
-    //     with a Stock Item link (Wix lines never get stock-linked by the
-    //     parser, so presence of a link means the florist added real flowers).
-    // In postgres mode _lines carries the full line objects; airtable mode
-    // falls back to a separate fetch.
-    if (!force) {
-      const lineRecords = existing._lines
-        || (lineIds.length > 0
-          ? await listByIds(TABLES.ORDER_LINES, lineIds, { fields: ['Stock Item', 'Flower Name', 'Quantity'] })
-          : []);
-      const reasons = [];
-      if (existing.Status && existing.Status !== 'New') {
-        reasons.push(`Status is "${existing.Status}" (not 'New').`);
-      }
-      const composed = lineRecords.filter(l =>
-        (Array.isArray(l['Stock Item']) && l['Stock Item'].length > 0) || l.stockItemId
-      );
-      if (composed.length > 0) {
-        const names = composed.map(l => `${l.Quantity ?? l.quantity ?? '?'}× ${l['Flower Name'] ?? l.flowerName ?? '?'}`).join(', ');
-        reasons.push(`${composed.length} line(s) have Stock Item links (composed bouquet): ${names}.`);
-      }
-      if (reasons.length > 0) {
-        return res.status(409).json({
-          error: 'Reprocess refused — order appears composed or edited.',
-          reasons,
-          hint: 'Pass ?force=true if you truly want to delete and recreate (accepts data loss).',
-          appOrderId: existing['App Order ID'] || existing.id,
-        });
-      }
-    }
-
-    // 2. Delete the order.
-    // In postgres mode orderRepo.deleteOrder cascades to lines + delivery via
-    // ON DELETE CASCADE — no individual record deletes needed. In airtable
-    // mode we fall back to the original per-record path.
-    if (orderRepo.getBackendMode() === 'postgres') {
-      await orderRepo.deleteOrder(existing._pgId || existing.id, { actor: actorFromReq(req) });
-    } else {
-      for (const lineId of lineIds) {
-        await db.deleteRecord(TABLES.ORDER_LINES, lineId).catch(err => {
-          console.warn(`[REPROCESS] delete line ${lineId}:`, err.message);
-        });
-      }
-      for (const delId of deliveryIds) {
-        await db.deleteRecord(TABLES.DELIVERIES, delId).catch(err => {
-          console.warn(`[REPROCESS] delete delivery ${delId}:`, err.message);
-        });
-      }
-      await db.deleteRecord(TABLES.ORDERS, existing.id);
-    }
-
-    // 3. Re-run the canonical pipeline with a synthetic webhook payload —
-    //    processWixOrder's dedup will miss (record just deleted) and fall
-    //    through to the Wix API fetch + fresh create.
-    await processWixOrder({ id: wixOrderId });
-
-    // 4. Return the newly created App Order so the UI can refresh.
-    const fresh = await orderRepo.findByWixOrderId(wixOrderId);
-    return res.json({
-      deleted: { orderId: existing.id, lineCount: lineIds.length, deliveryCount: deliveryIds.length },
-      created: fresh || null,
-      forced: force,
-    });
+    const result = await reprocessWixOrder(req.params.id, { force, actor: actorFromReq(req) });
+    return res.json(result);
   } catch (err) {
+    if (err.status === 404) return res.status(404).json({ error: err.message });
+    if (err.status === 409) return res.status(409).json(err.data);
     console.error('[REPROCESS] failed:', err);
     return res.status(500).json({ error: err.message || 'Reprocess failed.' });
   }

--- a/backend/src/services/configService.js
+++ b/backend/src/services/configService.js
@@ -1,0 +1,371 @@
+// App configuration service — in-memory config backed by Postgres App Config table.
+// Owns the singleton config state, daily session state (driver-of-day), and
+// the available-today cutoff reminder. Other modules import getters from here;
+// routes/settings.js handles the HTTP layer.
+import * as appConfigRepo from '../repos/appConfigRepo.js';
+import * as productConfigRepo from '../repos/productConfigRepo.js';
+import { sendAlert } from './telegram.js';
+
+// ── Default configuration values ────────────────────────────
+// Used as fallback if config row doesn't exist yet or is empty.
+const DEFAULTS = {
+  defaultDeliveryFee: 35,
+  targetMarkup:       2.2,
+  suppliers:          ['Stojek', '4f', 'Stefan', 'Mateusz', 'Other'],
+  stockCategories:    ['Roses', 'Tulips', 'Seasonal', 'Greenery', 'Accessories', 'Other'],
+  paymentMethods:     ['Cash', 'Card', 'Mbank', 'Monobank', 'Revolut', 'PayPal', 'Wix Online'],
+  orderSources:       ['In-store', 'Instagram', 'WhatsApp', 'Telegram', 'Wix', 'Flowwow', 'Other'],
+  driverCostPerDelivery: 35,
+  driverCostPerPORun: 45,
+  floristNames: ['Anya', 'Daria'],
+  rateTypes: ['Standard', 'Wedding', 'Holidays'],
+  floristRates: {},
+  extraDrivers: [],
+  storefrontCategories: {
+    permanent: [
+      { name: 'All Bouquets', slug: 'all-bouquets', description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
+      { name: 'Bestsellers',  slug: 'bestsellers',  description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
+    ],
+    seasonal: [
+      { name: "Valentine's Day", slug: 'valentines-day', from: '01-25', to: '02-15', description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
+      { name: "Women's Day",     slug: 'womens-day',     from: '02-25', to: '03-10', description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
+      { name: "Mother's Day",    slug: 'mothers-day',    from: '04-20', to: '05-26', description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
+      { name: 'Easter',          slug: 'easter',         from: '03-28', to: '04-15', description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
+      { name: 'Christmas',       slug: 'christmas',      from: '12-01', to: '12-26', description: '', translations: { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } } },
+    ],
+    auto: [
+      {
+        name: 'Available Today',
+        slug: 'available-today',
+        description: 'Bouquets ready for same-day delivery or pickup.',
+        translations: {
+          en: { title: 'Available Today',   description: 'Bouquets ready for same-day delivery or pickup.' },
+          pl: { title: 'Dostępne dziś',     description: 'Bukiety gotowe do dostawy lub odbioru tego samego dnia.' },
+          ru: { title: 'Доступно сегодня',  description: 'Букеты, готовые к доставке или самовывозу сегодня.' },
+          uk: { title: 'Доступно сьогодні', description: 'Букети, готові до доставки або самовивозу сьогодні.' },
+        },
+      },
+    ],
+    autoSchedule: true,
+    manualOverride: null,
+    wixCategoryMap: {},
+  },
+  deliveryZones: [
+    { id: 1, name: 'Central Krakow', fee: 35, postcodes: ['30-0', '30-1', '31-0'] },
+    { id: 2, name: 'Suburbs',        fee: 50, postcodes: ['32-0'] },
+    { id: 3, name: 'Out of city',    fee: 80, postcodes: [] },
+  ],
+  freeDeliveryThreshold: 300,
+  expressSurcharge: 20,
+  deliveryTimeSlots: ['10:00-12:00', '12:00-14:00', '14:00-16:00', '16:00-18:00'],
+  availableTodayCutoff: '18:00',
+  availableTodayTimezone: 'Europe/Warsaw',
+  cutoffReminderLastDate: null,
+  slotLeadTimeMinutes: 30,
+  // Shows the per-row "Reconcile premade" action on stock rows in the dashboard.
+  // Off by default — admin tooling for fixing historical data mismatches.
+  showStockRepairTools: false,
+};
+
+// ── In-memory config (loaded from Postgres on startup) ──────
+let config = structuredClone(DEFAULTS);
+let configLoaded = false;
+
+function deepMerge(target, source) {
+  const result = { ...target };
+  for (const key of Object.keys(source)) {
+    if (
+      source[key] !== null &&
+      typeof source[key] === 'object' &&
+      !Array.isArray(source[key]) &&
+      typeof target[key] === 'object' &&
+      !Array.isArray(target[key])
+    ) {
+      result[key] = deepMerge(target[key] || {}, source[key]);
+    } else {
+      result[key] = source[key];
+    }
+  }
+  return result;
+}
+
+function normalizeMMDD(val) {
+  if (!val) return val;
+  const clean = val.replace(/\./g, '-');
+  const parts = clean.split('-');
+  if (parts.length !== 2) return clean;
+  const [a, b] = parts.map(p => p.trim().padStart(2, '0'));
+  if (Number(a) > 12) return `${b}-${a}`;
+  return `${a}-${b}`;
+}
+
+function migrateSeasonalDates() {
+  const sc = config.storefrontCategories;
+  if (!sc?.seasonal) return;
+  let changed = false;
+  for (const entry of sc.seasonal) {
+    const newFrom = normalizeMMDD(entry.from);
+    const newTo = normalizeMMDD(entry.to);
+    if (newFrom !== entry.from || newTo !== entry.to) {
+      console.log(`[SETTINGS] Migrating dates for "${entry.name}": ${entry.from}→${newFrom}, ${entry.to}→${newTo}`);
+      entry.from = newFrom;
+      entry.to = newTo;
+      changed = true;
+    }
+  }
+  if (changed) saveConfig().catch(err => console.error('[SETTINGS] Date migration save failed:', err.message));
+}
+
+function migrateCategoryObjects() {
+  const sc = config.storefrontCategories;
+  if (!sc) return;
+  const emptyTranslations = { en: { title: '', description: '' }, pl: { title: '', description: '' }, ru: { title: '', description: '' }, uk: { title: '', description: '' } };
+  let changed = false;
+
+  if (Array.isArray(sc.permanent) && sc.permanent.length > 0 && typeof sc.permanent[0] === 'string') {
+    sc.permanent = sc.permanent.map(name => ({
+      name,
+      slug: name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-$/, ''),
+      description: '',
+      translations: JSON.parse(JSON.stringify(emptyTranslations)),
+    }));
+    changed = true;
+    console.log('[SETTINGS] Migrated permanent categories to object format');
+  }
+
+  if (!sc.auto) {
+    sc.auto = DEFAULTS.storefrontCategories.auto;
+    changed = true;
+  } else if (Array.isArray(sc.auto) && sc.auto.length > 0 && typeof sc.auto[0] === 'string') {
+    sc.auto = sc.auto.map(name => ({
+      name,
+      slug: name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-$/, ''),
+      description: '',
+      translations: JSON.parse(JSON.stringify(emptyTranslations)),
+    }));
+    changed = true;
+    console.log('[SETTINGS] Migrated auto categories to object format');
+  }
+
+  if (changed) saveConfig().catch(err => console.error('[SETTINGS] Category migration save failed:', err.message));
+}
+
+function migrateAutoCategoryTranslations() {
+  const sc = config.storefrontCategories;
+  if (!sc?.auto || !Array.isArray(sc.auto)) return;
+  let changed = false;
+
+  for (const stored of sc.auto) {
+    if (!stored || typeof stored !== 'object') continue;
+    const defaultEntry = (DEFAULTS.storefrontCategories.auto || []).find(d => d.slug === stored.slug);
+    if (!defaultEntry) continue;
+    if (!stored.translations) stored.translations = {};
+
+    for (const lang of ['en', 'pl', 'ru', 'uk']) {
+      const storedLang = stored.translations[lang] || {};
+      const defaultLang = defaultEntry.translations?.[lang] || {};
+      if (!storedLang.title && defaultLang.title) { storedLang.title = defaultLang.title; changed = true; }
+      if (!storedLang.description && defaultLang.description) { storedLang.description = defaultLang.description; changed = true; }
+      stored.translations[lang] = storedLang;
+    }
+
+    if (!stored.description && defaultEntry.description) { stored.description = defaultEntry.description; changed = true; }
+  }
+
+  if (changed) {
+    console.log('[SETTINGS] Backfilled auto-category translations');
+    saveConfig().catch(err => console.error('[SETTINGS] Auto-category translation backfill save failed:', err.message));
+  }
+}
+
+function migrateFloristRates() {
+  const rates = config.floristRates;
+  if (!rates || typeof rates !== 'object') return;
+  let changed = false;
+  const defaultType = (config.rateTypes && config.rateTypes[0]) || 'Standard';
+  for (const name of Object.keys(rates)) {
+    if (typeof rates[name] === 'number') {
+      rates[name] = { [defaultType]: rates[name] };
+      changed = true;
+    }
+  }
+  if (changed) {
+    console.log('[SETTINGS] Migrated floristRates to per-type format');
+    saveConfig().catch(err => console.error('[SETTINGS] FloristRates migration save failed:', err.message));
+  }
+}
+
+async function saveConfig() {
+  try {
+    await appConfigRepo.set('config', config);
+  } catch (err) {
+    console.error('[SETTINGS] Failed to save config to Postgres:', err.message);
+  }
+}
+
+async function loadConfig() {
+  try {
+    const stored = await appConfigRepo.get('config');
+    if (stored) {
+      config = deepMerge(DEFAULTS, stored);
+      migrateSeasonalDates();
+      migrateCategoryObjects();
+      migrateAutoCategoryTranslations();
+      migrateFloristRates();
+      console.log('[SETTINGS] Config loaded from Postgres');
+    } else {
+      await appConfigRepo.set('config', DEFAULTS);
+      console.log('[SETTINGS] Config row created in Postgres with defaults');
+    }
+  } catch (err) {
+    console.error('[SETTINGS] Failed to load config from Postgres:', err.message);
+    console.warn('[SETTINGS] Using in-memory defaults');
+  }
+  configLoaded = true;
+}
+
+// Load on startup
+loadConfig();
+
+// ── Available Today cutoff reminder ─────────────────────────
+setInterval(async () => {
+  try {
+    if (!configLoaded) return;
+    const cutoff = config.availableTodayCutoff || '18:00';
+    const tz = config.availableTodayTimezone || 'Europe/Warsaw';
+    const now = new Date();
+    const timeStr = new Intl.DateTimeFormat('en-GB', {
+      hour: '2-digit', minute: '2-digit', hour12: false, timeZone: tz,
+    }).format(now);
+    const todayStr = new Intl.DateTimeFormat('en-CA', { timeZone: tz }).format(now);
+
+    if (timeStr < cutoff) return;
+    if (config.cutoffReminderLastDate === todayStr) return;
+
+    const allActiveRows = await productConfigRepo.list({ activeOnly: true });
+    const zeroLeadRows = allActiveRows.filter(r => r['Lead Time Days'] === 0);
+
+    if (zeroLeadRows.length > 0) {
+      await sendAlert(
+        `⏰ Available Today reminder\n\n`
+        + `It's past ${cutoff} — you still have products marked as Available Today.\n`
+        + `Deactivate them in the dashboard if they're no longer available.`
+      );
+      config.cutoffReminderLastDate = todayStr;
+      saveConfig().catch(err => console.error('[SETTINGS] Failed to persist reminder date:', err.message));
+      console.log('[SETTINGS] Cutoff reminder sent');
+    }
+  } catch (err) {
+    console.error('[SETTINGS] Cutoff reminder error:', err.message);
+  }
+}, 60_000);
+
+// ── Daily session state (auto-reset at midnight) ─────────────
+const daily = {
+  driverOfDay:  null,
+  _lastSetDate: null,
+};
+
+// Build driver names from env vars (same pattern as auth.js)
+export const driverNames = Object.entries(process.env)
+  .filter(([key]) => key.startsWith('PIN_DRIVER_'))
+  .map(([key]) =>
+    key.replace('PIN_DRIVER_', '').charAt(0).toUpperCase()
+    + key.replace('PIN_DRIVER_', '').slice(1).toLowerCase()
+  );
+
+export function autoClearIfNewDay() {
+  const today = new Date().toISOString().split('T')[0];
+  if (daily._lastSetDate && daily._lastSetDate !== today) {
+    daily.driverOfDay = null;
+    daily._lastSetDate = null;
+  }
+}
+
+export function setDailyDriver(name) {
+  daily.driverOfDay = name || null;
+  daily._lastSetDate = name ? new Date().toISOString().split('T')[0] : null;
+}
+
+export function getDailyState() {
+  return daily;
+}
+
+// ── Public getters ────────────────────────────────────────────
+
+export function getDriverOfDay() {
+  autoClearIfNewDay();
+  return daily.driverOfDay;
+}
+
+export function getConfig(key) {
+  return config[key];
+}
+
+export function getAllConfig() {
+  return config;
+}
+
+export function updateConfig(key, value) {
+  config[key] = value;
+  saveConfig().catch(err => console.error('[SETTINGS] Background save failed:', err.message));
+}
+
+export function updateConfigBulk(updates) {
+  const allowed = Object.keys(config);
+  for (const key of Object.keys(updates)) {
+    if (allowed.includes(key)) config[key] = updates[key];
+  }
+  saveConfig().catch(err => console.error('[SETTINGS] Background save failed:', err.message));
+}
+
+export async function generateOrderId() {
+  const now      = new Date();
+  const monthKey = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}`;
+  try {
+    return await appConfigRepo.nextOrderId(monthKey);
+  } catch (err) {
+    console.error('[ORDER-ID] Counter error:', err.message);
+    return `${monthKey}-T${Date.now().toString().slice(-5)}`;
+  }
+}
+
+export function isPastCutoff() {
+  const cutoff = config.availableTodayCutoff || '18:00';
+  const tz = config.availableTodayTimezone || 'Europe/Warsaw';
+  const now = new Date();
+  const timeStr = new Intl.DateTimeFormat('en-GB', {
+    hour: '2-digit', minute: '2-digit',
+    hour12: false, timeZone: tz,
+  }).format(now);
+  return timeStr >= cutoff;
+}
+
+export function getActiveSeasonalCategory() {
+  const sc = config.storefrontCategories;
+
+  if (sc.manualOverride) {
+    const forced = sc.seasonal.find(s => s.slug === sc.manualOverride);
+    if (forced) return {
+      name: forced.name, slug: forced.slug,
+      description: forced.description || '',
+      translations: forced.translations || {},
+    };
+  }
+
+  if (sc.autoSchedule) {
+    const now = new Date();
+    const mmdd = `${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+    for (const s of sc.seasonal) {
+      if (mmdd >= s.from && mmdd <= s.to) {
+        return {
+          name: s.name, slug: s.slug,
+          description: s.description || '',
+          translations: s.translations || {},
+        };
+      }
+    }
+  }
+
+  return null;
+}

--- a/backend/src/services/webhookLog.js
+++ b/backend/src/services/webhookLog.js
@@ -1,7 +1,0 @@
-// Webhook event logger — persists every incoming webhook to Postgres webhook_log table.
-import { logEvent } from '../repos/webhookLogRepo.js';
-
-export async function logWebhookEvent({ status, wixOrderId, appOrderId, errorMessage, rawPayload }) {
-  void rawPayload; // not persisted — too large; Railway logs capture it via console.log in wix.js
-  await logEvent({ status, wixOrderId, appOrderId, errorMessage });
-}

--- a/backend/src/services/wix.js
+++ b/backend/src/services/wix.js
@@ -15,7 +15,8 @@ import { sanitizeFormulaValue } from '../utils/sanitize.js';
 import { broadcast } from './notifications.js';
 import { notifyNewOrder } from './telegram.js';
 import { logEvent as logWebhookEvent } from '../repos/webhookLogRepo.js';
-import { generateOrderId } from '../routes/settings.js';
+import { generateOrderId } from './configService.js';
+import { listByIds } from '../utils/batchQuery.js';
 import { DELIVERY_STATUS } from '../constants/statuses.js';
 
 const WIX_API_URL = 'https://www.wixapis.com';
@@ -474,4 +475,85 @@ export async function processWixOrder(payload) {
       rawPayload: payload,
     });
   }
+}
+
+/**
+ * Reprocess a Wix order: delete the existing App Order and re-run the
+ * canonical intake pipeline so the order is recreated from the Wix API.
+ *
+ * By default refuses if the order is composed (status != New or any line has
+ * a Stock Item link). Pass force=true to skip the check — accepts data loss.
+ */
+export async function reprocessWixOrder(wixOrderId, { force = false, actor = null } = {}) {
+  const existing = await orderRepo.findByWixOrderId(wixOrderId);
+  if (!existing) {
+    const err = new Error(`No App Order found with Wix Order ID ${wixOrderId}.`);
+    err.status = 404;
+    throw err;
+  }
+
+  const lineIds     = existing['Order Lines'] || [];
+  const deliveryIds = existing['Deliveries']  || [];
+
+  if (!force) {
+    const lineRecords = existing._lines
+      || (lineIds.length > 0
+        ? await listByIds(TABLES.ORDER_LINES, lineIds, { fields: ['Stock Item', 'Flower Name', 'Quantity'] })
+        : []);
+
+    const reasons = [];
+    if (existing.Status && existing.Status !== 'New') {
+      reasons.push(`Status is "${existing.Status}" (not 'New').`);
+    }
+    const composed = lineRecords.filter(l =>
+      (Array.isArray(l['Stock Item']) && l['Stock Item'].length > 0) || l.stockItemId
+    );
+    if (composed.length > 0) {
+      const names = composed
+        .map(l => `${l.Quantity ?? l.quantity ?? '?'}× ${l['Flower Name'] ?? l.flowerName ?? '?'}`)
+        .join(', ');
+      reasons.push(`${composed.length} line(s) have Stock Item links (composed bouquet): ${names}.`);
+    }
+
+    if (reasons.length > 0) {
+      const err = new Error('Reprocess refused — order appears composed or edited.');
+      err.status = 409;
+      err.data = {
+        error: err.message,
+        reasons,
+        hint: 'Pass ?force=true if you truly want to delete and recreate (accepts data loss).',
+        appOrderId: existing['App Order ID'] || existing.id,
+      };
+      throw err;
+    }
+  }
+
+  // Delete the existing order. Postgres mode cascades to lines + delivery via
+  // ON DELETE CASCADE. Airtable mode deletes records individually.
+  if (orderRepo.getBackendMode() === 'postgres') {
+    await orderRepo.deleteOrder(existing._pgId || existing.id, { actor });
+  } else {
+    for (const lineId of lineIds) {
+      await db.deleteRecord(TABLES.ORDER_LINES, lineId).catch(err => {
+        console.warn(`[REPROCESS] delete line ${lineId}:`, err.message);
+      });
+    }
+    for (const delId of deliveryIds) {
+      await db.deleteRecord(TABLES.DELIVERIES, delId).catch(err => {
+        console.warn(`[REPROCESS] delete delivery ${delId}:`, err.message);
+      });
+    }
+    await db.deleteRecord(TABLES.ORDERS, existing.id);
+  }
+
+  // Re-run the canonical Wix intake pipeline. Dedup won't fire (record was
+  // just deleted) so the pipeline fetches fresh data from the Wix API.
+  await processWixOrder({ id: wixOrderId });
+
+  const fresh = await orderRepo.findByWixOrderId(wixOrderId);
+  return {
+    deleted: { orderId: existing.id, lineCount: lineIds.length, deliveryCount: deliveryIds.length },
+    created: fresh || null,
+    forced:  force,
+  };
 }

--- a/backend/src/services/wix.js
+++ b/backend/src/services/wix.js
@@ -14,7 +14,7 @@ import { TABLES } from '../config/airtable.js';
 import { sanitizeFormulaValue } from '../utils/sanitize.js';
 import { broadcast } from './notifications.js';
 import { notifyNewOrder } from './telegram.js';
-import { logWebhookEvent } from './webhookLog.js';
+import { logEvent as logWebhookEvent } from '../repos/webhookLogRepo.js';
 import { generateOrderId } from '../routes/settings.js';
 import { DELIVERY_STATUS } from '../constants/statuses.js';
 


### PR DESCRIPTION
## Summary

Four high-ROI refactors from the `/improve-codebase-architecture` session. No behavior changes — all 301 tests pass.

- **Delete `webhookLog.js`** — 8-line wrapper delegated to `webhookLogRepo.logEvent` with no transformation. Callers in `wix.js` now import `logEvent` directly. Comment about rawPayload moved to the repo.
- **Extract `configService.js`** — `getConfig`, `getDriverOfDay`, `generateOrderId`, `isPastCutoff`, `getActiveSeasonalCategory` and all config state (DEFAULTS, loadConfig, migrations, cutoff reminder interval) move from `routes/settings.js` into `services/configService.js`. `settings.js` becomes a thin HTTP layer. Re-exports preserved for backward compat — callers can migrate incrementally.
- **Extract `reprocessWixOrder` to `wix.js`** — 83-line reprocess logic (safety check, dual-mode delete, re-intake) moved from the route into a testable service function. Route drops to 10 lines.
- **`stockLossRepo.enrichById` helper** — same 13-field SELECT+JOIN block appeared 3× in `list()`, `create()`, `update()`. Extracted to private `enrichById(id)` + `JOINED_FIELDS` const. Schema change now touches one place.

## Test plan
- [x] `cd backend && npx vitest run` → 30 files, 301 tests pass
- [ ] Smoke: settings endpoint returns config, driver-of-day, lists
- [ ] Smoke: Wix webhook fires → order created → webhook log entry present