### PR TITLE
fix(db): route stock-purchases writes through Postgres

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -26,7 +26,7 @@ scripts/           → Backfill, shadow-health, start-test-backend, etc.
 | stock.js | GET/POST/PATCH /stock, GET /stock/velocity | Inventory + velocity forecasting. Delegates to stockRepo when STOCK_BACKEND ≠ airtable. |
 | deliveries.js | GET/PATCH /deliveries | Driver assignments + status cascade to orders |
 | stockOrders.js | Full CRUD /stock-orders | PO lifecycle: create, send, shop, review, evaluate |
-| stockPurchases.js | POST /stock-purchases | Record supplier deliveries with batch tracking |
+| stockPurchases.js | POST /stock-purchases | Record supplier deliveries with batch tracking. Routes STOCK reads/writes through stockRepo; purchase records through stockPurchasesRepo. |
 | stockLoss.js | GET/POST /stock-loss | Waste logging by reason |
 | premadeBouquets.js | CRUD /premade-bouquets | Premade bouquet templates (composed of stock items) |
 | dashboard.js | GET /dashboard | Today's operational summary for owner |
@@ -79,7 +79,7 @@ Key paths:
 - `db/migrations/` — `.sql` files applied lexicographically. Used by Drizzle on real PG and by pglite at boot in tests.
 - `db/audit.js` — append-only audit log (`audit_log`); writes are tagged via the actor-context async-hook (`actor.js`) so every change carries who/role/req-id.
 - `db/index.js` — Postgres + pglite boot. Pglite refuses to boot in `NODE_ENV=production`.
-- `repos/orderRepo.js`, `repos/stockRepo.js`, `repos/customerRepo.js`, `repos/productRepo.js` — read/write through the chosen backend. Each repo's three modes share an interface; routes/services call the repo and don't branch on the env flag themselves. `productRepo` (`getImage`, `setImage`, `removeImage`, `getImagesBatch`) caches Wix bouquet image URLs in Airtable today (Product Config table) and is shaped to switch to Postgres in Phase 6 with no caller changes; `getImagesBatch` chunks `OR()` lookups at 100 IDs to stay within Airtable formula limits.
+- `repos/orderRepo.js`, `repos/stockRepo.js`, `repos/customerRepo.js`, `repos/productRepo.js` — read/write through the chosen backend. `repos/stockPurchasesRepo.js` — purchase record CRUD (always Postgres; `noteMarkerExists` + `findDateByPoMarker` used by PO evaluation idempotency). Each repo's three modes share an interface; routes/services call the repo and don't branch on the env flag themselves. `productRepo` (`getImage`, `setImage`, `removeImage`, `getImagesBatch`) caches Wix bouquet image URLs in Airtable today (Product Config table) and is shaped to switch to Postgres in Phase 6 with no caller changes; `getImagesBatch` chunks `OR()` lookups at 100 IDs to stay within Airtable formula limits.
 - `db/README.md` — design notes for the migration, including the Phase 4 parity-check stub at `orderRepo.js:1100-1111` (full impl pending — required before flipping `ORDER_BACKEND=shadow` to `postgres`).
 
 ## Auth Model
@@ -98,6 +98,8 @@ Key paths:
 
 ## Airtable Tables (16 tables, env-var-driven)
 CUSTOMERS, ORDERS, ORDER_LINES, STOCK, DELIVERIES, STOCK_PURCHASES, STOCK_ORDERS, STOCK_ORDER_LINES, PRODUCT_CONFIG, SYNC_LOG, APP_CONFIG, FLORIST_HOURS, WEBHOOK_LOG, MARKETING_SPEND, STOCK_LOSS_LOG, LEGACY_ORDERS
