### PR TITLE
fix: replace frozen Airtable reads with Postgres repos (#227 #228 #229)

### DIFF
--- a/backend/src/__tests__/stockPurchasesRepo.integration.test.js
+++ b/backend/src/__tests__/stockPurchasesRepo.integration.test.js
@@ -78,6 +78,24 @@ describe('stockPurchasesRepo', () => {
     });
   });
 
+  describe('list', () => {
+    it('returns all rows when no date range given', async () => {
+      await stockPurchasesRepo.create({ purchaseDate: '2026-04-01', supplier: 'A', quantityPurchased: 10 });
+      await stockPurchasesRepo.create({ purchaseDate: '2026-05-01', supplier: 'B', quantityPurchased: 5 });
+      const rows = await stockPurchasesRepo.list();
+      expect(rows).toHaveLength(2);
+    });
+
+    it('filters by from/to date range inclusive', async () => {
+      await stockPurchasesRepo.create({ purchaseDate: '2026-03-15', supplier: 'A', quantityPurchased: 10 });
+      await stockPurchasesRepo.create({ purchaseDate: '2026-04-10', supplier: 'B', quantityPurchased: 5 });
+      await stockPurchasesRepo.create({ purchaseDate: '2026-05-20', supplier: 'C', quantityPurchased: 3 });
+      const rows = await stockPurchasesRepo.list({ from: '2026-04-01', to: '2026-04-30' });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].Supplier).toBe('B');
+    });
+  });
+
   describe('findDateByPoMarker', () => {
     it('returns null when no rows for this PO', async () => {
       const result = await stockPurchasesRepo.findDateByPoMarker('recNONE');

--- a/backend/src/repos/customerRepo.js
+++ b/backend/src/repos/customerRepo.js
@@ -9,7 +9,7 @@
 
 import { db } from '../db/index.js';
 import { customers, keyPeople, legacyOrders, orders } from '../db/schema.js';
-import { eq, and, or, ilike, like, isNull, inArray, asc, desc, sql } from 'drizzle-orm';
+import { eq, and, or, ilike, like, isNull, isNotNull, inArray, asc, desc, sql } from 'drizzle-orm';
 
 // ── Field mapping: request body → PG column ──
 const PATCH_MAP = {

--- a/backend/src/repos/customerRepo.js
+++ b/backend/src/repos/customerRepo.js
@@ -421,3 +421,25 @@ export async function listOrders(customerId) {
     return b.date.localeCompare(a.date);
   });
 }
+
+// Returns customers who have at least one key person with importantDate set.
+// Used by the dashboard reminder widget.
+export async function listWithKeyPeopleHavingDates() {
+  const kpRows = await db.select().from(keyPeople)
+    .where(isNotNull(keyPeople.importantDate));
+
+  if (kpRows.length === 0) return [];
+
+  const custIds = [...new Set(kpRows.map(kp => kp.customerId))];
+
+  const custRows = await db.select().from(customers)
+    .where(and(inArray(customers.id, custIds), isNull(customers.deletedAt)));
+
+  const kpsByCustomer = {};
+  for (const kp of kpRows) {
+    kpsByCustomer[kp.customerId] = kpsByCustomer[kp.customerId] || [];
+    kpsByCustomer[kp.customerId].push(kp);
+  }
+
+  return custRows.map(row => _pgCustomerToResponse(row, kpsByCustomer[row.id] || []));
+}

--- a/backend/src/repos/stockPurchasesRepo.js
+++ b/backend/src/repos/stockPurchasesRepo.js
@@ -1,6 +1,6 @@
 import { db } from '../db/index.js';
 import { stockPurchases } from '../db/schema.js';
-import { eq, and, like, desc } from 'drizzle-orm';
+import { eq, and, like, desc, gte, lte } from 'drizzle-orm';
 
 function toWire(row) {
   return {
@@ -30,6 +30,18 @@ export async function create({ purchaseDate, supplier, stockId, stockAirtableId,
 
   const [row] = await db.insert(stockPurchases).values(values).returning();
   return toWire(row);
+}
+
+export async function list({ from, to } = {}) {
+  const conditions = [];
+  if (from) conditions.push(gte(stockPurchases.purchaseDate, from));
+  if (to)   conditions.push(lte(stockPurchases.purchaseDate, to));
+
+  const rows = await db.select().from(stockPurchases)
+    .where(conditions.length ? and(...conditions) : undefined)
+    .orderBy(desc(stockPurchases.purchaseDate));
+
+  return rows.map(toWire);
 }
 
 // Returns true when a row whose Notes field contains `marker` already exists.

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -1,9 +1,12 @@
 import { Router } from 'express';
 import { authorize } from '../middleware/auth.js';
-import * as db from '../services/airtable.js';
+import * as db from '../services/airtable.js'; // TODO Task 4: remove after customer section migrated
+import * as orderRepo from '../repos/orderRepo.js';
+import * as stockRepo from '../repos/stockRepo.js';
 import * as stockLossRepo from '../repos/stockLossRepo.js';
-import { TABLES } from '../config/airtable.js';
-import { sanitizeFormulaValue } from '../utils/sanitize.js';
+import * as stockPurchasesRepo from '../repos/stockPurchasesRepo.js';
+import * as customerRepo from '../repos/customerRepo.js';
+import { TABLES } from '../config/airtable.js'; // TODO Task 4: remove after customer section migrated
 import { getConfig } from '../services/configService.js';
 import { ORDER_STATUS, PAYMENT_STATUS } from '../constants/statuses.js';
 import {
@@ -28,98 +31,42 @@ router.get('/', async (req, res, next) => {
       return res.status(400).json({ error: 'from and to date params are required.' });
     }
 
-    // ── Build date filters ──
-    const safeFrom = sanitizeFormulaValue(from);
-    const safeTo = sanitizeFormulaValue(to);
-    const dateFilter = `AND(
-      NOT(IS_BEFORE({Order Date}, '${safeFrom}')),
-      NOT(IS_AFTER({Order Date}, '${safeTo}')),
-      {Status} != '${ORDER_STATUS.CANCELLED}'
-    )`;
-
     const fromDate = new Date(from);
     const toDate = new Date(to);
     const periodLengthMs = toDate.getTime() - fromDate.getTime();
     const prevToDate = new Date(fromDate.getTime() - 1);
     const prevFromDate = new Date(prevToDate.getTime() - periodLengthMs);
-    const safePrevFrom = sanitizeFormulaValue(prevFromDate.toISOString().split('T')[0]);
-    const safePrevTo = sanitizeFormulaValue(prevToDate.toISOString().split('T')[0]);
-    const prevDateFilter = `AND(
-      NOT(IS_BEFORE({Order Date}, '${safePrevFrom}')),
-      NOT(IS_AFTER({Order Date}, '${safePrevTo}')),
-      {Status} != '${ORDER_STATUS.CANCELLED}'
-    )`;
+    const prevFromStr = prevFromDate.toISOString().split('T')[0];
+    const prevToStr   = prevToDate.toISOString().split('T')[0];
 
     // ── Fetch all data in parallel ──
     const [orders, stock, prevOrders, cancelledOrders, stockPurchases, stockLosses] = await Promise.all([
-      db.list(TABLES.ORDERS, { filterByFormula: dateFilter }),
-      db.list(TABLES.STOCK, {
-        filterByFormula: '{Active} = TRUE()',
-        fields: ['Display Name', 'Dead/Unsold Stems', 'Current Cost Price', 'Current Sell Price', 'Current Quantity'],
-      }),
-      db.list(TABLES.ORDERS, {
-        filterByFormula: prevDateFilter,
-        fields: ['Order Lines', 'Payment Status'],
-      }),
-      db.list(TABLES.ORDERS, {
-        filterByFormula: `AND(
-          NOT(IS_BEFORE({Order Date}, '${safeFrom}')),
-          NOT(IS_AFTER({Order Date}, '${safeTo}')),
-          {Status} = '${ORDER_STATUS.CANCELLED}'
-        )`,
-        fields: ['Order Date'],
-      }).catch(() => []),
-      TABLES.STOCK_PURCHASES ? db.list(TABLES.STOCK_PURCHASES, {
-        filterByFormula: `AND(
-          NOT(IS_BEFORE({Purchase Date}, '${safeFrom}')),
-          NOT(IS_AFTER({Purchase Date}, '${safeTo}'))
-        )`,
-      }).catch(() => []) : Promise.resolve([]),
+      orderRepo.list({ pg: { dateFrom: from, dateTo: to, excludeStatuses: [ORDER_STATUS.CANCELLED] } }),
+      stockRepo.list({ pg: { active: true } }),
+      orderRepo.list({ pg: { dateFrom: prevFromStr, dateTo: prevToStr, excludeStatuses: [ORDER_STATUS.CANCELLED] } }),
+      orderRepo.list({ pg: { dateFrom: from, dateTo: to, statuses: [ORDER_STATUS.CANCELLED] } }),
+      stockPurchasesRepo.list({ from, to }).catch(() => []),
       stockLossRepo.list({ from, to }).catch(() => []),
     ]);
 
-    // ── Batch-fetch order lines + deliveries ──
-    const allLineIds = orders.flatMap(o => o['Order Lines'] || []);
-    const deliveryIds = orders.flatMap(o => o['Deliveries'] || []);
-    const allPrevLineIds = prevOrders.flatMap(o => o['Order Lines'] || []);
-    const batchSize = 100;
-
-    function batchFetch(ids, table, fields) {
-      if (ids.length === 0) return Promise.resolve([]);
-      const promises = [];
-      for (let i = 0; i < ids.length; i += batchSize) {
-        const batch = ids.slice(i, i + batchSize);
-        promises.push(
-          db.list(table, {
-            filterByFormula: `OR(${batch.map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-            fields,
-            maxRecords: batchSize,
-          })
-        );
-      }
-      return Promise.all(promises).then(results => results.flat());
-    }
-
-    const [allLines, deliveryRecords, prevLines] = await Promise.all([
-      batchFetch(allLineIds, TABLES.ORDER_LINES, ['Order', 'Flower Name', 'Quantity', 'Sell Price Per Unit', 'Cost Price Per Unit']),
-      batchFetch(deliveryIds, TABLES.DELIVERIES, ['Linked Order', 'Delivery Fee']),
-      batchFetch(allPrevLineIds, TABLES.ORDER_LINES, ['Order', 'Flower Name', 'Quantity']),
-    ]);
+    // orderRepo.list() embeds _lines and _delivery — no separate batch fetch needed.
+    const allLines  = orders.flatMap(o => o._lines || []);
+    const prevLines = prevOrders.flatMap(o => o._lines || []);
 
     // ── Build lookup maps ──
-    const orderSellTotals = {};
-    const orderCostTotals = {};
-    for (const line of allLines) {
-      const orderId = line.Order?.[0];
-      if (!orderId) continue;
-      const qty = line.Quantity || 0;
-      orderSellTotals[orderId] = (orderSellTotals[orderId] || 0) + (line['Sell Price Per Unit'] || 0) * qty;
-      orderCostTotals[orderId] = (orderCostTotals[orderId] || 0) + (line['Cost Price Per Unit'] || 0) * qty;
-    }
+    const orderSellTotals    = {};
+    const orderCostTotals    = {};
     const deliveryFeeByOrder = {};
-    for (const d of deliveryRecords) {
-      const orderId = d['Linked Order']?.[0];
-      if (orderId) deliveryFeeByOrder[orderId] = d['Delivery Fee'] || 0;
+
+    for (const order of orders) {
+      for (const line of (order._lines || [])) {
+        const qty = line.Quantity || 0;
+        orderSellTotals[order.id] = (orderSellTotals[order.id] || 0) + (line['Sell Price Per Unit'] || 0) * qty;
+        orderCostTotals[order.id] = (orderCostTotals[order.id] || 0) + (line['Cost Price Per Unit'] || 0) * qty;
+      }
+      if (order._delivery?.['Delivery Fee']) {
+        deliveryFeeByOrder[order.id] = order._delivery['Delivery Fee'];
+      }
     }
 
     // ── Compute all metrics via service functions ──
@@ -175,6 +122,7 @@ router.get('/', async (req, res, next) => {
       : 0;
 
     // ── Customer metrics ──
+    const batchSize = 100; // TODO Task 4: remove after customer section migrated
     const customerIds = [...new Set(orders.map(o => o.Customer?.[0]).filter(Boolean))];
     const customers = { newCount: 0, returningCount: 0, segments: {}, topSpenders: [] };
 

--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -1,12 +1,13 @@
 import { Router } from 'express';
 import { authorize } from '../middleware/auth.js';
-import * as db from '../services/airtable.js'; // TODO Task 4: remove after customer section migrated
 import * as orderRepo from '../repos/orderRepo.js';
 import * as stockRepo from '../repos/stockRepo.js';
 import * as stockLossRepo from '../repos/stockLossRepo.js';
 import * as stockPurchasesRepo from '../repos/stockPurchasesRepo.js';
 import * as customerRepo from '../repos/customerRepo.js';
-import { TABLES } from '../config/airtable.js'; // TODO Task 4: remove after customer section migrated
+import { db as pgDb } from '../db/index.js';
+import { orders as ordersTable } from '../db/schema.js';
+import { inArray, isNull, and as pgAnd, lt } from 'drizzle-orm';
 import { getConfig } from '../services/configService.js';
 import { ORDER_STATUS, PAYMENT_STATUS } from '../constants/statuses.js';
 import {
@@ -93,15 +94,13 @@ router.get('/', async (req, res, next) => {
     const stockLossBreakdown = breakdownStockLosses(stockLosses);
 
     // Supplier scorecard — stockLossRepo.list() already enriches each row with
-    // supplier and flowerName via LEFT JOIN, so no extra Airtable fetch needed.
-    // Build a synthetic lossStockItems list from the enriched loss records so
-    // buildSupplierScorecard can still do its id → supplier lookup.
+    // supplier and flowerName via LEFT JOIN, so no extra fetch needed.
     const lossStockItems = stockLosses
       .filter(l => l['Stock Item']?.[0])
       .map(l => ({ id: l['Stock Item'][0], Supplier: l.supplier || '', 'Display Name': l.flowerName || '' }));
     const supplierScorecard = buildSupplierScorecard(stockPurchases, stockLosses, lossStockItems);
 
-    // ── Source breakdown (simple aggregation, kept inline) ──
+    // ── Source breakdown ──
     const bySource = {};
     const revenueBySource = {};
     for (const o of orders) {
@@ -122,31 +121,30 @@ router.get('/', async (req, res, next) => {
       : 0;
 
     // ── Customer metrics ──
-    const batchSize = 100; // TODO Task 4: remove after customer section migrated
     const customerIds = [...new Set(orders.map(o => o.Customer?.[0]).filter(Boolean))];
     const customers = { newCount: 0, returningCount: 0, segments: {}, topSpenders: [] };
 
     if (customerIds.length > 0) {
-      const custRecords = [];
-      for (let i = 0; i < customerIds.length; i += batchSize) {
-        const batch = customerIds.slice(i, i + batchSize);
-        const recs = await db.list(TABLES.CUSTOMERS, {
-          filterByFormula: `OR(${batch.map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-          maxRecords: batchSize,
-        });
-        custRecords.push(...recs);
+      // Fetch all customers, index by both PG uuid and Airtable recXXX
+      const allCusts = await customerRepo.list({ withAggregates: false });
+      const custById = new Map(allCusts.map(c => [c.id, c]));
+      for (const c of allCusts) {
+        if (c.airtableId) custById.set(c.airtableId, c);
       }
+      const custRecords = customerIds.map(id => custById.get(id)).filter(Boolean);
 
-      const spendByCustomer = {};
-      for (const o of paidOrders) {
-        const cid = o.Customer?.[0];
-        if (cid) spendByCustomer[cid] = (spendByCustomer[cid] || 0) + (o['Effective Price'] || 0);
-      }
+      // Customers with any order before this period are "returning"
+      const priorRows = await pgDb.select({ customerId: ordersTable.customerId })
+        .from(ordersTable)
+        .where(pgAnd(
+          inArray(ordersTable.customerId, customerIds),
+          lt(ordersTable.orderDate, from),
+          isNull(ordersTable.deletedAt),
+        ));
+      const returningCustIds = new Set(priorRows.map(r => r.customerId));
 
-      const periodOrderIds = new Set(orders.map(o => o.id));
       for (const c of custRecords) {
-        const allCustOrders = c['App Orders'] || [];
-        if (allCustOrders.some(oid => !periodOrderIds.has(oid))) {
+        if (returningCustIds.has(c.id) || returningCustIds.has(c.airtableId)) {
           customers.returningCount++;
         } else {
           customers.newCount++;
@@ -160,11 +158,17 @@ router.get('/', async (req, res, next) => {
       }
       customers.segments = segments;
 
+      const spendByCustomer = {};
+      for (const o of paidOrders) {
+        const cid = o.Customer?.[0];
+        if (cid) spendByCustomer[cid] = (spendByCustomer[cid] || 0) + (o['Effective Price'] || 0);
+      }
+
       customers.topSpenders = custRecords
         .map(c => ({
           id: c.id,
           name: c.Name || c.Nickname || '—',
-          spend: spendByCustomer[c.id] || 0,
+          spend: spendByCustomer[c.id] || spendByCustomer[c.airtableId] || 0,
           segment: c.Segment || null,
         }))
         .sort((a, b) => b.spend - a.spend)

--- a/backend/src/routes/dashboard.js
+++ b/backend/src/routes/dashboard.js
@@ -48,128 +48,53 @@ router.get('/', async (req, res, next) => {
       customerRepo.listWithKeyPeopleHavingDates().catch(() => []),
     ]);
 
-    // Enrich orders with customer names + computed prices
-    // (same bulk-fetch pattern as orders route)
-    const uniqueCustomerIds = [...new Set(orders.flatMap(o => o.Customer || []))];
-    const allLineIds = orders.flatMap(o => o['Order Lines'] || []);
-
-    const [allCustomers, allLines] = await Promise.all([
-      uniqueCustomerIds.length > 0
-        ? db.list(TABLES.CUSTOMERS, {
-            filterByFormula: `OR(${uniqueCustomerIds.map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-            fields: ['Name', 'Nickname'],
-          }).catch(() => [])
-        : [],
-      allLineIds.length > 0
-        ? db.list(TABLES.ORDER_LINES, {
-            filterByFormula: `OR(${allLineIds.map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-            fields: ['Order', 'Sell Price Per Unit', 'Quantity'],
-            maxRecords: 1000,
-          }).catch(() => [])
-        : [],
-    ]);
-
+    // Build customerMap from all order customer IDs across all order arrays
+    const allCustIds = [...new Set([
+      ...orders.flatMap(o => o.Customer || []),
+      ...fulfillToday.flatMap(o => o.Customer || []),
+      ...tomorrowOrders.flatMap(o => o.Customer || []),
+    ].filter(Boolean))];
+    const custList = allCustIds.length > 0 ? await customerRepo.findMany(allCustIds) : [];
     const customerMap = {};
-    for (const c of allCustomers) customerMap[c.id] = c;
-
-    // Sum order line sell totals by order ID
-    const totalByOrder = {};
-    for (const line of allLines) {
-      const oid = line.Order?.[0];
-      if (oid) {
-        totalByOrder[oid] = (totalByOrder[oid] || 0)
-          + Number(line['Sell Price Per Unit'] || 0) * Number(line['Quantity'] || 0);
-      }
+    for (const c of custList) {
+      customerMap[c.id] = c;
+      if (c.airtableId) customerMap[c.airtableId] = c;
     }
 
-    for (const order of orders) {
+    function computeSellTotal(order) {
+      return (order._lines || []).reduce(
+        (sum, l) => sum + (l['Sell Price Per Unit'] || 0) * (l.Quantity || 0), 0
+      );
+    }
+    function enrichOrder(order) {
       const custId = order.Customer?.[0];
       order['Customer Name'] = customerMap[custId]?.Name || customerMap[custId]?.Nickname || '';
-
-      // Compute effective price (Final Price is an Airtable formula that may not return)
-      if (!order['Price Override'] && totalByOrder[order.id] !== undefined) {
-        order['Sell Total'] = totalByOrder[order.id];
+      if (!order['Price Override']) {
+        order['Sell Total'] = computeSellTotal(order);
       }
-      const deliveryFee = Number(order['Delivery Fee'] || 0);
-      // Price Override replaces flower total only; delivery fee always added on top
+      const deliveryFee = Number(
+        order['Delivery Fee'] || order._delivery?.['Delivery Fee'] || 0
+      );
       order['Effective Price'] = order['Final Price']
         ?? ((order['Price Override'] || order['Sell Total'] || 0) + deliveryFee);
     }
 
-    // Enrich fulfillToday orders with customer names + effective prices
-    // (reuse the same customerMap + totalByOrder if they overlap, fetch missing)
-    const fulfillCustIds = [...new Set(fulfillToday.flatMap(o => o.Customer || []).filter(id => !customerMap[id]))];
-    const fulfillLineIds = fulfillToday.flatMap(o => o['Order Lines'] || []).filter(id => !allLineIds.includes(id));
+    for (const order of orders) enrichOrder(order);
 
-    const [extraFulfillCusts, extraFulfillLines] = await Promise.all([
-      fulfillCustIds.length > 0
-        ? db.list(TABLES.CUSTOMERS, {
-            filterByFormula: `OR(${fulfillCustIds.map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-            fields: ['Name', 'Nickname'],
-          }).catch(() => [])
-        : [],
-      fulfillLineIds.length > 0
-        ? db.list(TABLES.ORDER_LINES, {
-            filterByFormula: `OR(${fulfillLineIds.map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-            fields: ['Order', 'Sell Price Per Unit', 'Quantity', 'Flower Name'],
-            maxRecords: 1000,
-          }).catch(() => [])
-        : [],
-    ]);
-    for (const c of extraFulfillCusts) customerMap[c.id] = c;
-    for (const line of extraFulfillLines) {
-      const oid = line.Order?.[0];
-      if (oid) {
-        totalByOrder[oid] = (totalByOrder[oid] || 0)
-          + Number(line['Sell Price Per Unit'] || 0) * Number(line['Quantity'] || 0);
-      }
-    }
+    for (const order of fulfillToday) enrichOrder(order);
 
-    for (const order of fulfillToday) {
-      const custId = order.Customer?.[0];
-      order['Customer Name'] = customerMap[custId]?.Name || customerMap[custId]?.Nickname || '';
-      if (!order['Price Override'] && totalByOrder[order.id] !== undefined) {
-        order['Sell Total'] = totalByOrder[order.id];
-      }
-      const deliveryFee = Number(order['Delivery Fee'] || 0);
-      order['Effective Price'] = order['Final Price']
-        ?? ((order['Price Override'] || order['Sell Total'] || 0) + deliveryFee);
-    }
-
-    // Enrich tomorrowOrders with customer names + order line summaries
-    const tmrwCustIds = [...new Set(tomorrowOrders.flatMap(o => o.Customer || []).filter(id => !customerMap[id]))];
-    const tmrwLineIds = tomorrowOrders.flatMap(o => o['Order Lines'] || []);
-
-    const [extraTmrwCusts, tmrwLines] = await Promise.all([
-      tmrwCustIds.length > 0
-        ? db.list(TABLES.CUSTOMERS, {
-            filterByFormula: `OR(${tmrwCustIds.map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-            fields: ['Name', 'Nickname'],
-          }).catch(() => [])
-        : [],
-      tmrwLineIds.length > 0
-        ? db.list(TABLES.ORDER_LINES, {
-            filterByFormula: `OR(${tmrwLineIds.slice(0, 200).map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-            fields: ['Order', 'Flower Name', 'Quantity'],
-            maxRecords: 500,
-          }).catch(() => [])
-        : [],
-    ]);
-    for (const c of extraTmrwCusts) customerMap[c.id] = c;
-
-    // Build line summaries per order for tomorrow
+    // Enrich tomorrowOrders with customer names + line summaries from embedded _lines
     const tmrwLineSummary = {};
-    for (const line of tmrwLines) {
-      const oid = line.Order?.[0];
-      if (!oid) continue;
-      if (!tmrwLineSummary[oid]) tmrwLineSummary[oid] = { items: [], count: 0 };
-      tmrwLineSummary[oid].items.push(`${line['Flower Name'] || '?'} ×${line.Quantity || 1}`);
-      tmrwLineSummary[oid].count++;
-    }
-
     for (const order of tomorrowOrders) {
       const custId = order.Customer?.[0];
       order['Customer Name'] = customerMap[custId]?.Name || customerMap[custId]?.Nickname || '';
+      const lines = order._lines || [];
+      if (lines.length > 0) {
+        tmrwLineSummary[order.id] = {
+          items: lines.map(l => `${l['Flower Name'] || '?'} ×${l.Quantity || 1}`),
+          count: lines.length,
+        };
+      }
       const summary = tmrwLineSummary[order.id];
       order['Line Summary'] = summary ? summary.items.join(', ') : '';
       order['Line Count'] = summary ? summary.count : 0;
@@ -193,23 +118,10 @@ router.get('/', async (req, res, next) => {
       d.Status !== DELIVERY_STATUS.DELIVERED
     );
 
-    // Bulk-fetch order lines for unpaid orders to calculate accurate sell totals.
-    // Can't rely on 'Sell Price Total' rollup — it may be stale after price edits.
-    const unpaidLineIds = unpaidOrders.flatMap(o => o['Order Lines'] || []);
-    const unpaidLines = unpaidLineIds.length > 0
-      ? await db.list(TABLES.ORDER_LINES, {
-          filterByFormula: `OR(${unpaidLineIds.slice(0, 200).map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-          fields: ['Order', 'Sell Price Per Unit', 'Quantity'],
-          maxRecords: 1000,
-        }).catch(() => [])
-      : [];
+    // Compute unpaid order sell totals from embedded _lines
     const unpaidTotalByOrder = {};
-    for (const line of unpaidLines) {
-      const oid = line.Order?.[0];
-      if (oid) {
-        unpaidTotalByOrder[oid] = (unpaidTotalByOrder[oid] || 0)
-          + Number(line['Sell Price Per Unit'] || 0) * Number(line['Quantity'] || 0);
-      }
+    for (const o of unpaidOrders) {
+      unpaidTotalByOrder[o.id] = computeSellTotal(o);
     }
 
     // Unpaid orders aging: group by how old they are relative to today
@@ -273,8 +185,6 @@ router.get('/', async (req, res, next) => {
     keyDateReminders.sort((a, b) => a.daysUntil - b.daysUntil);
 
     // Enrich pending deliveries with customer name (who ordered)
-    // by following the chain: Delivery → Order → Customer.
-    // We already have orders loaded, so we only need the link hop.
     const orderIdSet = new Set(orders.map(o => o.id));
     const orderMapForDeliveries = {};
     for (const o of orders) orderMapForDeliveries[o.id] = o;
@@ -285,19 +195,16 @@ router.get('/', async (req, res, next) => {
       .filter(id => !orderIdSet.has(id));
 
     if (missingOrderIds.length > 0) {
-      const extraOrders = await db.list(TABLES.ORDERS, {
-        filterByFormula: `OR(${missingOrderIds.map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-        fields: ['Customer'],
-      });
-      const extraCustIds = [...new Set(extraOrders.flatMap(o => o.Customer || []))];
-      const extraCusts = extraCustIds.length > 0
-        ? await db.list(TABLES.CUSTOMERS, {
-            filterByFormula: `OR(${extraCustIds.map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-            fields: ['Name', 'Nickname'],
-          })
-        : [];
-      for (const c of extraCusts) customerMap[c.id] = c;
-      for (const o of extraOrders) orderMapForDeliveries[o.id] = o;
+      const extraOrders = await Promise.all(
+        missingOrderIds.map(id => orderRepo.getById(id).catch(() => null))
+      );
+      const extraCustIds = extraOrders.filter(Boolean).flatMap(o => o.Customer || []);
+      const extraCusts = extraCustIds.length > 0 ? await customerRepo.findMany(extraCustIds) : [];
+      for (const c of extraCusts) {
+        customerMap[c.id] = c;
+        if (c.airtableId) customerMap[c.airtableId] = c;
+      }
+      for (const o of extraOrders.filter(Boolean)) orderMapForDeliveries[o.id] = o;
     }
 
     for (const d of deliveries) {
@@ -305,9 +212,7 @@ router.get('/', async (req, res, next) => {
       const order = orderMapForDeliveries[orderId];
       const custId = order?.Customer?.[0];
       const cust = customerMap[custId];
-      if (cust) {
-        d['Customer Name'] = cust.Name || cust.Nickname || '';
-      }
+      if (cust) d['Customer Name'] = cust.Name || cust.Nickname || '';
     }
 
     // Include deferred order lines as additional demand in "Flowers Needed".

--- a/backend/src/routes/dashboard.js
+++ b/backend/src/routes/dashboard.js
@@ -1,9 +1,13 @@
 import { Router } from 'express';
 import { authorize } from '../middleware/auth.js';
 import * as db from '../services/airtable.js';
+import * as orderRepo from '../repos/orderRepo.js';
+import * as customerRepo from '../repos/customerRepo.js';
 import * as stockRepo from '../repos/stockRepo.js';
 import { TABLES } from '../config/airtable.js';
-import { sanitizeFormulaValue } from '../utils/sanitize.js';
+import { db as pgDb } from '../db/index.js';
+import { orderLines as orderLinesTable, orders as ordersTable } from '../db/schema.js';
+import { and, or, eq, isNull, inArray, gte, lte, asc } from 'drizzle-orm';
 import { ORDER_STATUS, PAYMENT_STATUS, DELIVERY_STATUS } from '../constants/statuses.js';
 
 const router = Router();
@@ -13,68 +17,35 @@ router.use(authorize('dashboard'));
 router.get('/', async (req, res, next) => {
   try {
     // Accept optional ?date= param, default to today
-    const today = sanitizeFormulaValue(req.query.date || new Date().toISOString().split('T')[0]);
+    const today = (req.query.date || new Date().toISOString().split('T')[0]).slice(0, 10);
 
     const tomorrow = new Date(new Date(today).getTime() + 86400000).toISOString().split('T')[0];
 
     const [orders, ordersDueToday, fulfillToday, tomorrowOrders, deliveries, lowStock, unpaidOrders, negativeStockItems, customersWithDates] = await Promise.all([
-      // Today's orders (by Order Date — for revenue, status breakdown)
-      db.list(TABLES.ORDERS, {
-        filterByFormula: `DATESTR({Order Date}) = '${today}'`,
-        sort: [{ field: 'Order Date', direction: 'desc' }],
-      }).catch(() => []),
-      // Orders due today (by Required By — for "planned today" count)
-      db.list(TABLES.ORDERS, {
-        filterByFormula: `AND(DATESTR({Required By}) = '${today}', {Status} != '${ORDER_STATUS.CANCELLED}')`,
-        fields: ['Required By', 'Status'],
-        maxRecords: 200,
-      }).catch(() => []),
-      // Orders to fulfill today: Required By = today, not cancelled (full data for display)
-      db.list(TABLES.ORDERS, {
-        filterByFormula: `AND(DATESTR({Required By}) = '${today}', {Status} != '${ORDER_STATUS.CANCELLED}')`,
-        sort: [{ field: 'Required By', direction: 'asc' }],
-        maxRecords: 200,
-      }).catch(() => []),
-      // Tomorrow's orders: Required By = tomorrow, not cancelled (show all for planning)
-      db.list(TABLES.ORDERS, {
-        filterByFormula: `AND(DATESTR({Required By}) = '${tomorrow}', {Status} != '${ORDER_STATUS.CANCELLED}')`,
-        fields: ['Customer', 'Required By', 'Status', 'Delivery Type', 'Order Lines', 'Customer Request', 'App Order ID', 'Delivery Time'],
-        maxRecords: 100,
-      }).catch(() => []),
-      // Today's pending deliveries (all statuses — we filter below)
-      db.list(TABLES.DELIVERIES, {
-        filterByFormula: `AND(DATESTR({Delivery Date}) = '${today}', {Status} != '${DELIVERY_STATUS.DELIVERED}')`,
-      }).catch(() => []),
+      // Today's orders by Order Date (for revenue + status breakdown)
+      orderRepo.list({ pg: { forDate: today }, sort: [{ field: 'Order Date', direction: 'desc' }] }).catch(() => []),
+      // Orders due today by Required By (count only — we only need .length)
+      orderRepo.list({ pg: { requiredByFrom: today, requiredByTo: today, excludeStatuses: [ORDER_STATUS.CANCELLED] } }).catch(() => []),
+      // Full data for fulfill-today orders
+      orderRepo.list({ pg: { requiredByFrom: today, requiredByTo: today, excludeStatuses: [ORDER_STATUS.CANCELLED] }, sort: [{ field: 'Required By', direction: 'asc' }] }).catch(() => []),
+      // Tomorrow's orders for planning view
+      orderRepo.list({ pg: { requiredByFrom: tomorrow, requiredByTo: tomorrow, excludeStatuses: [ORDER_STATUS.CANCELLED] } }).catch(() => []),
+      // Today's pending deliveries (filter to non-Delivered below)
+      orderRepo.listDeliveries({ pg: { date: today } }).then(rows => rows.filter(d => d.Status !== DELIVERY_STATUS.DELIVERED)).catch(() => []),
       // Stock items below reorder threshold
-      stockRepo.list({
-        filterByFormula: `AND({Active} = TRUE(), {Current Quantity} < {Reorder Threshold})`,
-        sort: [{ field: 'Current Quantity', direction: 'asc' }],
-        // PG-mode equivalent — caller filters threshold below since we
-        // don't have a column-vs-column comparison option yet.
-        pg: { active: true, includeEmpty: true },
-      }).then(rows => rows.filter(r => {
-        // Defence-in-depth: PG-mode returns all active stock; filter on threshold here.
+      stockRepo.list({ pg: { active: true, includeEmpty: true } }).then(rows => rows.filter(r => {
         const t = Number(r['Reorder Threshold'] || 0);
         return t > 0 && Number(r['Current Quantity'] || 0) < t;
       })).catch(() => []),
-      // All unpaid/partial non-cancelled orders for aging calculation
-      // Don't restrict fields — 'Final Price' is a formula field that may not exist in all bases
-      db.list(TABLES.ORDERS, {
-        filterByFormula: `AND(OR({Payment Status} = '${PAYMENT_STATUS.UNPAID}', {Payment Status} = '${PAYMENT_STATUS.PARTIAL}'), {Status} != '${ORDER_STATUS.CANCELLED}')`,
-      }).catch(() => []),
+      // Unpaid/partial non-cancelled orders
+      orderRepo.list({ pg: { excludeStatuses: [ORDER_STATUS.CANCELLED] } })
+        .then(rows => rows.filter(o =>
+          o['Payment Status'] === PAYMENT_STATUS.UNPAID || o['Payment Status'] === PAYMENT_STATUS.PARTIAL
+        )).catch(() => []),
       // Active stock items with negative quantity
-      stockRepo.list({
-        filterByFormula: `AND({Active} = TRUE(), {Current Quantity} < 0)`,
-        fields: ['Display Name', 'Purchase Name', 'Current Quantity', 'Supplier', 'Order Lines'],
-        pg: { active: true, includeEmpty: true },
-      }).then(rows => rows.filter(r => Number(r['Current Quantity'] || 0) < 0))
-        .catch(() => []),
-      // Customers with key person dates set for upcoming reminders
-      // Wrapped in catch — these fields may not exist in all Airtable bases
-      db.list(TABLES.CUSTOMERS, {
-        filterByFormula: `OR({Key person 1 (important DATE)} != '', {Key person 2 (important DATE)} != '')`,
-        fields: ['Name', 'Nickname', 'Key person 1 (Name + Contact details)', 'Key person 1 (important DATE)', 'Key person 2 (Name + Contact details)', 'Key person 2 (important DATE)'],
-      }).catch(() => []),
+      stockRepo.list({ pg: { active: true, includeEmpty: true } }).then(rows => rows.filter(r => Number(r['Current Quantity'] || 0) < 0)).catch(() => []),
+      // Customers with key person reminder dates
+      customerRepo.listWithKeyPeopleHavingDates().catch(() => []),
     ]);
 
     // Enrich orders with customer names + computed prices

--- a/backend/src/routes/dashboard.js
+++ b/backend/src/routes/dashboard.js
@@ -298,7 +298,7 @@ router.get('/', async (req, res, next) => {
         }
         const group = groupMap.get(groupKey);
         group.qty += Number(s['Current Quantity'] || 0);
-        group.batchIds.push(s.id);
+        group.batchIds.push(s._pgId || s.id);
         const nb = neededByMap[s._pgId];
         if (nb && (!group.neededBy || nb < group.neededBy)) group.neededBy = nb;
         if (!group.supplier && s.Supplier) group.supplier = s.Supplier;
@@ -314,7 +314,7 @@ router.get('/', async (req, res, next) => {
     // Merge deferred demand into negativeStock list.
     // Match by batch ID (deferred items reference specific stock records within a group).
     for (const [stockId, demand] of Object.entries(deferredDemand)) {
-      const existing = negativeStock.find(s => s.id === stockId || s.batchIds?.includes(stockId));
+      const existing = negativeStock.find(s => s._pgId === stockId || s.id === stockId || s.batchIds?.includes(stockId));
       if (existing) {
         existing.deferredQty = (existing.deferredQty || 0) + demand.qty;
         if (demand.neededBy && (!existing.neededBy || demand.neededBy < existing.neededBy)) {

--- a/backend/src/routes/dashboard.js
+++ b/backend/src/routes/dashboard.js
@@ -1,10 +1,8 @@
 import { Router } from 'express';
 import { authorize } from '../middleware/auth.js';
-import * as db from '../services/airtable.js';
 import * as orderRepo from '../repos/orderRepo.js';
 import * as customerRepo from '../repos/customerRepo.js';
 import * as stockRepo from '../repos/stockRepo.js';
-import { TABLES } from '../config/airtable.js';
 import { db as pgDb } from '../db/index.js';
 import { orderLines as orderLinesTable, orders as ordersTable } from '../db/schema.js';
 import { and, or, eq, isNull, inArray, gte, lte, asc } from 'drizzle-orm';
@@ -217,102 +215,91 @@ router.get('/', async (req, res, next) => {
 
     // Include deferred order lines as additional demand in "Flowers Needed".
     // Deferred lines have Stock Deferred = true — they signal "need to buy" without deducting stock.
-    const deferredLines = await db.list(TABLES.ORDER_LINES, {
-      filterByFormula: `AND({Stock Deferred} = TRUE())`,
-      fields: ['Stock Item', 'Flower Name', 'Quantity', 'Order'],
-      maxRecords: 500,
-    }).catch(() => []);
+    const rawDeferredLines = await pgDb.select().from(orderLinesTable)
+      .where(and(eq(orderLinesTable.stockDeferred, true), isNull(orderLinesTable.deletedAt)));
 
     // Aggregate deferred demand by stock item: stockId → { name, qty, neededBy }
     const deferredDemand = {};
-    if (deferredLines.length > 0) {
-      // Fetch parent orders to get Required By dates and exclude cancelled orders
-      const deferredOrderIds = [...new Set(deferredLines.flatMap(l => l.Order || []))];
+    if (rawDeferredLines.length > 0) {
+      const deferredOrderIds = [...new Set(rawDeferredLines.map(l => l.orderId).filter(Boolean))];
       const deferredOrders = deferredOrderIds.length > 0
-        ? await db.list(TABLES.ORDERS, {
-            filterByFormula: `AND(OR(${deferredOrderIds.slice(0, 50).map(id => `RECORD_ID() = "${id}"`).join(',')}), {Status} != '${ORDER_STATUS.CANCELLED}')`,
-            fields: ['Required By'],
-          }).catch(() => [])
+        ? await orderRepo.list({ pg: { excludeStatuses: [ORDER_STATUS.CANCELLED] } })
+            .then(rows => rows.filter(o => deferredOrderIds.includes(o._pgId || o.id)))
         : [];
-      const deferredOrderMap = {};
-      for (const o of deferredOrders) deferredOrderMap[o.id] = o;
 
-      for (const line of deferredLines) {
-        const stockId = line['Stock Item']?.[0];
+      const deferredOrderMap = {};
+      for (const o of deferredOrders) {
+        if (o._pgId) deferredOrderMap[o._pgId] = o;
+        deferredOrderMap[o.id] = o;
+      }
+
+      for (const line of rawDeferredLines) {
+        const stockId = line.stockItemId;
         if (!stockId) continue;
-        const orderId = line.Order?.[0];
-        const parentOrder = deferredOrderMap[orderId];
-        if (!parentOrder) continue; // order cancelled or not found
+        const parentOrder = deferredOrderMap[line.orderId];
+        if (!parentOrder) continue;
         const reqBy = parentOrder['Required By'] || null;
 
         if (!deferredDemand[stockId]) {
-          deferredDemand[stockId] = { name: line['Flower Name'] || '?', qty: 0, neededBy: null };
+          deferredDemand[stockId] = { name: line.flowerName || '?', qty: 0, neededBy: null };
         }
-        deferredDemand[stockId].qty += Number(line.Quantity || 0);
+        deferredDemand[stockId].qty += Number(line.quantity || 0);
         if (reqBy && (!deferredDemand[stockId].neededBy || reqBy < deferredDemand[stockId].neededBy)) {
           deferredDemand[stockId].neededBy = reqBy;
         }
       }
     }
 
-    // Compute needed-by dates for negative stock items
-    // For each negative item, find linked order lines → parent order → earliest Required By date
+    // Compute needed-by dates for negative stock items via PG order_lines
     let negativeStock = [];
     if (negativeStockItems.length > 0) {
-      // Collect all order line IDs from negative stock items
-      const negLineIds = negativeStockItems.flatMap(s => s['Order Lines'] || []);
-      const negLines = negLineIds.length > 0
-        ? await db.list(TABLES.ORDER_LINES, {
-            filterByFormula: `OR(${negLineIds.slice(0, 100).map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-            fields: ['Order'],
-            maxRecords: 200,
-          }).catch(() => [])
+      const negPgIds = negativeStockItems.map(s => s._pgId).filter(Boolean);
+
+      const negLines = negPgIds.length > 0
+        ? await pgDb.select({
+            orderId:     orderLinesTable.orderId,
+            stockItemId: orderLinesTable.stockItemId,
+          }).from(orderLinesTable)
+            .where(and(inArray(orderLinesTable.stockItemId, negPgIds), isNull(orderLinesTable.deletedAt)))
         : [];
 
-      // Get unique parent order IDs
-      const parentOrderIds = [...new Set(negLines.flatMap(l => l.Order || []))];
-      const parentOrders = parentOrderIds.length > 0
-        ? await db.list(TABLES.ORDERS, {
-            filterByFormula: `AND(OR(${parentOrderIds.slice(0, 50).map(id => `RECORD_ID() = "${id}"`).join(',')}), {Status} != '${ORDER_STATUS.CANCELLED}')`,
-            fields: ['Required By', 'Order Lines'],
-          }).catch(() => [])
+      const negOrderIds = [...new Set(negLines.map(l => l.orderId).filter(Boolean))];
+      const negOrders = negOrderIds.length > 0
+        ? await orderRepo.list({ pg: { excludeStatuses: [ORDER_STATUS.CANCELLED] } })
+            .then(rows => rows.filter(o => negOrderIds.includes(o._pgId || o.id)))
         : [];
+      const negOrderMap = {};
+      for (const o of negOrders) {
+        if (o._pgId) negOrderMap[o._pgId] = o;
+        negOrderMap[o.id] = o;
+      }
 
-      // Build map: stockId → earliest neededBy
       const neededByMap = {};
-      for (const order of parentOrders) {
-        const reqBy = order['Required By'];
-        if (!reqBy) continue;
-        const orderLineIds = new Set(order['Order Lines'] || []);
-        for (const si of negativeStockItems) {
-          const siLineIds = si['Order Lines'] || [];
-          if (siLineIds.some(lid => orderLineIds.has(lid))) {
-            if (!neededByMap[si.id] || reqBy < neededByMap[si.id]) {
-              neededByMap[si.id] = reqBy;
-            }
-          }
+      for (const nl of negLines) {
+        const order = negOrderMap[nl.orderId];
+        if (!order?.['Required By']) continue;
+        if (!neededByMap[nl.stockItemId] || order['Required By'] < neededByMap[nl.stockItemId]) {
+          neededByMap[nl.stockItemId] = order['Required By'];
         }
       }
 
-      // Group negative stock by Purchase Name (flower type) so batches merge into one demand line.
-      // Like aggregating material demand across warehouse bins in MRP.
       const groupMap = new Map();
       for (const s of negativeStockItems) {
         const groupKey = s['Purchase Name'] || s['Display Name'];
         if (!groupMap.has(groupKey)) {
           groupMap.set(groupKey, {
-            id: s.id,          // primary batch ID (for PO linking)
-            batchIds: [],      // all batch IDs in this group
-            name: groupKey,    // clean flower type name (no date suffix)
+            id: s.id,
+            batchIds: [],
+            name: groupKey,
             qty: 0,
             neededBy: null,
             supplier: s.Supplier || null,
           });
         }
         const group = groupMap.get(groupKey);
-        group.qty += s['Current Quantity'];
+        group.qty += Number(s['Current Quantity'] || 0);
         group.batchIds.push(s.id);
-        const nb = neededByMap[s.id];
+        const nb = neededByMap[s._pgId];
         if (nb && (!group.neededBy || nb < group.neededBy)) group.neededBy = nb;
         if (!group.supplier && s.Supplier) group.supplier = s.Supplier;
       }

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -506,7 +506,7 @@ router.get('/:id/usage', async (req, res, next) => {
     const orderCutoff = new Date(Date.now() - 365 * 86400000).toISOString().split('T')[0];
     const recentOrders = await orderRepo.list({
       pg: { dateFrom: orderCutoff },
-    }).catch(() => []);
+    }).catch(err => { console.error('[STOCK] usage orderRepo.list failed:', err.message); return []; });
 
     // Filter _lines to those whose Stock Item resolves to one of our siblings
     const matchedLines = [];
@@ -873,7 +873,7 @@ router.get('/reconciliation', async (req, res, next) => {
     //    original so the owner knows which orders need swapping.
     const activeOrders = await orderRepo.list({
       pg: { excludeStatuses: [ORDER_STATUS.DELIVERED, ORDER_STATUS.PICKED_UP, ORDER_STATUS.CANCELLED] },
-    }).catch(() => []);
+    }).catch(err => { console.error('[STOCK] substitute-swap orderRepo.list failed:', err.message); return []; });
 
     const custIds = [...new Set(activeOrders.flatMap(o => o.Customer || []))];
     const custs = custIds.length > 0 ? await customerRepo.findMany(custIds) : [];

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -871,27 +871,20 @@ router.get('/reconciliation', async (req, res, next) => {
 
     // 3. Non-terminal orders + lines — find which lines still reference an
     //    original so the owner knows which orders need swapping.
-    const orders = await db.list(TABLES.ORDERS, {
-      filterByFormula: `AND({Status} != '${ORDER_STATUS.DELIVERED}', {Status} != '${ORDER_STATUS.PICKED_UP}', {Status} != '${ORDER_STATUS.CANCELLED}')`,
-      fields: ['Order Lines', 'Customer', 'Required By', 'App Order ID', 'Status'],
-      maxRecords: 1000,
-    });
-    const allLineIds = orders.flatMap(o => o['Order Lines'] || []);
-    const allLines = allLineIds.length > 0
-      ? await listByIds(TABLES.ORDER_LINES, allLineIds, {
-          fields: ['Order', 'Stock Item', 'Quantity', 'Flower Name'],
-        })
-      : [];
+    const activeOrders = await orderRepo.list({
+      pg: { excludeStatuses: [ORDER_STATUS.DELIVERED, ORDER_STATUS.PICKED_UP, ORDER_STATUS.CANCELLED] },
+    }).catch(() => []);
 
-    const custIds = [...new Set(orders.flatMap(o => o.Customer || []))];
-    const custs = custIds.length > 0
-      ? await listByIds(TABLES.CUSTOMERS, custIds, { fields: ['Name', 'Nickname'] })
-      : [];
+    const custIds = [...new Set(activeOrders.flatMap(o => o.Customer || []))];
+    const custs = custIds.length > 0 ? await customerRepo.findMany(custIds) : [];
     const custMap = {};
-    for (const c of custs) custMap[c.id] = c;
+    for (const c of custs) {
+      custMap[c.id] = c;
+      if (c.airtableId) custMap[c.airtableId] = c;
+    }
 
     const orderMap = {};
-    for (const o of orders) {
+    for (const o of activeOrders) {
       const cid = o.Customer?.[0];
       orderMap[o.id] = {
         appOrderId: o['App Order ID'] || '',
@@ -905,25 +898,26 @@ router.get('/reconciliation', async (req, res, next) => {
     // swapped or zeroed out — no work left).
     const linesByOriginal = {};
     const originalIdSet = new Set(originalIds);
-    for (const line of allLines) {
-      const stockId = line['Stock Item']?.[0];
-      if (!stockId || !originalIdSet.has(stockId)) continue;
-      const qty = Number(line.Quantity || 0);
-      if (qty <= 0) continue;
-      const oid = line.Order?.[0];
-      const oi = oid ? orderMap[oid] : null;
-      if (!oi) continue;
-      if (!linesByOriginal[stockId]) linesByOriginal[stockId] = [];
-      linesByOriginal[stockId].push({
-        lineId: line.id,
-        orderId: oid,
-        appOrderId: oi.appOrderId,
-        customerName: oi.customerName,
-        requiredBy: oi.requiredBy,
-        orderStatus: oi.status,
-        quantity: qty,
-        suggestedSwapQty: qty,
-      });
+    for (const order of activeOrders) {
+      for (const line of (order._lines || [])) {
+        const stockId = line['Stock Item']?.[0];
+        if (!stockId || !originalIdSet.has(stockId)) continue;
+        const qty = Number(line.Quantity || 0);
+        if (qty <= 0) continue;
+        const oi = orderMap[order.id];
+        if (!oi) continue;
+        if (!linesByOriginal[stockId]) linesByOriginal[stockId] = [];
+        linesByOriginal[stockId].push({
+          lineId: line.id,
+          orderId: order.id,
+          appOrderId: oi.appOrderId,
+          customerName: oi.customerName,
+          requiredBy: oi.requiredBy,
+          orderStatus: oi.status,
+          quantity: qty,
+          suggestedSwapQty: qty,
+        });
+      }
     }
 
     // 4. Build response: only include originals that still have affected lines.

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -2,6 +2,8 @@ import { Router } from 'express';
 import { authorize } from '../middleware/auth.js';
 import * as db from '../services/airtable.js';
 import * as stockRepo from '../repos/stockRepo.js';
+import * as orderRepo from '../repos/orderRepo.js';
+import * as customerRepo from '../repos/customerRepo.js';
 import * as stockLossRepo from '../repos/stockLossRepo.js';
 import { TABLES } from '../config/airtable.js';
 import { sanitizeFormulaValue } from '../utils/sanitize.js';
@@ -171,55 +173,39 @@ router.get('/premade-committed', async (req, res, next) => {
 router.get('/committed', async (req, res, next) => {
   try {
     const today = new Date().toISOString().split('T')[0];
-    const orders = await db.list(TABLES.ORDERS, {
-      filterByFormula: `AND({Status} != '${ORDER_STATUS.DELIVERED}', {Status} != '${ORDER_STATUS.PICKED_UP}', {Status} != '${ORDER_STATUS.CANCELLED}', IS_AFTER({Required By}, '${today}'))`,
-      fields: ['Order Lines', 'Customer', 'Required By', 'App Order ID', 'Status'],
-      maxRecords: 500,
+
+    const activeOrders = await orderRepo.list({
+      pg: {
+        excludeStatuses: [ORDER_STATUS.DELIVERED, ORDER_STATUS.PICKED_UP, ORDER_STATUS.CANCELLED],
+        requiredByFrom: today,
+      },
     });
 
-    const allLineIds = orders.flatMap(o => o['Order Lines'] || []);
-    const allLines = await listByIds(TABLES.ORDER_LINES, allLineIds, {
-      fields: ['Order', 'Stock Item', 'Quantity', 'Flower Name'],
-      maxRecords: 2000,
-    });
-
-    const uniqueCustomerIds = [...new Set(orders.flatMap(o => o.Customer || []))];
-    const allCustomers = await listByIds(TABLES.CUSTOMERS, uniqueCustomerIds, {
-      fields: ['Name', 'Nickname'],
-    });
+    const uniqueCustomerIds = [...new Set(activeOrders.flatMap(o => o.Customer || []))];
+    const allCustomers = uniqueCustomerIds.length > 0 ? await customerRepo.findMany(uniqueCustomerIds) : [];
     const customerMap = {};
-    for (const c of allCustomers) customerMap[c.id] = c;
-
-    const orderMap = {};
-    for (const o of orders) {
-      const custId = o.Customer?.[0];
-      orderMap[o.id] = {
-        appOrderId: o['App Order ID'] || '',
-        customerName: customerMap[custId]?.Name || customerMap[custId]?.Nickname || '',
-        requiredBy: o['Required By'] || null,
-        status: o.Status || 'New',
-      };
+    for (const c of allCustomers) {
+      customerMap[c.id] = c;
+      if (c.airtableId) customerMap[c.airtableId] = c;
     }
 
     const committed = {};
-    for (const line of allLines) {
-      const stockId = line['Stock Item']?.[0];
-      if (!stockId) continue;
-      const qty = Number(line.Quantity || 0);
-      if (qty <= 0) continue;
-
-      if (!committed[stockId]) committed[stockId] = { committed: 0, orders: [] };
-      committed[stockId].committed += qty;
-
-      const orderId = line.Order?.[0];
-      const orderInfo = orderId ? orderMap[orderId] : null;
-      if (orderInfo) {
+    for (const order of activeOrders) {
+      const custId = order.Customer?.[0];
+      const customerName = customerMap[custId]?.Name || customerMap[custId]?.Nickname || '';
+      for (const line of (order._lines || [])) {
+        const stockId = line['Stock Item']?.[0];
+        if (!stockId) continue;
+        const qty = Number(line.Quantity || 0);
+        if (qty <= 0) continue;
+        if (!committed[stockId]) committed[stockId] = { committed: 0, orders: [] };
+        committed[stockId].committed += qty;
         committed[stockId].orders.push({
-          orderId,
-          appOrderId: orderInfo.appOrderId,
-          customerName: orderInfo.customerName,
-          requiredBy: orderInfo.requiredBy,
-          status: orderInfo.status,
+          orderId: order.id,
+          appOrderId: order['App Order ID'] || '',
+          customerName,
+          requiredBy: order['Required By'] || null,
+          status: order.Status || 'New',
           qty,
         });
       }

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -504,43 +504,35 @@ router.get('/:id/usage', async (req, res, next) => {
     // a larger result set. For a small shop (<2000 orders/year) both queries
     // return in well under a second via the rate-limited queue.
     const orderCutoff = new Date(Date.now() - 365 * 86400000).toISOString().split('T')[0];
-    const recentOrders = await db.list(TABLES.ORDERS, {
-      filterByFormula: `OR({Order Date} = '', NOT(IS_BEFORE({Order Date}, '${orderCutoff}')))`,
-      fields: ['Order Lines', 'App Order ID', 'Customer', 'Status', 'Required By', 'Order Date'],
-      maxRecords: 2000,
-    });
-    const allLineIds = recentOrders.flatMap(o => o['Order Lines'] || []);
-    const allLines = allLineIds.length > 0
-      ? await listByIds(TABLES.ORDER_LINES, allLineIds, {
-          fields: ['Order', 'Flower Name', 'Quantity', 'Sell Price Per Unit', 'Cost Price Per Unit', 'Stock Item'],
-        })
-      : [];
-    // Keep only lines whose Stock Item link resolves to one of our siblings.
-    // Orphan lines (no link) don't affect qty (atomicStockAdjust needs a
-    // stock ID), so dropping them is harmless.
-    const matchedLines = allLines.filter(l => siblingIds.has(l['Stock Item']?.[0]));
+    const recentOrders = await orderRepo.list({
+      pg: { dateFrom: orderCutoff },
+    }).catch(() => []);
 
-    // Build the order map from the orders we already fetched — no second
-    // round-trip needed.
+    // Filter _lines to those whose Stock Item resolves to one of our siblings
+    const matchedLines = [];
     const orderMap = {};
-    for (const o of recentOrders) orderMap[o.id] = o;
+    for (const o of recentOrders) {
+      orderMap[o.id] = o;
+      for (const line of (o._lines || [])) {
+        if (siblingIds.has(line['Stock Item']?.[0])) {
+          matchedLines.push({ ...line, _orderId: o.id });
+        }
+      }
+    }
 
-    // Fetch only the customers whose orders actually matched this stock —
-    // otherwise we'd pull every customer from the past year.
-    const matchedOrderIds = new Set(matchedLines.flatMap(l => l.Order || []));
+    const matchedOrderIds = new Set(matchedLines.map(l => l._orderId));
     const customerIds = [...new Set(
-      recentOrders
-        .filter(o => matchedOrderIds.has(o.id))
-        .flatMap(o => o.Customer || [])
+      recentOrders.filter(o => matchedOrderIds.has(o.id)).flatMap(o => o.Customer || [])
     )];
-    const customers = customerIds.length > 0
-      ? await listByIds(TABLES.CUSTOMERS, customerIds, { fields: ['Name', 'Nickname'] })
-      : [];
+    const custList = customerIds.length > 0 ? await customerRepo.findMany(customerIds) : [];
     const customerMap = {};
-    for (const c of customers) customerMap[c.id] = c;
+    for (const c of custList) {
+      customerMap[c.id] = c;
+      if (c.airtableId) customerMap[c.airtableId] = c;
+    }
 
     const usageOrders = matchedLines.map(l => {
-      const orderId = l.Order?.[0];
+      const orderId = l._orderId;
       const o = orderId ? orderMap[orderId] : null;
       const custId = o?.Customer?.[0];
       const cust = custId ? customerMap[custId] : null;


### PR DESCRIPTION
## Summary

Orders, order lines, deliveries, and customers have been in Postgres since the Phase 4/5 cutover (2026-05-02). Three routes were still reading from the frozen Airtable snapshot, making 5+ weeks of data invisible.

- **#228 `analytics.js`** — revenue, KPIs, top products, supplier scorecard, customer segments all now read from `orderRepo` + `customerRepo` + `stockPurchasesRepo`. `orderRepo.list()` returns `_lines` and `_delivery` embedded — the entire batch-fetch chain is gone.
- **#227 `dashboard.js`** — all 9 parallel queries + enrichment + deferred-lines + negative-stock order lines replaced. Deferred lines use direct Drizzle (`stockDeferred = true`). Negative stock order lines use `inArray(stockItemId, negPgIds)`.
- **#229 `stock.js`** — `/committed`, `/usage`, and substitute-swap all replaced. `/committed` uses `requiredByFrom: today` (correct — only future demand is informational).

Two small repo additions: `stockPurchasesRepo.list({ from, to })` and `customerRepo.listWithKeyPeopleHavingDates()`.

**One bug found and fixed by the quality reviewer:** deferred demand merge was keying `batchIds` with `s.id` (airtableId for backfilled items) while `deferredDemand` was keyed by PG UUID. Fixed to `s._pgId || s.id`.

## Verification

- ✅ 310/310 backend unit + integration tests
- ✅ 186/186 E2E assertions (24 sections)
- Final Opus review: approved

## What's still on Airtable (out of scope)

`stock.js` still reads `STOCK_ORDERS`, `STOCK_ORDER_LINES`, `PREMADE_BOUQUETS` — separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)