### PR TITLE
fix(stock): resolve phantom rec IDs in premade-committed

### DIFF
--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -136,7 +136,9 @@ router.get('/premade-committed', async (req, res, next) => {
     const bouquetMap = {};
     for (const b of bouquets) bouquetMap[b.id] = b;
 
-    const committed = {};
+    // Keyed by whatever Stock Item ID Airtable stored (may be a phantom rec
+    // ID if the premade was created against a post-cutover UUID stock item).
+    const rawCommitted = {};
     for (const line of allLines) {
       const stockId = line['Stock Item']?.[0];
       if (!stockId) continue;
@@ -145,14 +147,29 @@ router.get('/premade-committed', async (req, res, next) => {
       const bouquetId = line['Premade Bouquets']?.[0];
       const bouquet = bouquetId ? bouquetMap[bouquetId] : null;
       if (!bouquet) continue;
-      if (!committed[stockId]) committed[stockId] = { qty: 0, bouquets: [] };
-      committed[stockId].qty += qty;
-      committed[stockId].bouquets.push({
-        bouquetId,
-        name: bouquet.Name || '?',
-        qty,
-      });
+      if (!rawCommitted[stockId]) rawCommitted[stockId] = { qty: 0, bouquets: [], _flowerName: line['Flower Name'] || '' };
+      rawCommitted[stockId].qty += qty;
+      rawCommitted[stockId].bouquets.push({ bouquetId, name: bouquet.Name || '?', qty });
     }
+
+    // Resolve each Airtable stock ID to the PG stock ID the frontend uses.
+    // Post-cutover stock items have UUID ids; premade lines created against them
+    // store phantom rec IDs in Airtable (Airtable can't store UUIDs in linked
+    // fields). For those, fall back to matching by flower name.
+    const allStock = await stockRepo.list({ pg: { includeInactive: true, includeEmpty: true } });
+    const stockById  = new Map(allStock.map(s => [s.id, s]));
+    const stockByName = new Map(allStock.map(s => [(s['Display Name'] || '').toLowerCase(), s]));
+
+    const committed = {};
+    for (const [atId, entry] of Object.entries(rawCommitted)) {
+      const { _flowerName, ...data } = entry;
+      let pgId = stockById.has(atId) ? atId : stockByName.get((_flowerName || '').toLowerCase())?.id;
+      if (!pgId) continue; // can't resolve — omit rather than pollute the map
+      if (!committed[pgId]) committed[pgId] = { qty: 0, bouquets: [] };
+      committed[pgId].qty += data.qty;
+      committed[pgId].bouquets.push(...data.bouquets);
+    }
+
     res.json(committed);
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary
- `GET /stock/premade-committed` was returning Airtable phantom `rec*` IDs as keys for stock items that were created after the stock cutover (UUID-only, no Airtable ID)
- Root cause: Airtable's linked record fields cannot store UUIDs — when a premade bouquet line was created with a UUID stock item ID, Airtable silently linked to a phantom record
- Resulted in 3 out of 4 stock items in Mix S 1/S 2 showing no "+N in premades" badge — the committed map had the right data but under unresolvable keys
- Fix: after building the raw map, resolve each key to the PG stock ID (direct lookup first; name fallback for phantom IDs)

## Root cause trace
- Mix S 1: Hydrangea Pink (6.May.) / Antirrhinum Yellow (6.May.) — post-cutover UUIDs, phantom rec IDs in Airtable
- Mix S 2: Coral Peony (6.May.) — same issue
- Only Peony Pink (30.Apr.) worked because it was a backfilled item with a real `airtable_id`

## Test plan
- [ ] All 4 flowers in Mix S 1/S 2 show "+N in premades" badge on stock screen
- [ ] Quantities correct: Hydrangea Pink +1, Peony Pink +5, Antirrhinum Yellow +3, Coral Peony +9
- [ ] No regression for stock items that already worked (backfilled rec IDs)

Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)