+
+Note: STOCK_PURCHASES writes now go to Postgres via `stockPurchasesRepo`. The Airtable env var is kept for reads in `stock.js` (usage trace), `analytics.js`, and `stockOrders.js` (PO marker lookup fallback) until those are migrated (GH #227–229).
 
 ## Tests
 Run all: `cd backend && npx vitest run`

--- a/backend/src/__tests__/stockPurchasesRepo.integration.test.js
+++ b/backend/src/__tests__/stockPurchasesRepo.integration.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+
+const dbHolder = { db: null };
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  isPostgresConfigured: true,
+  pool: null,
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+import * as stockPurchasesRepo from '../repos/stockPurchasesRepo.js';
+
+let harness;
+beforeEach(async () => { harness = await setupPgHarness(); dbHolder.db = harness.db; });
+afterEach(async () => { await teardownPgHarness(harness); dbHolder.db = null; });
+
+describe('stockPurchasesRepo', () => {
+  it('creates a purchase record without a stock link', async () => {
+    const p = await stockPurchasesRepo.create({
+      purchaseDate: '2026-05-07',
+      supplier: 'Rynkowy',
+      quantityPurchased: 50,
+      pricePerUnit: 1.25,
+      notes: '',
+    });
+
+    expect(p.id).toBeTruthy();
+    expect(p['Purchase Date']).toBe('2026-05-07');
+    expect(p.Supplier).toBe('Rynkowy');
+    expect(p['Quantity Purchased']).toBe(50);
+    expect(p['Price Per Unit']).toBe(1.25);
+    expect(p.Flower).toEqual([]);
+  });
+
+  it('stores stockAirtableId and exposes it via Flower field', async () => {
+    const p = await stockPurchasesRepo.create({
+      purchaseDate: '2026-05-07',
+      supplier: 'Rynkowy',
+      stockAirtableId: 'recABC123',
+      quantityPurchased: 20,
+      pricePerUnit: 2.00,
+      notes: 'test',
+    });
+
+    expect(p.Flower).toEqual(['recABC123']);
+  });
+
+  describe('noteMarkerExists', () => {
+    it('returns false when no matching row', async () => {
+      const result = await stockPurchasesRepo.noteMarkerExists('PO #recXXX L#recYYY primary');
+      expect(result).toBe(false);
+    });
+
+    it('returns true after a matching row is created', async () => {
+      const marker = 'PO #recPO1 L#recLN1 primary';
+      await stockPurchasesRepo.create({
+        purchaseDate: '2026-05-07',
+        supplier: 'Test',
+        quantityPurchased: 10,
+        notes: marker,
+      });
+
+      expect(await stockPurchasesRepo.noteMarkerExists(marker)).toBe(true);
+    });
+
+    it('does not match partial markers that share a prefix', async () => {
+      await stockPurchasesRepo.create({
+        purchaseDate: '2026-05-07',
+        supplier: 'Test',
+        quantityPurchased: 5,
+        notes: 'PO #recPO1 L#recLN1 primary',
+      });
+
+      // Different line — must not match
+      expect(await stockPurchasesRepo.noteMarkerExists('PO #recPO1 L#recLN2 primary')).toBe(false);
+    });
+  });
+
+  describe('findDateByPoMarker', () => {
+    it('returns null when no rows for this PO', async () => {
+      const result = await stockPurchasesRepo.findDateByPoMarker('recNONE');
+      expect(result).toBeNull();
+    });
+
+    it('returns the purchase_date of the most recent matching row', async () => {
+      await stockPurchasesRepo.create({
+        purchaseDate: '2026-05-01',
+        supplier: 'Test',
+        quantityPurchased: 10,
+        notes: 'PO #recPO9 L#recL1 primary',
+      });
+      await stockPurchasesRepo.create({
+        purchaseDate: '2026-05-01',
+        supplier: 'Test',
+        quantityPurchased: 5,
+        notes: 'PO #recPO9 L#recL2 alt - substitute for "Rose"',
+      });
+
+      const date = await stockPurchasesRepo.findDateByPoMarker('recPO9');
+      expect(date).toBe('2026-05-01');
+    });
+  });
+});

--- a/backend/src/db/migrations/0009_stock_purchases.sql
+++ b/backend/src/db/migrations/0009_stock_purchases.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS stock_purchases (
+  id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  airtable_id         TEXT,
+  purchase_date       TEXT NOT NULL,
+  supplier            TEXT NOT NULL DEFAULT '',
+  stock_id            UUID REFERENCES stock(id),
+  stock_airtable_id   TEXT,
+  quantity_purchased  INTEGER NOT NULL DEFAULT 0,
+  price_per_unit      NUMERIC(10, 4),
+  notes               TEXT NOT NULL DEFAULT '',
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS stock_purchases_airtable_id_idx
+  ON stock_purchases (airtable_id) WHERE airtable_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS stock_purchases_date_idx
+  ON stock_purchases (purchase_date);
+CREATE INDEX IF NOT EXISTS stock_purchases_stock_id_idx
+  ON stock_purchases (stock_id);

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1746648000000,
       "tag": "0008_feedback_reports",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1746734400000,
+      "tag": "0009_stock_purchases",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema.js
+++ b/backend/src/db/schema.js
@@ -399,6 +399,29 @@ export const feedbackReports = pgTable('feedback_reports', {
   createdAt:         timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 });
 
+// Supplier delivery records — one row per batch receive event.
+// Written by POST /stock-purchases (manual florist entry) and by the PO
+// evaluate flow in stockOrders.js. `stock_id` links to the *batch* stock
+// row that was created or credited (not the template record). Notes embeds
+// a stable marker (`PO #<id> L#<id> primary|alt`) for PO-evaluation
+// idempotency; the marker format must stay in sync with stockOrders.js.
+export const stockPurchases = pgTable('stock_purchases', {
+  id:                 uuid('id').primaryKey().defaultRandom(),
+  airtableId:         text('airtable_id'),
+  purchaseDate:       text('purchase_date').notNull(),  // YYYY-MM-DD
+  supplier:           text('supplier').notNull().default(''),
+  stockId:            uuid('stock_id').references(() => stock.id),
+  stockAirtableId:    text('stock_airtable_id'),  // Airtable recXXX of batch during cutover
+  quantityPurchased:  integer('quantity_purchased').notNull().default(0),
+  pricePerUnit:       numeric('price_per_unit', { precision: 10, scale: 4 }),
+  notes:              text('notes').notNull().default(''),
+  createdAt:          timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => ({
+  airtableIdx:  uniqueIndex('stock_purchases_airtable_id_idx').on(t.airtableId).where(isNotNull(t.airtableId)),
+  dateIdx:      index('stock_purchases_date_idx').on(t.purchaseDate),
+  stockIdx:     index('stock_purchases_stock_id_idx').on(t.stockId),
+}));
+
 export const productConfig = pgTable('product_config', {
   id:           uuid('id').primaryKey().defaultRandom(),
   airtableId:   text('airtable_id'),

--- a/backend/src/repos/stockPurchasesRepo.js
+++ b/backend/src/repos/stockPurchasesRepo.js
@@ -1,0 +1,55 @@
+import { db } from '../db/index.js';
+import { stockPurchases } from '../db/schema.js';
+import { eq, and, like, desc } from 'drizzle-orm';
+
+function toWire(row) {
+  return {
+    id:                  row.id,
+    airtableId:          row.airtableId || null,
+    'Purchase Date':     row.purchaseDate,
+    Supplier:            row.supplier || '',
+    Flower:              row.stockAirtableId
+                           ? [row.stockAirtableId]
+                           : row.stockId ? [row.stockId] : [],
+    'Quantity Purchased': Number(row.quantityPurchased || 0),
+    'Price Per Unit':    row.pricePerUnit != null ? Number(row.pricePerUnit) : null,
+    Notes:               row.notes || '',
+  };
+}
+
+export async function create({ purchaseDate, supplier, stockId, stockAirtableId, quantityPurchased, pricePerUnit, notes }) {
+  const values = {
+    purchaseDate: purchaseDate || new Date().toISOString().split('T')[0],
+    supplier:     supplier || '',
+    quantityPurchased: Number(quantityPurchased) || 0,
+    notes:        notes || '',
+  };
+  if (stockId)          values.stockId         = stockId;
+  if (stockAirtableId)  values.stockAirtableId = stockAirtableId;
+  if (pricePerUnit != null) values.pricePerUnit = String(pricePerUnit);
+
+  const [row] = await db.insert(stockPurchases).values(values).returning();
+  return toWire(row);
+}
+
+// Returns true when a row whose Notes field contains `marker` already exists.
+// Used by PO evaluation for idempotency — prevent double-crediting on retry.
+export async function noteMarkerExists(marker) {
+  const [row] = await db.select({ id: stockPurchases.id })
+    .from(stockPurchases)
+    .where(like(stockPurchases.notes, `%${marker}%`))
+    .limit(1);
+  return row != null;
+}
+
+// Returns the purchase_date of the first row whose Notes contains `marker`.
+// Used by PO evaluate retry to recover the original evalDate.
+export async function findDateByPoMarker(poId) {
+  const marker = `PO #${poId}`;
+  const [row] = await db.select({ purchaseDate: stockPurchases.purchaseDate })
+    .from(stockPurchases)
+    .where(like(stockPurchases.notes, `%${marker}%`))
+    .orderBy(desc(stockPurchases.createdAt))
+    .limit(1);
+  return row?.purchaseDate || null;
+}

--- a/backend/src/routes/stockOrders.js
+++ b/backend/src/routes/stockOrders.js
@@ -10,6 +10,7 @@ import { authorize } from '../middleware/auth.js';
 import * as db from '../services/airtable.js';
 import * as stockRepo from '../repos/stockRepo.js';
 import * as stockLossRepo from '../repos/stockLossRepo.js';
+import * as stockPurchasesRepo from '../repos/stockPurchasesRepo.js';
 import { TABLES } from '../config/airtable.js';
 import { broadcast } from '../services/notifications.js';
 import { sanitizeFormulaValue } from '../utils/sanitize.js';
@@ -551,18 +552,10 @@ router.post('/:id/approve-review', authorize('stock-orders', ['owner']), async (
 // Idempotency helper — returns true if a STOCK_PURCHASES row already exists
 // for this PO + line + variant (primary/alt). Used on retry after a partial
 // failure, so a second receiveIntoStock does NOT double-credit the batch.
-//
-// We identify each receive step by a stable marker embedded in the Notes field.
-// That avoids adding a new Airtable schema column and works with the existing
-// purchase history.
 async function purchaseAlreadyRecorded(poId, lineId, variant) {
-  if (!TABLES.STOCK_PURCHASES) return false;
   const marker = `PO #${poId} L#${lineId} ${variant}`;
-  // Airtable FIND() returns 0 when not found, which is falsy.
-  const formula = `FIND("${marker}", {Notes} & "") > 0`;
   try {
-    const rows = await db.list(TABLES.STOCK_PURCHASES, { filterByFormula: formula, maxRecords: 1 });
-    return rows.length > 0;
+    return await stockPurchasesRepo.noteMarkerExists(marker);
   } catch (e) {
     console.error('[STOCK-ORDER] Idempotency check failed:', e.message);
     return false; // fail-open — better to risk a warning than block a retry
@@ -706,16 +699,10 @@ router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), as
     // from lines already processed in the first attempt so all stock entries
     // for this PO share the same receive date (the day flowers actually arrived).
     let evalDate = new Date().toISOString().split('T')[0];
-    if (po.Status === PO_STATUS.EVAL_ERROR && TABLES.STOCK_PURCHASES) {
-      const marker = `PO #${req.params.id}`;
+    if (po.Status === PO_STATUS.EVAL_ERROR) {
       try {
-        const prev = await db.list(TABLES.STOCK_PURCHASES, {
-          filterByFormula: `FIND("${marker}", {Notes} & "") > 0`,
-          maxRecords: 1,
-        });
-        if (prev.length > 0 && prev[0]['Purchase Date']) {
-          evalDate = prev[0]['Purchase Date'];
-        }
+        const prevDate = await stockPurchasesRepo.findDateByPoMarker(req.params.id);
+        if (prevDate) evalDate = prevDate;
       } catch { /* fall back to today */ }
     }
     const lineResults = []; // track per-line outcome for partial failure recovery
@@ -797,16 +784,16 @@ router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), as
           if (!already) {
             const finalItemId = await receiveIntoStock(stockItemId, accepted, costPrice, sellPrice, supplier, evalDate);
 
-            // Audit trail — marker must match purchaseAlreadyRecorded() exactly.
-            // Flower link is skipped when finalItemId is a PG UUID (STOCK_PURCHASES
-            // is still Airtable-only until Phase 6, which rejects non-recXXX linked values).
-            await db.create(TABLES.STOCK_PURCHASES, {
-              'Purchase Date': evalDate,
-              Supplier: supplier,
-              ...(finalItemId.startsWith('rec') ? { Flower: [finalItemId] } : {}),
-              'Quantity Purchased': accepted,
-              'Price Per Unit': costPrice,
-              Notes: `PO #${req.params.id} L#${evalLine.lineId} primary`,
+            // Marker must match purchaseAlreadyRecorded() exactly.
+            const batchItem = await stockRepo.getById(finalItemId).catch(() => null);
+            await stockPurchasesRepo.create({
+              purchaseDate:      evalDate,
+              supplier,
+              stockId:           batchItem?._pgId || null,
+              stockAirtableId:   finalItemId.startsWith('rec') ? finalItemId : null,
+              quantityPurchased: accepted,
+              pricePerUnit:      costPrice,
+              notes:             `PO #${req.params.id} L#${evalLine.lineId} primary`,
             });
           } else {
             console.log(`[STOCK-ORDER] Skipping primary receive for line ${evalLine.lineId} — already recorded`);
@@ -849,13 +836,15 @@ router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), as
             );
             substituteStockId = altFinalId; // may be a new batch id
 
-            await db.create(TABLES.STOCK_PURCHASES, {
-              'Purchase Date': evalDate,
-              Supplier: altSupplier,
-              ...(altFinalId.startsWith('rec') ? { Flower: [altFinalId] } : {}),
-              'Quantity Purchased': altAccepted,
-              'Price Per Unit': altCostPerStem,
-              Notes: `PO #${req.params.id} L#${evalLine.lineId} alt - substitute for "${normaliseFlowerName(line['Flower Name'])}"`,
+            const altBatchItem = await stockRepo.getById(altFinalId).catch(() => null);
+            await stockPurchasesRepo.create({
+              purchaseDate:      evalDate,
+              supplier:          altSupplier,
+              stockId:           altBatchItem?._pgId || null,
+              stockAirtableId:   altFinalId.startsWith('rec') ? altFinalId : null,
+              quantityPurchased: altAccepted,
+              pricePerUnit:      altCostPerStem,
+              notes:             `PO #${req.params.id} L#${evalLine.lineId} alt - substitute for "${normaliseFlowerName(line['Flower Name'])}"`,
             });
           } else {
             console.log(`[STOCK-ORDER] Skipping alt receive for line ${evalLine.lineId} — already recorded`);

--- a/backend/src/routes/stockPurchases.js
+++ b/backend/src/routes/stockPurchases.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { authorize } from '../middleware/auth.js';
-import * as db from '../services/airtable.js';
-import { TABLES } from '../config/airtable.js';
+import * as stockRepo from '../repos/stockRepo.js';
+import * as stockPurchasesRepo from '../repos/stockPurchasesRepo.js';
 
 const router = Router();
 router.use(authorize('stock-purchases'));
@@ -15,33 +15,27 @@ router.post('/', async (req, res, next) => {
     const { stockItemId, supplierName, quantityPurchased, pricePerUnit, sellPricePerUnit, notes } = req.body;
     const today = new Date().toISOString().split('T')[0];
 
-    let finalItemId = stockItemId;
+    let finalItem = null; // the batch stock record (wire-format response from stockRepo)
 
-    // Batch logic: always create a new dated batch so every delivery is traceable.
-    // If the original record has negative qty (pre-sold demand), absorb the deficit
-    // into the new batch and zero out the original.
     if (stockItemId) {
-      const stockItem = await db.getById(TABLES.STOCK, stockItemId);
+      const stockItem = await stockRepo.getById(stockItemId);
       const existingQty = Number(stockItem['Current Quantity']) || 0;
 
       const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
       const d = new Date(today);
       const batchLabel = `${d.getDate()}.${months[d.getMonth()]}.`;
 
-      // Strip any existing date suffix to avoid double-dating
       const rawName = stockItem['Display Name'] || '';
       const baseName = (rawName.match(DATE_BATCH_RE)?.[1] || rawName).trim();
 
-      // Absorb negative deficit from original
       let batchQty = quantityPurchased;
       if (existingQty < 0) {
-        batchQty = quantityPurchased + existingQty; // e.g. 25 + (-7) = 18
+        batchQty = quantityPurchased + existingQty; // absorb pre-sold deficit
         if (batchQty < 0) batchQty = 0;
-        // Zero out the original so the negative display disappears
-        await db.update(TABLES.STOCK, stockItemId, { 'Current Quantity': 0 });
+        await stockRepo.update(stockItemId, { 'Current Quantity': 0 });
       }
 
-      const newBatch = await db.create(TABLES.STOCK, {
+      finalItem = await stockRepo.create({
         'Display Name':       `${baseName} (${batchLabel})`,
         'Purchase Name':      stockItem['Purchase Name'] || baseName,
         Category:             stockItem.Category || 'Other',
@@ -54,26 +48,24 @@ router.post('/', async (req, res, next) => {
         Active:               true,
         'Last Restocked':     today,
       });
-      finalItemId = newBatch.id;
-      console.log(`[STOCK] New batch created: ${newBatch['Display Name']} (prev qty on original: ${existingQty})`);
+      console.log(`[STOCK] New batch created: ${finalItem['Display Name']}`);
 
-      // Keep template record's prices current
       const templateUpdate = { 'Current Cost Price': pricePerUnit, 'Last Restocked': today };
       if (sellPricePerUnit) templateUpdate['Current Sell Price'] = sellPricePerUnit;
-      await db.update(TABLES.STOCK, stockItemId, templateUpdate);
+      await stockRepo.update(stockItemId, templateUpdate);
     }
 
-    // Create the purchase record linked to the actual batch
-    const purchase = await db.create(TABLES.STOCK_PURCHASES, {
-      'Purchase Date':      today,
-      Supplier:             supplierName || '',
-      ...(finalItemId ? { Flower: [finalItemId] } : {}),
-      'Quantity Purchased': quantityPurchased,
-      'Price Per Unit':     pricePerUnit,
-      Notes:                notes || '',
+    const purchase = await stockPurchasesRepo.create({
+      purchaseDate:      today,
+      supplier:          supplierName || '',
+      stockId:           finalItem?._pgId || null,
+      stockAirtableId:   finalItem?.id?.startsWith('rec') ? finalItem.id : null,
+      quantityPurchased,
+      pricePerUnit,
+      notes:             notes || '',
     });
 
-    res.status(201).json({ ...purchase, batchItemId: finalItemId });
+    res.status(201).json({ ...purchase, batchItemId: finalItem?.id || null });
   } catch (err) {
     next(err);
   }

--- a/backend/src/services/configService.js
+++ b/backend/src/services/configService.js
@@ -209,7 +209,7 @@ async function saveConfig(before) {
         after:      { storefrontCategories: config.storefrontCategories },
         actorRole:  'system',
         actorPinLabel: null,
-      }).catch(() => {});
+      }).catch(err => console.error('[SETTINGS] Failed to log audit event:', err.message));
     }
   } catch (err) {
     console.error('[SETTINGS] Failed to save config to Postgres:', err.message);

--- a/docs/superpowers/specs/2026-05-07-dual-seasonal-slots-design.md
+++ b/docs/superpowers/specs/2026-05-07-dual-seasonal-slots-design.md
@@ -1,0 +1,264 @@
+# Dual Seasonal Slots — Design Spec
+
+**Date:** 2026-05-07  
+**Feature:** Extend the storefront seasonal category system from one slot to two independent variable slots.
+
+---
+
+## Problem
+
+The owner can currently activate one seasonal category at a time (e.g., Mother's Day). She wants two independent variable slots so she can show two concurrent seasonal categories — or one, or none — without ever touching Wix to add or remove collections.
+
+---
+
+## Behavior
+
+| Slot 1 | Slot 2 | Website shows |
+|--------|--------|---------------|
+| Active | Active | Both nav items visible, both Wix collections populated |
+| Active | None   | Slot 1 nav item visible, slot 2 nav item removed from menu |
+| None   | Active | Slot 1 nav item removed, slot 2 visible |
+| None   | None   | Both nav items removed |
+
+- **Slot 1** supports auto-schedule (date-based) or manual override — same behavior as today.
+- **Slot 2** is always manual: owner explicitly picks a category or leaves it empty.
+- Hiding is enforced client-side in masterPage.js (same pattern as "Available Today").
+- Wix Store collections always exist (`seasonal`, `seasonal-2`); the backend empties them when a slot is inactive.
+
+---
+
+## Data Model
+
+### Config shape (after migration)
+
+```js
+storefrontCategories: {
+  seasonal: [
+    // Shared library — owner defines seasons here once.
+    // Either slot can reference any entry.
+    { name: "Valentine's Day", slug: 'valentines-day', from: '01-25', to: '02-15', translations: {...} },
+    { name: "Mother's Day",    slug: 'mothers-day',    from: '04-20', to: '05-26', translations: {...} },
+    // ...
+  ],
+  slots: [
+    { id: 'slot1', wixSlug: 'seasonal',   autoSchedule: true,  manualOverride: null },
+    { id: 'slot2', wixSlug: 'seasonal-2', autoSchedule: false, manualOverride: null },
+  ],
+  wixCategoryMap: {
+    'seasonal':   '<wix-collection-id-1>',   // existing
+    'seasonal-2': '<wix-collection-id-2>',   // new — owner pastes after Wix setup
+  },
+}
+```
+
+### Migration (automatic, on first load)
+
+configService reads existing `autoSchedule` and `manualOverride` flat fields and writes them into `slots[0]`. Old fields are dropped. Existing saved configs require no manual intervention.
+
+```js
+// Migration pseudocode inside configService loadConfig()
+// sc = saved.storefrontCategories at this point
+if (!sc.slots) {
+  sc.slots = [
+    { id: 'slot1', wixSlug: 'seasonal', autoSchedule: sc.autoSchedule !== false, manualOverride: sc.manualOverride || null },
+    { id: 'slot2', wixSlug: 'seasonal-2', autoSchedule: false, manualOverride: null },
+  ];
+  delete sc.autoSchedule;
+  delete sc.manualOverride;
+}
+```
+
+---
+
+## Backend Changes
+
+### `backend/src/services/configService.js`
+
+- Add `slots` to `DEFAULTS.storefrontCategories` (replacing flat `autoSchedule`/`manualOverride`).
+- Add migration in `loadConfig()` (see above).
+- Add `getActiveSeasonalSlots()` — returns `[{ slot, category }, { slot, category }]`. `category` is `null` when the slot has no active category.
+- Keep `getActiveSeasonalCategory()` as a thin wrapper returning `getActiveSeasonalSlots()[0]?.category ?? null` for backward compatibility with any existing callers.
+
+Resolution logic per slot:
+```js
+function resolveSlot(slot, seasonalLibrary, mmdd) {
+  if (slot.manualOverride) return seasonalLibrary.find(s => s.slug === slot.manualOverride) || null;
+  if (slot.autoSchedule)   return seasonalLibrary.find(s => mmdd >= s.from && mmdd <= s.to) || null;
+  return null;
+}
+```
+
+### `backend/src/services/wixProductSync.js`
+
+Replace the single-seasonal sync block with a loop over both slots:
+
+```js
+const activeSlots = getActiveSeasonalSlots();
+
+for (const { slot, category } of activeSlots) {
+  const wixId = catMap[category?.slug] || catMap[slot.wixSlug];
+  if (!wixId) {
+    log('warn', `No Wix collection mapped for ${slot.wixSlug} — skipping`);
+    continue;
+  }
+  if (!category) {
+    await setWixCategoryProducts(wixId, []);
+    log('item', `${slot.id}: no active category → Wix collection emptied`);
+    continue;
+  }
+  const productIds = [...new Set(
+    allConfigRows
+      .filter(r => parseCategoryField(r['Category']).includes(category.name))
+      .map(r => r['Wix Product ID'])
+      .filter(Boolean)
+  )];
+  await setWixCategoryProducts(wixId, productIds);
+  // Only rename if using the generic slot (dedicated slug collections keep their own name)
+  if (!catMap[category.slug]) {
+    const enTitle = category.translations?.en?.title;
+    const enDesc  = category.translations?.en?.description;
+    if (enTitle || enDesc) await updateWixCategory(wixId, { name: enTitle || category.name, description: enDesc });
+    await pushCollectionTranslations(wixId, category.translations);
+  }
+  log('item', `${slot.id} («${category.name}»): ${productIds.length} products`);
+}
+```
+
+### `backend/src/routes/public.js` — `GET /api/public/categories`
+
+Keep `seasonal` = slot 1 result (exact same shape as today — backward compat for Wix Velo code that already calls this).  
+Add `seasonal2` = slot 2 result (`null` when inactive).
+
+```js
+const [slot1, slot2] = getActiveSeasonalSlots();
+
+res.json({
+  // ...existing fields unchanged...
+  seasonal: slot1.category
+    ? { name: slot1.category.name, slug: slot1.category.slug, description: slot1.category.description || '', translations: slot1.category.translations || {} }
+    : { active: null, slug: null },
+  seasonal2: slot2.category
+    ? { name: slot2.category.name, slug: slot2.category.slug, description: slot2.category.description || '', translations: slot2.category.translations || {} }
+    : null,
+  seasonalSlugs,  // unchanged — all slugs from the library
+});
+```
+
+---
+
+## Dashboard UI Changes
+
+### `apps/dashboard/src/components/settings/StorefrontCategoriesSection.jsx`
+
+Replace the single auto-schedule toggle + single manual override dropdown with two slot sub-sections rendered from `sc.slots`.
+
+**Slot 1 — Primary**
+- Auto-schedule toggle (same as today)
+- Manual override dropdown (None + all seasonal categories)
+
+**Slot 2 — Secondary**
+- Manual override dropdown only (no auto-schedule toggle — slot 2 is always manual)
+- Helper text: "Select a category to show a second seasonal slot on the website"
+
+Each seasonal category row in the library gains a per-slot badge:
+```
+Mother's Day    Apr 20 → May 26    [Slot 1]    [edit] [×]
+Easter          Mar 28 → Apr 15               [edit] [×]
+Christmas       Dec 01 → Dec 26    [Slot 2]    [edit] [×]
+```
+
+Slot badges are computed client-side using the same `resolveSlot` logic as configService (date check + override check).
+
+**Update handler** for each slot: `onUpdate({ storefrontCategories: { ...sc, slots: updatedSlots } })`.
+
+### `apps/dashboard/src/translations.js`
+
+Add keys (English + Russian):
+```js
+sfSlot1:           'Primary seasonal slot',
+sfSlot2:           'Secondary seasonal slot',
+sfSlot2Hint:       'Pick a category to show a second seasonal section on the website. Leave empty to hide it.',
+sfSlot1Active:     'Slot 1',
+sfSlot2Active:     'Slot 2',
+```
+
+---
+
+## Wix Changes
+
+### One-time setup (owner, done once)
+
+1. In Wix Stores dashboard: create a new collection named `seasonal-2` (or any name — the slug must be `seasonal-2`).
+2. In Wix Editor: add a nav menu item linking to `/category/seasonal-2` in all 4 language menus (PL/EN/UK/RU).
+3. In Blossom dashboard Settings → Storefront Categories → Wix Category Map: paste the new collection's ID as the value for key `seasonal-2`.
+
+After this, the backend controls everything.
+
+### `src/pages/masterPage.js` (Blossom-Wix repo)
+
+Two additions to the existing logic:
+
+**1. Resolve slot 2 title** (same as slot 1 logic):
+```js
+var seasonal2 = categories.seasonal2;
+var title2 = null;
+if (seasonal2 && seasonal2.name) {
+  var t2 = seasonal2.translations || {};
+  title2 = (t2[lang] && t2[lang].title) || (t2.en && t2.en.title) || seasonal2.name;
+}
+var menuLabel2 = title2 ? title2.toUpperCase() : null;
+var activeSeasonalLink2 = '/category/seasonal-2';
+```
+
+**2. In `transformMenuItems`** — extend to handle slot 2 items + explicit removal for both slots when null:
+```js
+function isSeasonalLink2(link) {
+  return link && link.indexOf('/category/seasonal-2') !== -1;
+}
+
+// In the map pass:
+if (isSeasonalLink2(item.link)) {
+  if (!menuLabel2) return null;  // mark for removal
+  return Object.assign({}, item, { label: menuLabel2, link: activeSeasonalLink2 });
+}
+if (isSeasonalLink(item.link) || isSeasonalLabel(label)) {
+  if (!menuLabel) return null;   // mark for removal when slot 1 is also inactive
+  return Object.assign({}, item, { label: menuLabel, link: activeSeasonalLink });
+}
+
+// After map, filter out nulls:
+renamed = renamed.filter(Boolean);
+```
+
+Note: slot 1 removal (when `menuLabel` is null) is a behavior improvement over today — currently inactive slot 1 leaves a ghost nav item. This fix brings slot 1 in line with slot 2's behavior.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `backend/src/services/configService.js` | DEFAULTS, migration, `getActiveSeasonalSlots()`, keep `getActiveSeasonalCategory()` as wrapper |
+| `backend/src/services/wixProductSync.js` | Single-slot sync → loop over slots |
+| `backend/src/routes/public.js` | Add `seasonal2` to `/categories` response |
+| `apps/dashboard/src/components/settings/StorefrontCategoriesSection.jsx` | Two-slot UI replacing single toggle+dropdown |
+| `apps/dashboard/src/translations.js` | New slot UI keys |
+| `src/pages/masterPage.js` (Blossom-Wix) | Handle `seasonal2`, explicit removal for null slots |
+
+---
+
+## What Does Not Change
+
+- `seasonal[]` library shape — owner edits seasonal categories exactly as today
+- Permanent, auto, and Available Today categories — untouched
+- `/api/public/products` endpoint — untouched
+- `wixCategoryMap` structure — one new key (`seasonal-2`) added by owner, no code change needed
+- Florist app — no changes (seasonal categories are owner-only config)
+
+---
+
+## Known Risks
+
+- **wixCategoryMap missing `seasonal-2`**: If the owner hasn't completed Wix setup yet, `wixId` will be undefined for slot 2. The sync logs a warning and skips — no crash, no data loss. Slot 2 stays empty/hidden.
+- **Both slots assigned the same category**: Technically possible via two manual overrides. The backend would sync the same products to both Wix collections. Not harmful but redundant. No validation is added — the owner is expected to pick distinct categories.
+- **Auto-schedule for slot 1 when a date range overlaps with slot 2's manual override**: The same category could appear in slot 1 (auto) and slot 2 (manual) simultaneously if the owner doesn't notice. Same as above — redundant but harmless.


### PR DESCRIPTION
## Summary

- **stockPurchases.js route**: all 3 Airtable STOCK calls (`getById`, `update ×2`, `create`) now go through `stockRepo`. New batch stock items land in Postgres.
- **New `stock_purchases` PG table** (`migration 0009`) + `stockPurchasesRepo.js` — purchase records now write to Postgres, not frozen Airtable.
- **stockOrders.js evaluate endpoint**: 3 remaining bypasses fixed:
  - `purchaseAlreadyRecorded()` idempotency check → `stockPurchasesRepo.noteMarkerExists()` (critical: Airtable bypass meant PO retries would double-credit stock)
  - evalDate recovery on `EVAL_ERROR` → `stockPurchasesRepo.findDateByPoMarker()`
  - `db.create(TABLES.STOCK_PURCHASES, ...)` ×2 → `stockPurchasesRepo.create()`

## What's NOT in this PR

Reads of STOCK_PURCHASES in `stock.js` (usage trace), `analytics.js`, and `stockOrders.js` (PO marker lookup fallback) stay on Airtable — tracked in GH #227–229. Those are read-only and read-stale is tolerable; the double-credit write risk was not.

## Test plan

- [x] 7 new integration tests (`stockPurchasesRepo.integration.test.js`) — create, noteMarkerExists (true/false/partial-match), findDateByPoMarker
- [x] 308/308 backend tests pass
- [ ] Smoke: receive a PO evaluation on prod, verify `stock_purchases` row appears in Railway Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)