### PR TITLE
fix(stock): apply JS sibling filter in usage trace for PG mode

### DIFF
--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -487,12 +487,15 @@ router.get('/:id/usage', async (req, res, next) => {
     // "<base> (dd.Mmm.)" dated batches.
     let siblingStocks = [];
     try {
-      siblingStocks = await stockRepo.list({
+      const allForName = await stockRepo.list({
         filterByFormula: `OR({Display Name} = '${safeBase}', FIND('${safeBase} (', {Display Name} & '') = 1)`,
         fields: ['Display Name', 'Current Quantity'],
-        // PG-mode: no formula equivalent — caller filters on returned rows.
-        // Return all active stock for the base name; JS filter below handles the variant match.
         pg: { active: true, includeEmpty: true },
+      });
+      // PG mode returns all active stock (no formula support) — filter JS-side.
+      siblingStocks = allForName.filter(s => {
+        const n = s['Display Name'] || '';
+        return n === baseName || n.startsWith(baseName + ' (');
       });
     } catch {
       siblingStocks = [stockItem];


### PR DESCRIPTION
## Summary
- `GET /stock/:id/usage` was showing wrong orders in the trace — e.g. "Peony Pink" trace showing all 3 lines of order 202605-026 (Влад Штак) even though that order used Paeonia sarah bernhardt / Oxypetalum / Hydrangea, not Peony Pink
- Root cause: `stockRepo.list()` in postgres mode ignores `filterByFormula` and returns all ~128 active stock items; the JS filter that was supposed to narrow results to name-matching siblings was never implemented — so `siblingIds` contained every stock ID and every order line matched
- Fix: filter returned items JS-side: `displayName === baseName || displayName.startsWith(baseName + ' (')`

## Test plan
- [ ] Peony Pink trace shows only orders that actually used Peony Pink or Peony Pink (30.Apr.)
- [ ] No phantom orders from other flowers appear
- [ ] The -21 quantity on Peony Pink now makes sense from the trace entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)