### PR TITLE
Phase 7 PR 1: Stock Orders + Premade Bouquets to Postgres

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -40,6 +40,7 @@ Reports row counts in PG + audit activity. parity_log is no longer fed (shadow m
 
 **Standing investigations (have shadow data now to debug with):**
 - "Stock not deducted via bouquet edit" bug from memory — once shadow has a few days of data, query `audit_log` for stock updates triggered by bouquet edits and cross-reference with the suspicious orders. Far easier to diagnose now.
+- **PO evaluate write-off retry idempotency** — `stock_loss_log` rows duplicate when an evaluate retries after partial failure. ADR-0003 marker idempotency was extended to receives (`stock_purchases`) only. Fix: add a `lossMarker` column or `lossMarkerExists` analog to `stockLossRepo`, gate write-off logging in `stockOrders.js` evaluate the same way receives are gated. Captured by `it.todo` in `backend/src/__tests__/stockOrderRepo.integration.test.js`. Surfaced by Phase 7 T9 Opus review (2026-05-08).
 
 **Stale local branches to clean up** (low priority):
 - `feat/sql-migration-phase-1` (PR #156 merged via squash — local branch obsolete)

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -13,9 +13,10 @@ If a future Claude session is opening this repo cold, here's the live state and 
 - Phase 4 (Orders) **CUT OVER 2026-05-02**. `ORDER_BACKEND=postgres` live on prod. Airtable Orders / Order Lines / Deliveries = frozen legacy snapshots. Order shadow window was skipped — backfill + harness Wix replay + spot-check served as the verification gate (see `docs/superpowers/plans/2026-05-02-phase-3-4-cutover.md`).
 - Phase 5 (Customers) **CUT OVER 2026-05-06**. `customers`, `key_people`, `legacy_orders` tables live. 1110 customers + 1524 legacy orders backfilled. Direct cutover, no shadow window.
 - Phase 6 (Config + log tables) **CUT OVER 2026-05-07**. app_config, florist_hours, marketing_spend, stock_loss_log, webhook_log, sync_log, product_config now on Postgres.
+- Phase 7 PR 1 (Stock Orders + Premade Bouquets) **CUT OVER 2026-05-08**. `stock_orders`, `stock_order_lines`, `premade_bouquets`, `premade_bouquet_lines` tables live. All `stockOrders.js` + `premadeBouquetService.js` routes on Postgres. 5 live Airtable bypasses fixed in `stock.js` (`/velocity`, `/pending-po`, `/:id/usage`, PATCH `/:id` premade cascade, `/meta/lookups`). New ADR-0003 PO marker format (human-readable PO number). Backfill: `backend/scripts/backfill-phase7.js`. Plan: `docs/superpowers/plans/2026-05-08-phase7-stock-orders-premade.md`.
 - **STOCK_PURCHASES** writes now go to Postgres via `stockPurchasesRepo` (PR #256, 2026-05-07). PO retry idempotency reads also from PG.
-- **Read-path bypasses fixed 2026-05-08** (PR #258): dashboard.js, analytics.js, stock.js committed/usage/substitute-swap all read from `orderRepo`/`customerRepo`/`stockPurchasesRepo`. Remaining Airtable reads: STOCK_ORDERS, STOCK_ORDER_LINES, PREMADE_BOUQUETS (Phase 7 scope).
-- Remaining Airtable tables not yet migrated: STOCK_ORDERS, STOCK_ORDER_LINES, PREMADE_BOUQUETS, PREMADE_BOUQUET_LINES.
+- **Read-path bypasses fixed 2026-05-08** (PR #258): dashboard.js, analytics.js, stock.js committed/usage/substitute-swap all read from `orderRepo`/`customerRepo`/`stockPurchasesRepo`. Remaining Phase 7 bypasses cleaned up in PR 1 (this commit).
+- After Phase 7 PR 1, **no production code path reads from or writes to Airtable.** Remaining `airtable.js` / `airtableSchema.js` / `config/airtable.js` / `airtable` npm dep / `STOCK_BACKEND`+`ORDER_BACKEND` flag logic = Phase 7 PR 2 scope.
 
 **Health check after cutover** (~30 sec):
 ```bash
@@ -36,7 +37,7 @@ Reports row counts in PG + audit activity. parity_log is no longer fed (shadow m
 7. **`scripts/simulate-orders.js`** — owner-runnable day-in-the-life. Integration tests already cover the same scenarios; this is convenience.
 8. **Phase 5 prep — Customers** (after Phase 4 cutover proves stable) — design doc, schema (with FK to existing customer_id text columns), customerRepo skeleton, dedup tooling for Universe A (legacy) + B (app).
 9. ~~**Phase 6 — Config + log tables**~~ — DONE 2026-05-07. App Config, Florist Hours, Marketing Spend, Stock Loss Log, Webhook Log, Sync Log, Product Config migrated to Postgres. Direct cutover, no shadow window. Backfill: `backend/scripts/backfill-phase6.js`.
-10. **Phase 7 — Retire Airtable** — delete services/airtable.js, services/airtableSchema.js, config/airtable.js. Cancel subscription. Final snapshot.
+10. **Phase 7 PR 2 — Retire Airtable** (IN PROGRESS, separate PR) — delete `backend/src/services/airtable.js`, `airtable-real.js`, `airtable-mock.js`, `airtable-mock-formula.js`, `airtableSchema.js`, `config/airtable.js`. Drop `airtable` npm dependency. Strip `STOCK_BACKEND` / `ORDER_BACKEND` env flag logic + boot guard from `index.js` / `orderRepo.js` / `stockRepo.js` (PG-only after PR 1). Remove `tblMockStock*` etc. fixture data still needed only by airtable-mock. Final Airtable snapshot. Cancel subscription. Phase 7 PR 1 (this) lays the groundwork: no production code reads from or writes to Airtable anymore.
 
 **Standing investigations (have shadow data now to debug with):**
 - "Stock not deducted via bouquet edit" bug from memory — once shadow has a few days of data, query `audit_log` for stock updates triggered by bouquet edits and cross-reference with the suspicious orders. Far easier to diagnose now.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ Review this entire file before flipping to production.
 
 ---
 
+## Phase 7 PR 1 — Stock Orders + Premade Bouquets on Postgres (2026-05-08)
+
+Migrates the last two domains writing to Airtable. After this PR, **no production code path reads from or writes to Airtable.** PR 2 (separate plan) will delete the airtable.js / airtableSchema.js / config / npm dep / dead env-flag logic.
+
+### Schema (migration 0011)
+- New tables: `stock_orders`, `stock_order_lines`, `premade_bouquets`, `premade_bouquet_lines` with FK + CASCADE
+- `substitute_*` columns on `stock_order_lines` (CONTEXT.md domain term; API surface keeps "Alt *" for frontend compat)
+- Partial unique indexes: `airtable_id IS NOT NULL`, `po_number <> ''`. Indexes on status / created_date / driver / po_id / bouquet_id / stock_id
+
+### Code migration
+- `backend/src/repos/stockOrderRepo.js` (new): header + line CRUD with dual-lookup (recXXX or uuid). `nextPoSequence(date)` returns `MAX(N)+1` of existing `PO-YYYYMMDD-N` values (was COUNT — would corrupt under backfill)
+- `backend/src/repos/premadeBouquetRepo.js` (new): bouquet + line CRUD; `getLinesByStockId` for /stock PATCH cascade and orderService premade price-sync
+- `backend/src/routes/stockOrders.js` (~1000 LOC fully migrated): all `db.*` calls routed through `stockOrderRepo` / `stockRepo` / `stockPurchasesRepo`
+- `backend/src/services/premadeBouquetService.js` (rewritten): full migration to `premadeBouquetRepo`
+- `backend/src/routes/stock.js` 5 live bypasses fixed: `/velocity` (was reading frozen ORDERS), `/pending-po`, `/:id/usage` (purchase trail + premade trail), PATCH `/:id` premade price-sync, `/meta/lookups`
+- `backend/src/services/orderService.js`: extracted `findOrdersNeedingSubstitution(substitutionsMade)` from the evaluate endpoint (it was reading frozen Airtable since 2026-05-02). Fixed premade price-sync in `createOrder` (same root cause)
+
+### Operational
+- New PO marker format embeds human-readable PO number: `PO #PO-20260508-1 L#<uuid> primary` (see ADR-0003). Old `recXXX` markers in historical `stock_purchases.notes` rows degrade gracefully (regex matches both formats; lookup falls back to empty `poDisplayId` after Airtable retirement)
+- Backfill script: `backend/scripts/backfill-phase7.js` (DESTRUCTIVE, idempotent ON CONFLICT DO UPDATE on `airtable_id`). Captures all POs (Draft/Sent/Shopping/Reviewing/Evaluating/Complete) + premade bouquets. Pre-populates poIdMap + bouquetIdMap from existing PG rows so re-runs resolve line links after no-op upserts. Logs orphan-line counts.
+- E2E harness: PO + premade fixtures migrated from `airtable-test-base.json` mock to `backend/src/__tests__/helpers/phase7-seed.js` (pglite SQL seed). `/test/state` now exposes `pg.stockOrders[]` / `pg.premadeBouquets[]` for boot-invariant checks
+- `airtableSchema.js` write-field validation entries for STOCK_ORDERS/STOCK_ORDER_LINES/PREMADE tables removed (frozen, never written)
+- Carry-over: write-off retry idempotency gap on PO evaluate captured by `it.todo` in `stockOrderRepo.integration.test.js`. Pre-existing — predates Phase 7. Standing investigation entry added to BACKLOG; fix sketch is "extend ADR-0003 marker pattern to write-offs".
+
+### Verification
+- Backend Vitest: 343 passed + 1 todo (write-off retry capture)
+- Shared Vitest: 130 passed
+- Florist + Dashboard + Delivery vite builds: GREEN
+- E2E: 186 passed, 0 failed (24 sections + Phase 5 customer CRUD)
+
+### Out of scope (PR 2)
+- Delete `airtable.js`, `airtable-real.js`, `airtable-mock.js`, `airtable-mock-formula.js`, `airtableSchema.js`, `config/airtable.js`
+- Drop `airtable` npm dependency
+- Remove `STOCK_BACKEND` / `ORDER_BACKEND` env flag logic + boot guard
+- Cancel Airtable subscription, take final snapshot
+
+### Plan + ADR
+- `docs/superpowers/plans/2026-05-08-phase7-stock-orders-premade.md`
+- `docs/adr/0003-po-marker-format-dual-format.md`
+- `docs/adr/0002-demand-entry-aggregate-model.md` corrected (in-place text was inaccurate; receiveIntoStock creates a new Batch and zeroes the Demand Entry)
+
+---
+
 ## Postgres read-path cleanup — dashboard, analytics, stock (2026-05-08)
 
 Fixes GH #227, #228, #229. All Airtable reads for ORDERS/ORDER_LINES/DELIVERIES/CUSTOMERS in three routes replaced with `orderRepo`/`customerRepo`/`stockPurchasesRepo`. Post-cutover orders (since 2026-05-02) now visible in owner dashboard, analytics KPIs, and stock committed/usage views.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -25,10 +25,10 @@ scripts/           → Backfill, shadow-health, start-test-backend, etc.
 | customers.js | GET/POST/PATCH /customers, GET /customers/insights | CRM + RFM segmentation |
 | stock.js | GET/POST/PATCH /stock, GET /stock/velocity | Inventory + velocity forecasting. Delegates to stockRepo when STOCK_BACKEND ≠ airtable. |
 | deliveries.js | GET/PATCH /deliveries | Driver assignments + status cascade to orders |
-| stockOrders.js | Full CRUD /stock-orders | PO lifecycle: create, send, shop, review, evaluate |
+| stockOrders.js | Full CRUD /stock-orders | PO lifecycle: create, send, shop, review, evaluate. **Postgres** via `stockOrderRepo` (Phase 7). New PO markers embed human-readable PO number (ADR-0003). |
 | stockPurchases.js | POST /stock-purchases | Record supplier deliveries with batch tracking. Routes STOCK reads/writes through stockRepo; purchase records through stockPurchasesRepo. |
 | stockLoss.js | GET/POST /stock-loss | Waste logging by reason |
-| premadeBouquets.js | CRUD /premade-bouquets | Premade bouquet templates (composed of stock items) |
+| premadeBouquets.js | CRUD /premade-bouquets | Premade bouquet templates (composed of stock items). Service uses `premadeBouquetRepo` (Postgres, Phase 7). |
 | dashboard.js | GET /dashboard | Today's operational summary for owner |
 | analytics.js | GET /analytics | Financial KPIs with period comparison |
 | settings.js | GET/POST /settings | Thin HTTP layer for app config. State lives in `services/configService.js`. Re-exports its getters for backward compat — callers should migrate to importing from configService directly. |
@@ -54,7 +54,7 @@ scripts/           → Backfill, shadow-health, start-test-backend, etc.
 | __fixtures__/ | Seed data + sample records for the mock (used by harness + integration tests). |
 | airtableSchema.js | Startup validation — checks all expected fields exist in live Airtable base. Skipped under `TEST_BACKEND=mock-airtable`. |
 | orderService.js | Order state machine, auto-match stock, create with rollback, cancel with stock return, edit bouquet lines. Delegates to `orderRepo` when ORDER_BACKEND ≠ airtable. |
-| premadeBouquetService.js | Dissolve premade bouquets into constituent stock-item lines on order creation. |
+| premadeBouquetService.js | Dissolve premade bouquets into constituent stock-item lines on order creation. Persistence via `premadeBouquetRepo` (Postgres, Phase 7). |
 | notifications.js | SSE broadcast to all connected clients (heartbeat every 30s). No catch-up buffer yet — clients miss events while disconnected. |
 | wix.js | Wix webhook processor — parses payload, creates order + lines + delivery. |
 | wixProductSync.js | Bidirectional Wix product pull/push with sync logging. `runPush` accepts `onProgress(entry)` and parallelizes Wix API calls per phase via `p-queue` (concurrency 8) so the full push lands in 10–20s. Pull mirrors Wix → Airtable for prices and descriptions (the 2026-04-22 lockout was specific to the legacy `runSync` flow, which the UI no longer calls). (1200+ L — split candidate.) |
@@ -66,13 +66,12 @@ scripts/           → Backfill, shadow-health, start-test-backend, etc.
 | configService.js | App config singleton — DEFAULTS, in-memory config state, loadConfig/saveConfig, migrations, driver-of-day daily state, cutoff reminder interval. Exports: `getConfig`, `updateConfig`, `generateOrderId`, `getDriverOfDay`, `isPastCutoff`, `getActiveSeasonalCategory`. Import from here, not from routes/settings.js. |
 | driverState.js | In-memory backup driver state (resets daily at midnight). |
 
-## Database (in transition — Phase 3+ SQL migration)
-Backend is mid-migration from Airtable to Postgres. Two flags control routing:
+## Database (Phases 3–7 complete, PR 2 cleanup pending)
+Backend has finished migrating from Airtable to Postgres. After Phase 7 PR 1 (2026-05-08), no production code path reads from or writes to Airtable. Phase 7 PR 2 will delete the now-dead infrastructure:
 
-- `STOCK_BACKEND` ∈ {airtable, shadow, postgres} (default airtable). Phase 3 — currently in shadow week on prod.
-- `ORDER_BACKEND` ∈ {airtable, shadow, postgres} (default airtable). Phase 4 — implementation merged but not flipped; read-path migration is the active blocker (see `BACKLOG.md`).
-
-Boot guard in `index.js` rejects mixed modes (e.g. `ORDER_BACKEND=postgres` with `STOCK_BACKEND=airtable`) — order/stock cross-domain transactions cannot span two stores.
+- Phase 3 (Stock), Phase 4 (Orders/Lines/Deliveries), Phase 5 (Customers/KeyPeople/LegacyOrders), Phase 6 (config + log tables), and Phase 7 PR 1 (StockOrders/Lines + Premade Bouquets/Lines) are all live on Postgres.
+- `STOCK_BACKEND` / `ORDER_BACKEND` env flags are dead code awaiting PR 2 removal — the only valid value at this point is `postgres`. Boot guard in `index.js` still validates them; will be deleted in PR 2.
+- New repos in Phase 7: `stockOrderRepo.js`, `premadeBouquetRepo.js` — same wire-format pattern as Phase 3+ repos, dual-lookup (recXXX or uuid) so in-flight callers from before the cutover keep working.
 
 Key paths:
 - `db/schema.js` — Drizzle table definitions (orders, order_lines, deliveries, stock, stock_movements, audit_log, parity_log, ...).

--- a/backend/scripts/backfill-phase7.js
+++ b/backend/scripts/backfill-phase7.js
@@ -44,11 +44,13 @@ async function backfillStockOrders() {
 
   // Map Airtable PO id → PG uuid. Pre-populate from existing PG rows so a
   // re-run can resolve line links even when the header upsert is a no-op.
+  // Also runs in dry mode so dry-run logs accurately show line resolution.
   const poIdMap = new Map();
-  if (!DRY && headers.length > 0) {
+  if (headers.length > 0) {
     const existing = await db.select({ id: stockOrders.id, airtableId: stockOrders.airtableId }).from(stockOrders);
     for (const r of existing) if (r.airtableId) poIdMap.set(r.airtableId, r.id);
   }
+  let orphanLineCount = 0;
 
   for (const h of headers) {
     const f = h.fields;
@@ -79,9 +81,9 @@ async function backfillStockOrders() {
   for (const l of lines) {
     const f = l.fields;
     const poAirtableId = Array.isArray(f['Stock Orders']) ? f['Stock Orders'][0] : null;
-    if (!poAirtableId) { console.warn(`[backfill] line ${l.id} has no PO link, skipping`); continue; }
+    if (!poAirtableId) { console.warn(`[backfill] line ${l.id} has no PO link, skipping`); orphanLineCount++; continue; }
     const poPgId = poIdMap.get(poAirtableId);
-    if (!poPgId) { console.warn(`[backfill] line ${l.id} references missing PO ${poAirtableId}, skipping`); continue; }
+    if (!poPgId) { console.warn(`[backfill] line ${l.id} references missing PO ${poAirtableId}, skipping`); orphanLineCount++; continue; }
 
     const stockAtId = Array.isArray(f['Stock Item']) ? f['Stock Item'][0] : null;
     const stockPgId = await findStockPgIdByAirtableId(stockAtId);
@@ -120,6 +122,9 @@ async function backfillStockOrders() {
         set: updateSet,
       });
   }
+  if (orphanLineCount > 0) {
+    console.log(`[backfill] Skipped ${orphanLineCount} orphan stock_order_lines (missing or unlinked parent PO).`);
+  }
   console.log(`[backfill] Stock Orders done.`);
 }
 
@@ -130,10 +135,11 @@ async function backfillPremadeBouquets() {
   console.log(`[backfill] ${headers.length} bouquets, ${lines.length} lines`);
 
   const bouquetIdMap = new Map();
-  if (!DRY && headers.length > 0) {
+  if (headers.length > 0) {
     const existing = await db.select({ id: premadeBouquets.id, airtableId: premadeBouquets.airtableId }).from(premadeBouquets);
     for (const r of existing) if (r.airtableId) bouquetIdMap.set(r.airtableId, r.id);
   }
+  let orphanPremadeLineCount = 0;
 
   for (const h of headers) {
     const f = h.fields;
@@ -159,9 +165,9 @@ async function backfillPremadeBouquets() {
   for (const l of lines) {
     const f = l.fields;
     const bouquetAtId = Array.isArray(f['Premade Bouquets']) ? f['Premade Bouquets'][0] : null;
-    if (!bouquetAtId) continue;
+    if (!bouquetAtId) { orphanPremadeLineCount++; continue; }
     const bouquetPgId = bouquetIdMap.get(bouquetAtId);
-    if (!bouquetPgId) { console.warn(`[backfill] premade line ${l.id} references missing bouquet`); continue; }
+    if (!bouquetPgId) { console.warn(`[backfill] premade line ${l.id} references missing bouquet`); orphanPremadeLineCount++; continue; }
 
     const stockAtId = Array.isArray(f['Stock Item']) ? f['Stock Item'][0] : null;
     const stockPgId = await findStockPgIdByAirtableId(stockAtId);
@@ -184,6 +190,9 @@ async function backfillPremadeBouquets() {
         target: premadeBouquetLines.airtableId,
         set: updateSet,
       });
+  }
+  if (orphanPremadeLineCount > 0) {
+    console.log(`[backfill] Skipped ${orphanPremadeLineCount} orphan premade_bouquet_lines (missing or unlinked parent bouquet).`);
   }
   console.log(`[backfill] Premade Bouquets done.`);
 }

--- a/backend/scripts/backfill-phase7.js
+++ b/backend/scripts/backfill-phase7.js
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+// CATEGORY: DESTRUCTIVE — writes to prod Postgres. Idempotent (ON CONFLICT DO UPDATE).
+//
+// Backfills stock_orders, stock_order_lines, premade_bouquets, premade_bouquet_lines
+// from the frozen Airtable snapshot. Run once before the Phase 7 deploy flips the
+// code to PG-only.
+//
+// Usage:
+//   AIRTABLE_API_KEY=... AIRTABLE_BASE_ID=... DATABASE_URL=... \
+//   node backend/scripts/backfill-phase7.js [--dry-run]
+//
+// Idempotency: runs UPSERT on airtable_id. Safe to re-run if it errors mid-way.
+
+import 'dotenv/config';
+import Airtable from 'airtable';
+import { db } from '../src/db/index.js';
+import { stockOrders, stockOrderLines, premadeBouquets, premadeBouquetLines, stock } from '../src/db/schema.js';
+import { eq, sql } from 'drizzle-orm';
+
+const DRY = process.argv.includes('--dry-run');
+const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY })
+  .base(process.env.AIRTABLE_BASE_ID);
+
+async function fetchAll(tableId) {
+  const out = [];
+  await base(tableId).select({ pageSize: 100 }).eachPage((records, next) => {
+    for (const r of records) out.push({ id: r.id, fields: r.fields });
+    next();
+  });
+  return out;
+}
+
+async function findStockPgIdByAirtableId(atId) {
+  if (!atId) return null;
+  const [row] = await db.select({ id: stock.id }).from(stock).where(eq(stock.airtableId, atId)).limit(1);
+  return row?.id || null;
+}
+
+async function backfillStockOrders() {
+  console.log('[backfill] Fetching Stock Orders from Airtable…');
+  const headers = await fetchAll(process.env.AIRTABLE_STOCK_ORDERS_TABLE);
+  const lines   = await fetchAll(process.env.AIRTABLE_STOCK_ORDER_LINES_TABLE);
+  console.log(`[backfill] ${headers.length} POs, ${lines.length} lines`);
+
+  // Map Airtable PO id → PG uuid. Pre-populate from existing PG rows so a
+  // re-run can resolve line links even when the header upsert is a no-op.
+  const poIdMap = new Map();
+  if (!DRY && headers.length > 0) {
+    const existing = await db.select({ id: stockOrders.id, airtableId: stockOrders.airtableId }).from(stockOrders);
+    for (const r of existing) if (r.airtableId) poIdMap.set(r.airtableId, r.id);
+  }
+
+  for (const h of headers) {
+    const f = h.fields;
+    const values = {
+      airtableId:        h.id,
+      poNumber:          f['Stock Order ID'] || '',
+      status:            f.Status || 'Draft',
+      createdDate:       f['Created Date'] || '',
+      assignedDriver:    f['Assigned Driver'] || '',
+      plannedDate:       f['Planned Date'] || null,
+      notes:             f.Notes || '',
+      supplierPayments:  String(f['Supplier Payments'] ?? ''),
+      driverPayment:     String(f['Driver Payment'] ?? ''),
+    };
+    if (DRY) { console.log(`[dry] would upsert PO ${h.id} → ${values.poNumber}`); continue; }
+
+    const updateSet = { ...values };
+    delete updateSet.airtableId;  // do not overwrite key
+    const [row] = await db.insert(stockOrders).values(values)
+      .onConflictDoUpdate({
+        target: stockOrders.airtableId,
+        set: updateSet,
+      })
+      .returning();
+    poIdMap.set(h.id, row.id);
+  }
+
+  for (const l of lines) {
+    const f = l.fields;
+    const poAirtableId = Array.isArray(f['Stock Orders']) ? f['Stock Orders'][0] : null;
+    if (!poAirtableId) { console.warn(`[backfill] line ${l.id} has no PO link, skipping`); continue; }
+    const poPgId = poIdMap.get(poAirtableId);
+    if (!poPgId) { console.warn(`[backfill] line ${l.id} references missing PO ${poAirtableId}, skipping`); continue; }
+
+    const stockAtId = Array.isArray(f['Stock Item']) ? f['Stock Item'][0] : null;
+    const stockPgId = await findStockPgIdByAirtableId(stockAtId);
+
+    const values = {
+      airtableId:               l.id,
+      poId:                     poPgId,
+      stockId:                  stockPgId,
+      stockAirtableId:          stockAtId || null,
+      flowerName:               String(f['Flower Name'] || ''),
+      quantityNeeded:           Number(f['Quantity Needed']) || 0,
+      quantityFound:            Number(f['Quantity Found']) || 0,
+      lotSize:                  Number(f['Lot Size']) || 0,
+      driverStatus:             f['Driver Status'] || 'Pending',
+      supplier:                 f.Supplier || '',
+      costPrice:                String(Number(f['Cost Price']) || 0),
+      sellPrice:                String(Number(f['Sell Price']) || 0),
+      farmer:                   f.Farmer || '',
+      notes:                    f.Notes || '',
+      substituteFlowerName:     f['Alt Flower Name'] || '',
+      substituteStatus:         f['Alt Flower Status'] || '',
+      substituteQuantityFound:  Number(f['Alt Quantity Found']) || 0,
+      substituteCost:           String(Number(f['Alt Cost']) || 0),
+      substituteSupplier:       f['Alt Supplier'] || '',
+      quantityAccepted:         Number(f['Quantity Accepted']) || 0,
+      writeOffQty:              Number(f['Write Off Qty']) || 0,
+      evalStatus:               f['Eval Status'] || '',
+    };
+    if (DRY) { console.log(`[dry] would upsert line ${l.id}`); continue; }
+
+    const updateSet = { ...values };
+    delete updateSet.airtableId;
+    await db.insert(stockOrderLines).values(values)
+      .onConflictDoUpdate({
+        target: stockOrderLines.airtableId,
+        set: updateSet,
+      });
+  }
+  console.log(`[backfill] Stock Orders done.`);
+}
+
+async function backfillPremadeBouquets() {
+  console.log('[backfill] Fetching Premade Bouquets from Airtable…');
+  const headers = await fetchAll(process.env.AIRTABLE_PREMADE_BOUQUETS_TABLE);
+  const lines   = await fetchAll(process.env.AIRTABLE_PREMADE_BOUQUET_LINES_TABLE);
+  console.log(`[backfill] ${headers.length} bouquets, ${lines.length} lines`);
+
+  const bouquetIdMap = new Map();
+  if (!DRY && headers.length > 0) {
+    const existing = await db.select({ id: premadeBouquets.id, airtableId: premadeBouquets.airtableId }).from(premadeBouquets);
+    for (const r of existing) if (r.airtableId) bouquetIdMap.set(r.airtableId, r.id);
+  }
+
+  for (const h of headers) {
+    const f = h.fields;
+    const values = {
+      airtableId:    h.id,
+      name:          (f.Name || '').trim(),
+      createdBy:     f['Created By'] || '',
+      priceOverride: f['Price Override'] != null ? String(f['Price Override']) : null,
+      notes:         f.Notes || '',
+    };
+    if (DRY) { console.log(`[dry] would upsert premade ${h.id} → ${values.name}`); continue; }
+    const updateSet = { ...values };
+    delete updateSet.airtableId;
+    const [row] = await db.insert(premadeBouquets).values(values)
+      .onConflictDoUpdate({
+        target: premadeBouquets.airtableId,
+        set: updateSet,
+      })
+      .returning();
+    bouquetIdMap.set(h.id, row.id);
+  }
+
+  for (const l of lines) {
+    const f = l.fields;
+    const bouquetAtId = Array.isArray(f['Premade Bouquets']) ? f['Premade Bouquets'][0] : null;
+    if (!bouquetAtId) continue;
+    const bouquetPgId = bouquetIdMap.get(bouquetAtId);
+    if (!bouquetPgId) { console.warn(`[backfill] premade line ${l.id} references missing bouquet`); continue; }
+
+    const stockAtId = Array.isArray(f['Stock Item']) ? f['Stock Item'][0] : null;
+    const stockPgId = await findStockPgIdByAirtableId(stockAtId);
+
+    const values = {
+      airtableId:        l.id,
+      bouquetId:         bouquetPgId,
+      stockId:           stockPgId,
+      stockAirtableId:   stockAtId || null,
+      flowerName:        String(f['Flower Name'] || ''),
+      quantity:          Number(f.Quantity) || 0,
+      costPricePerUnit:  String(Number(f['Cost Price Per Unit']) || 0),
+      sellPricePerUnit:  String(Number(f['Sell Price Per Unit']) || 0),
+    };
+    if (DRY) continue;
+    const updateSet = { ...values };
+    delete updateSet.airtableId;
+    await db.insert(premadeBouquetLines).values(values)
+      .onConflictDoUpdate({
+        target: premadeBouquetLines.airtableId,
+        set: updateSet,
+      });
+  }
+  console.log(`[backfill] Premade Bouquets done.`);
+}
+
+async function main() {
+  if (DRY) console.log('[backfill] DRY-RUN. No PG writes.');
+  await backfillStockOrders();
+  await backfillPremadeBouquets();
+
+  if (!DRY) {
+    const [poCount]  = await db.select({ c: sql`count(*)::int` }).from(stockOrders);
+    const [polCount] = await db.select({ c: sql`count(*)::int` }).from(stockOrderLines);
+    const [pbCount]  = await db.select({ c: sql`count(*)::int` }).from(premadeBouquets);
+    const [pblCount] = await db.select({ c: sql`count(*)::int` }).from(premadeBouquetLines);
+    console.log(`[backfill] PG row counts — stock_orders=${poCount.c}, stock_order_lines=${polCount.c}, premade_bouquets=${pbCount.c}, premade_bouquet_lines=${pblCount.c}`);
+  }
+  process.exit(0);
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/backend/src/__tests__/helpers/phase7-seed.js
+++ b/backend/src/__tests__/helpers/phase7-seed.js
@@ -1,0 +1,77 @@
+// Seeds representative POs + premade bouquets into pglite for E2E tests.
+// Replaces the Phase 7 mock-Airtable seed (POs + premades migrated to PG).
+//
+// Used by /test/reset (routes/test.js) so the harness has Phase 7 fixtures
+// after every spec resets state. Stock seed must be applied first — line
+// stock_id references rows already in the stock table.
+
+import { stockOrders, stockOrderLines, premadeBouquets, premadeBouquetLines, stock } from '../../db/schema.js';
+
+export async function seedPhase7(db) {
+  if (!db) return { stockOrders: 0, stockOrderLines: 0, premadeBouquets: 0, premadeBouquetLines: 0 };
+
+  // Reference an existing stock row if any are present. Line FK is nullable —
+  // null is acceptable for a stockless harness boot.
+  const [r] = await db.select({ id: stock.id }).from(stock).limit(1);
+  const sampleStockId = r?.id || null;
+
+  // Two POs spanning lifecycle (boot invariant in scripts/e2e-test.js
+  // expects exactly 2 rows here).
+  const [po1] = await db.insert(stockOrders).values({
+    airtableId:     'recE2EPO1',
+    poNumber:       'PO-20260508-1',
+    status:         'Draft',
+    createdDate:    '2026-05-08',
+    assignedDriver: 'Timur',
+  }).returning();
+
+  const [po2] = await db.insert(stockOrders).values({
+    airtableId:  'recE2EPO2',
+    poNumber:    'PO-20260507-1',
+    status:      'Complete',
+    createdDate: '2026-05-07',
+  }).returning();
+
+  await db.insert(stockOrderLines).values([
+    {
+      airtableId:     'recE2EPL1',
+      poId:           po1.id,
+      stockId:        sampleStockId,
+      flowerName:     'Red Rose',
+      quantityNeeded: 25,
+      driverStatus:   'Pending',
+      supplier:       'Market A',
+      costPrice:      '3.5',
+      sellPrice:      '12',
+    },
+    {
+      airtableId:     'recE2EPL2',
+      poId:           po2.id,
+      stockId:        sampleStockId,
+      flowerName:     'White Tulip',
+      quantityNeeded: 30,
+      quantityFound:  30,
+      driverStatus:   'Pending',
+      supplier:       'Market B',
+      costPrice:      '2.5',
+      sellPrice:      '8',
+    },
+  ]);
+
+  const [b1] = await db.insert(premadeBouquets).values({
+    airtableId: 'recE2EPB1',
+    name:       'Spring Mix',
+  }).returning();
+
+  await db.insert(premadeBouquetLines).values({
+    airtableId:        'recE2EPBL1',
+    bouquetId:         b1.id,
+    stockId:           sampleStockId,
+    flowerName:        'Red Rose',
+    quantity:          5,
+    costPricePerUnit:  '3.5',
+    sellPricePerUnit:  '12',
+  });
+
+  return { stockOrders: 2, stockOrderLines: 2, premadeBouquets: 1, premadeBouquetLines: 1 };
+}

--- a/backend/src/__tests__/premadeBouquetRepo.integration.test.js
+++ b/backend/src/__tests__/premadeBouquetRepo.integration.test.js
@@ -1,0 +1,122 @@
+// premadeBouquetRepo integration tests — pglite-backed CRUD + dual-lookup +
+// CASCADE coverage. Phase 7.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import { premadeBouquets, premadeBouquetLines, stock } from '../db/schema.js';
+import { eq } from 'drizzle-orm';
+
+const dbHolder = { db: null };
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  isPostgresConfigured: true,
+  pool: null,
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+import * as premadeBouquetRepo from '../repos/premadeBouquetRepo.js';
+
+let harness;
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+});
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+describe('premadeBouquetRepo', () => {
+  it('create + line CRUD round-trip', async () => {
+    const b = await premadeBouquetRepo.create({ Name: 'Spring Mix', 'Created By': 'florist' });
+    expect(b.Name).toBe('Spring Mix');
+    expect(b._pgId).toBeDefined();
+
+    const line = await premadeBouquetRepo.createLine({
+      'Premade Bouquets':    [b._pgId],
+      'Flower Name':         'Tulip',
+      Quantity:              10,
+      'Cost Price Per Unit': 2.5,
+      'Sell Price Per Unit': 8,
+    });
+    expect(line.Quantity).toBe(10);
+    expect(line['Cost Price Per Unit']).toBe(2.5);
+    expect(line['Sell Price Per Unit']).toBe(8);
+
+    const lines = await premadeBouquetRepo.getLinesByBouquetId(b._pgId);
+    expect(lines).toHaveLength(1);
+  });
+
+  it('CASCADE on delete', async () => {
+    const b = await premadeBouquetRepo.create({ Name: 'X' });
+    await premadeBouquetRepo.createLine({
+      'Premade Bouquets': [b._pgId], 'Flower Name': 'Rose', Quantity: 5,
+    });
+    await premadeBouquetRepo.deleteById(b._pgId);
+    const remaining = await harness.db.select().from(premadeBouquetLines)
+      .where(eq(premadeBouquetLines.bouquetId, b._pgId));
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('getLinesByStockId resolves recXXX and uuid', async () => {
+    const [s] = await harness.db.insert(stock).values({
+      displayName: 'Lily', currentQuantity: 0, active: true,
+    }).returning();
+
+    const b = await premadeBouquetRepo.create({ Name: 'Lily Bouquet' });
+    await premadeBouquetRepo.createLine({
+      'Premade Bouquets': [b._pgId], 'Stock Item': [s.id], 'Flower Name': 'Lily', Quantity: 3,
+    });
+    const found = await premadeBouquetRepo.getLinesByStockId(s.id);
+    expect(found).toHaveLength(1);
+
+    // Now insert a line referencing a recXXX-style stock id
+    const b2 = await premadeBouquetRepo.create({ Name: 'Legacy' });
+    await premadeBouquetRepo.createLine({
+      'Premade Bouquets': [b2._pgId], 'Stock Item': ['recLEGACY'], 'Flower Name': 'Legacy', Quantity: 2,
+    });
+    const foundLegacy = await premadeBouquetRepo.getLinesByStockId('recLEGACY');
+    expect(foundLegacy).toHaveLength(1);
+  });
+
+  it('getById dual-lookup (recXXX or uuid)', async () => {
+    const [row] = await harness.db.insert(premadeBouquets).values({
+      airtableId: 'recBQ1', name: 'AT Bouquet',
+    }).returning();
+    const byAt = await premadeBouquetRepo.getById('recBQ1');
+    expect(byAt._pgId).toBe(row.id);
+    expect(byAt.id).toBe('recBQ1');
+    const byUuid = await premadeBouquetRepo.getById(row.id);
+    expect(byUuid._pgId).toBe(row.id);
+  });
+
+  it('create() rejects empty name', async () => {
+    await expect(premadeBouquetRepo.create({ Name: '' })).rejects.toThrow(/name/i);
+  });
+
+  it('update() patches only provided fields', async () => {
+    const b = await premadeBouquetRepo.create({ Name: 'Orig', Notes: 'original notes' });
+    const updated = await premadeBouquetRepo.update(b._pgId, { 'Price Override': 199.99 });
+    expect(updated['Price Override']).toBe(199.99);
+    expect(updated.Name).toBe('Orig');
+    expect(updated.Notes).toBe('original notes');
+  });
+
+  it('lineToWire Stock Item array shape', async () => {
+    const [s] = await harness.db.insert(stock).values({
+      displayName: 'Peony', currentQuantity: 0, active: true,
+    }).returning();
+    const b = await premadeBouquetRepo.create({ Name: 'Peony Mix' });
+    const line = await premadeBouquetRepo.createLine({
+      'Premade Bouquets': [b._pgId], 'Stock Item': [s.id], 'Flower Name': 'Peony', Quantity: 4,
+    });
+    expect(line['Stock Item']).toEqual([s.id]);
+
+    // Line without stock item link → empty array
+    const lineNoStock = await premadeBouquetRepo.createLine({
+      'Premade Bouquets': [b._pgId], 'Flower Name': 'Mystery', Quantity: 1,
+    });
+    expect(lineNoStock['Stock Item']).toEqual([]);
+  });
+});

--- a/backend/src/__tests__/premadeBouquetService.integration.test.js
+++ b/backend/src/__tests__/premadeBouquetService.integration.test.js
@@ -1,15 +1,14 @@
-// premadeBouquetService integration tests — exercise the stock-adjustment
-// path against a real Postgres (via pglite) to prove writes land in PG, not
-// Airtable. Backstops the 2026-05-04 bug where return-to-stock incremented
-// Airtable (frozen post-cutover) while the dashboard read from PG.
+// premadeBouquetService integration tests — exercise the full service against
+// real Postgres (via pglite). Phase 7: premade bouquets and lines now live in
+// PG, so seeding goes via Drizzle inserts directly into the new tables, not
+// the airtable mock.
 //
-// Premade bouquet records themselves still live on Airtable (no PG migration
-// for that table yet), so those calls remain mocked. Only the stock side is
-// real-SQL.
+// Backstops the 2026-05-04 bug where return-to-stock incremented Airtable
+// (frozen post-cutover) while the dashboard read from PG.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
-import { stock } from '../db/schema.js';
+import { stock, premadeBouquets, premadeBouquetLines } from '../db/schema.js';
 import { eq } from 'drizzle-orm';
 
 const dbHolder = { db: null };
@@ -22,28 +21,17 @@ vi.mock('../db/index.js', () => ({
   disconnectPostgres: async () => {},
 }));
 
-// Airtable layer — premade bouquet table operations stay on Airtable; only
-// stub deleteRecord + getById since those are the only premade-side calls
-// the return-to-stock flow makes.
+// Airtable layer should NOT fire post-cutover. Stub atomicStockAdjust so the
+// regression assertion can confirm the legacy path stays cold.
 vi.mock('../services/airtable.js', () => ({
   create: vi.fn(),
   update: vi.fn(),
-  deleteRecord: vi.fn().mockResolvedValue({ deleted: true }),
+  deleteRecord: vi.fn(),
   getById: vi.fn(),
   list: vi.fn(),
   atomicStockAdjust: vi.fn(),
 }));
 
-vi.mock('../config/airtable.js', () => ({
-  default: {},
-  TABLES: {
-    PREMADE_BOUQUETS: 'tblPremadeBouquets',
-    PREMADE_BOUQUET_LINES: 'tblPremadeBouquetLines',
-    STOCK: 'tblStock',
-  },
-}));
-
-vi.mock('../utils/batchQuery.js', () => ({ listByIds: vi.fn() }));
 vi.mock('../services/notifications.js', () => ({ broadcast: vi.fn() }));
 vi.mock('../services/orderService.js', () => ({
   autoMatchStock: vi.fn().mockResolvedValue(0),
@@ -51,7 +39,6 @@ vi.mock('../services/orderService.js', () => ({
 }));
 
 import * as airtable from '../services/airtable.js';
-import { listByIds } from '../utils/batchQuery.js';
 import * as stockRepo from '../repos/stockRepo.js';
 import {
   returnPremadeBouquetToStock,
@@ -64,7 +51,6 @@ beforeEach(async () => {
   harness = await setupPgHarness();
   dbHolder.db = harness.db;
   vi.clearAllMocks();
-  airtable.deleteRecord.mockResolvedValue({ deleted: true });
   stockRepo._setMode('postgres');
 });
 
@@ -85,6 +71,24 @@ async function seedStockRow(displayName, qty) {
   return row;
 }
 
+// Seeds a premade bouquet + its lines directly into pglite.
+async function seedPremadeBouquet(name, lineSpecs /* [{stockUuid, flowerName, qty}] */) {
+  const [b] = await harness.db.insert(premadeBouquets).values({
+    name,
+  }).returning();
+  for (const ls of lineSpecs) {
+    await harness.db.insert(premadeBouquetLines).values({
+      bouquetId:        b.id,
+      stockId:          ls.stockUuid,
+      flowerName:       ls.flowerName,
+      quantity:         ls.qty,
+      costPricePerUnit: '1',
+      sellPricePerUnit: '5',
+    });
+  }
+  return b;
+}
+
 describe('returnPremadeBouquetToStock — postgres mode (regression for 2026-05-04 bug)', () => {
   it('increments PG stock quantities, not Airtable', async () => {
     // Seed two stock rows in PG with the qty AFTER the premade was created
@@ -92,17 +96,13 @@ describe('returnPremadeBouquetToStock — postgres mode (regression for 2026-05-
     const rose = await seedStockRow('Rose', 7);        // started at 10, 3 in bouquet
     const euca = await seedStockRow('Eucalyptus', 8);  // started at 10, 2 in bouquet
 
-    airtable.getById.mockResolvedValue({
-      id: 'recBouquet1',
-      Name: 'Spring Pink',
-      Lines: ['recLine1', 'recLine2'],
-    });
-    listByIds.mockResolvedValue([
-      { id: 'recLine1', 'Stock Item': [rose.airtableId], 'Flower Name': 'Rose', Quantity: 3 },
-      { id: 'recLine2', 'Stock Item': [euca.airtableId], 'Flower Name': 'Eucalyptus', Quantity: 2 },
+    // Seed the premade in PG (rather than Airtable mock)
+    const bouquet = await seedPremadeBouquet('Spring Pink', [
+      { stockUuid: rose.id, flowerName: 'Rose', qty: 3 },
+      { stockUuid: euca.id, flowerName: 'Eucalyptus', qty: 2 },
     ]);
 
-    const result = await returnPremadeBouquetToStock('recBouquet1');
+    const result = await returnPremadeBouquetToStock(bouquet.id);
 
     // PG rows should be back to their pre-bouquet quantities.
     const [roseAfter] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
@@ -110,10 +110,13 @@ describe('returnPremadeBouquetToStock — postgres mode (regression for 2026-05-
     expect(roseAfter.currentQuantity).toBe(10);
     expect(eucaAfter.currentQuantity).toBe(10);
 
-    // Airtable stock-adjust must NOT have fired — Airtable Stock is the
-    // frozen legacy snapshot post-cutover. Bypassing the repo here was the
-    // exact bug owner hit on 2026-05-04.
+    // Airtable stock-adjust must NOT have fired — Airtable Stock is frozen
+    // post-cutover. Bypassing the repo here was the exact 2026-05-04 bug.
     expect(airtable.atomicStockAdjust).not.toHaveBeenCalled();
+
+    // Bouquet record removed (CASCADE removes lines)
+    const [check] = await harness.db.select().from(premadeBouquets).where(eq(premadeBouquets.id, bouquet.id));
+    expect(check).toBeUndefined();
 
     // Service still reports per-line summary so the toast can name what came back.
     expect(result.returnedItems).toHaveLength(2);
@@ -123,17 +126,14 @@ describe('returnPremadeBouquetToStock — postgres mode (regression for 2026-05-
   it('handles a line whose Stock Item link is missing without aborting other returns', async () => {
     const rose = await seedStockRow('Rose', 7);
 
-    airtable.getById.mockResolvedValue({
-      id: 'recBouquet2',
-      Name: 'Mixed',
-      Lines: ['recLine1', 'recLine2'],
-    });
-    listByIds.mockResolvedValue([
-      { id: 'recLine1', 'Stock Item': [rose.airtableId], 'Flower Name': 'Rose', Quantity: 3 },
-      { id: 'recLine2', 'Stock Item': [], 'Flower Name': 'Mystery', Quantity: 2 },
+    // Seed bouquet with one linked + one orphan line
+    const [b] = await harness.db.insert(premadeBouquets).values({ name: 'Mixed' }).returning();
+    await harness.db.insert(premadeBouquetLines).values([
+      { bouquetId: b.id, stockId: rose.id, flowerName: 'Rose', quantity: 3, costPricePerUnit: '1', sellPricePerUnit: '5' },
+      { bouquetId: b.id, stockId: null, flowerName: 'Mystery', quantity: 2, costPricePerUnit: '1', sellPricePerUnit: '5' },
     ]);
 
-    const result = await returnPremadeBouquetToStock('recBouquet2');
+    const result = await returnPremadeBouquetToStock(b.id);
 
     const [roseAfter] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
     expect(roseAfter.currentQuantity).toBe(10);
@@ -146,19 +146,10 @@ describe('createPremadeBouquet — postgres mode', () => {
   it('decrements PG stock when the bouquet is composed', async () => {
     const rose = await seedStockRow('Rose', 10);
 
-    airtable.create
-      .mockResolvedValueOnce({ id: 'recBouquet1', Name: 'Solo' })
-      .mockResolvedValueOnce({ id: 'recLine1' });
-    airtable.getById.mockResolvedValue({
-      id: 'recBouquet1', Name: 'Solo', Lines: ['recLine1'],
-    });
-    listByIds.mockResolvedValue([
-      { id: 'recLine1', 'Flower Name': 'Rose', Quantity: 4, 'Sell Price Per Unit': 10, 'Cost Price Per Unit': 4 },
-    ]);
-
     await createPremadeBouquet({
       name: 'Solo',
       lines: [
+        // Pass the airtableId — stockRepo.adjustQuantity accepts either form.
         { stockItemId: rose.airtableId, flowerName: 'Rose', quantity: 4, costPricePerUnit: 4, sellPricePerUnit: 10 },
       ],
       createdBy: 'Florist',
@@ -167,5 +158,13 @@ describe('createPremadeBouquet — postgres mode', () => {
     const [roseAfter] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
     expect(roseAfter.currentQuantity).toBe(6);
     expect(airtable.atomicStockAdjust).not.toHaveBeenCalled();
+
+    // PG bouquet + line should exist
+    const allBouquets = await harness.db.select().from(premadeBouquets);
+    expect(allBouquets).toHaveLength(1);
+    expect(allBouquets[0].name).toBe('Solo');
+    const allLines = await harness.db.select().from(premadeBouquetLines);
+    expect(allLines).toHaveLength(1);
+    expect(allLines[0].quantity).toBe(4);
   });
 });

--- a/backend/src/__tests__/premadeBouquetService.test.js
+++ b/backend/src/__tests__/premadeBouquetService.test.js
@@ -1,44 +1,29 @@
-// Tests for premadeBouquetService — create/return/match flows.
+// Tests for premadeBouquetService — create / return / match flows.
 //
-// These tests mock the Airtable layer (services/airtable.js) and the order
-// service's createOrder so we can assert the business logic without touching
-// the real Airtable base.
+// Phase 7: persistence is now via premadeBouquetRepo (not airtable.js).
+// These tests mock the repo and the order service's createOrder so we can
+// assert the business logic without touching real Postgres.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Stub TABLES so the service sees real string IDs for our new tables even
-// when env vars aren't set in the test environment.
-vi.mock('../config/airtable.js', () => ({
-  default: {},
-  TABLES: {
-    PREMADE_BOUQUETS: 'tblPremadeBouquets',
-    PREMADE_BOUQUET_LINES: 'tblPremadeBouquetLines',
-    STOCK: 'tblStock',
-    ORDERS: 'tblOrders',
-    ORDER_LINES: 'tblOrderLines',
-    DELIVERIES: 'tblDeliveries',
-    CUSTOMERS: 'tblCustomers',
-  },
-}));
-
-// ── Mock the database layer ──
-vi.mock('../services/airtable.js', () => ({
-  create: vi.fn(),
-  update: vi.fn(),
-  deleteRecord: vi.fn(),
-  getById: vi.fn(),
-  list: vi.fn(),
-  atomicStockAdjust: vi.fn(),
+// ── Mock the premade bouquet repo ──
+vi.mock('../repos/premadeBouquetRepo.js', () => ({
+  list:                vi.fn(),
+  getById:             vi.fn(),
+  create:              vi.fn(),
+  update:              vi.fn(),
+  deleteById:          vi.fn(),
+  createLine:          vi.fn(),
+  getLineById:         vi.fn(),
+  getLinesByBouquetId: vi.fn(),
+  getLinesByStockId:   vi.fn(),
+  updateLine:          vi.fn(),
+  deleteLineById:      vi.fn(),
 }));
 
 // ── Mock stockRepo (post-cutover stock adjustments route through here) ──
 vi.mock('../repos/stockRepo.js', () => ({
   adjustQuantity: vi.fn(),
-}));
-
-// ── Mock batchQuery (listByIds) ──
-vi.mock('../utils/batchQuery.js', () => ({
-  listByIds: vi.fn(),
 }));
 
 // ── Mock notifications ──
@@ -52,9 +37,8 @@ vi.mock('../services/orderService.js', () => ({
   createOrder: vi.fn(),
 }));
 
-import * as db from '../services/airtable.js';
+import * as premadeBouquetRepo from '../repos/premadeBouquetRepo.js';
 import * as stockRepo from '../repos/stockRepo.js';
-import { listByIds } from '../utils/batchQuery.js';
 import { broadcast } from '../services/notifications.js';
 import { createOrder } from '../services/orderService.js';
 import {
@@ -65,23 +49,27 @@ import {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  // Default: deleteRecord returns a resolved promise so `.catch()` chains don't blow up.
-  db.deleteRecord.mockResolvedValue({ deleted: true });
+  premadeBouquetRepo.deleteById.mockResolvedValue(undefined);
+  premadeBouquetRepo.deleteLineById.mockResolvedValue(undefined);
 });
 
 describe('createPremadeBouquet', () => {
   it('creates the bouquet, lines, and deducts stock', async () => {
-    db.create
-      .mockResolvedValueOnce({ id: 'recBouquet1', Name: 'Spring Pink' })   // parent
-      .mockResolvedValueOnce({ id: 'recLine1' })                            // line 1
-      .mockResolvedValueOnce({ id: 'recLine2' });                           // line 2
-    stockRepo.adjustQuantity.mockResolvedValue({ stockId: 'x', previousQty: 10, newQty: 7 });
-    db.getById.mockResolvedValue({
-      id: 'recBouquet1', Name: 'Spring Pink', Lines: ['recLine1', 'recLine2'],
+    premadeBouquetRepo.create.mockResolvedValue({
+      id: 'recBouquet1', _pgId: 'uuid-bouquet-1', Name: 'Spring Pink',
     });
-    listByIds.mockResolvedValue([
-      { id: 'recLine1', 'Flower Name': 'Rose', Quantity: 3, 'Sell Price Per Unit': 10, 'Cost Price Per Unit': 4 },
-      { id: 'recLine2', 'Flower Name': 'Eucalyptus', Quantity: 2, 'Sell Price Per Unit': 5, 'Cost Price Per Unit': 2 },
+    premadeBouquetRepo.createLine
+      .mockResolvedValueOnce({ id: 'recLine1', _pgId: 'uuid-line-1' })
+      .mockResolvedValueOnce({ id: 'recLine2', _pgId: 'uuid-line-2' });
+    stockRepo.adjustQuantity.mockResolvedValue({ stockId: 'x', previousQty: 10, newQty: 7 });
+
+    // getPremadeBouquet() at the end calls getById + getLinesByBouquetId
+    premadeBouquetRepo.getById.mockResolvedValue({
+      id: 'recBouquet1', _pgId: 'uuid-bouquet-1', Name: 'Spring Pink', 'Price Override': null,
+    });
+    premadeBouquetRepo.getLinesByBouquetId.mockResolvedValue([
+      { id: 'recLine1', _pgId: 'uuid-line-1', 'Flower Name': 'Rose', Quantity: 3, 'Sell Price Per Unit': 10, 'Cost Price Per Unit': 4 },
+      { id: 'recLine2', _pgId: 'uuid-line-2', 'Flower Name': 'Eucalyptus', Quantity: 2, 'Sell Price Per Unit': 5, 'Cost Price Per Unit': 2 },
     ]);
 
     const result = await createPremadeBouquet({
@@ -93,14 +81,19 @@ describe('createPremadeBouquet', () => {
       createdBy: 'Florist',
     });
 
-    // Parent + 2 lines created
-    expect(db.create).toHaveBeenCalledTimes(3);
+    // Parent created + 2 lines created
+    expect(premadeBouquetRepo.create).toHaveBeenCalledTimes(1);
+    expect(premadeBouquetRepo.createLine).toHaveBeenCalledTimes(2);
+    // Lines linked to the parent's _pgId (uuid)
+    expect(premadeBouquetRepo.createLine).toHaveBeenCalledWith(expect.objectContaining({
+      'Premade Bouquets': ['uuid-bouquet-1'],
+      'Flower Name': 'Rose',
+      Quantity: 3,
+    }));
     // Stock deducted twice via stockRepo, with negative deltas
     expect(stockRepo.adjustQuantity).toHaveBeenCalledWith('recStock1', -3);
     expect(stockRepo.adjustQuantity).toHaveBeenCalledWith('recStock2', -2);
-    // Legacy direct-Airtable path must NOT fire post-cutover
-    expect(db.atomicStockAdjust).not.toHaveBeenCalled();
-    // Broadcast fired
+    // Broadcast fired with the wire-format id (airtableId || uuid)
     expect(broadcast).toHaveBeenCalledWith(expect.objectContaining({
       type: 'premade_bouquet_created',
       bouquetId: 'recBouquet1',
@@ -115,7 +108,7 @@ describe('createPremadeBouquet', () => {
       name: '',
       lines: [{ stockItemId: 'x', flowerName: 'Rose', quantity: 1 }],
     })).rejects.toThrow(/name is required/);
-    expect(db.create).not.toHaveBeenCalled();
+    expect(premadeBouquetRepo.create).not.toHaveBeenCalled();
   });
 
   it('rejects when lines array is empty', async () => {
@@ -123,7 +116,7 @@ describe('createPremadeBouquet', () => {
       name: 'Test',
       lines: [],
     })).rejects.toThrow(/at least one flower line/);
-    expect(db.create).not.toHaveBeenCalled();
+    expect(premadeBouquetRepo.create).not.toHaveBeenCalled();
   });
 
   it('rejects when a line quantity is not positive', async () => {
@@ -131,15 +124,16 @@ describe('createPremadeBouquet', () => {
       name: 'Test',
       lines: [{ stockItemId: 'x', flowerName: 'Rose', quantity: 0 }],
     })).rejects.toThrow(/quantity must be a positive number/);
-    expect(db.create).not.toHaveBeenCalled();
+    expect(premadeBouquetRepo.create).not.toHaveBeenCalled();
   });
 
   it('rolls back stock and deletes records on failure', async () => {
-    db.create
-      .mockResolvedValueOnce({ id: 'recBouquet1' })  // parent created
-      .mockResolvedValueOnce({ id: 'recLine1' })     // line 1 created
-      .mockRejectedValueOnce(new Error('airtable exploded')); // line 2 fails
-    stockRepo.adjustQuantity.mockResolvedValue({ stockId: 'x', previousQty: 10, newQty: 9 });
+    premadeBouquetRepo.create.mockResolvedValue({
+      id: 'recBouquet1', _pgId: 'uuid-bouquet-1',
+    });
+    premadeBouquetRepo.createLine
+      .mockResolvedValueOnce({ id: 'recLine1', _pgId: 'uuid-line-1' })
+      .mockRejectedValueOnce(new Error('repo exploded'));
 
     await expect(createPremadeBouquet({
       name: 'Boom',
@@ -147,24 +141,24 @@ describe('createPremadeBouquet', () => {
         { stockItemId: 'recStock1', flowerName: 'Rose', quantity: 1, costPricePerUnit: 4, sellPricePerUnit: 10 },
         { stockItemId: 'recStock2', flowerName: 'Eucalyptus', quantity: 1, costPricePerUnit: 2, sellPricePerUnit: 5 },
       ],
-    })).rejects.toThrow(/airtable exploded/);
+    })).rejects.toThrow(/repo exploded/);
 
-    // Note: stock deduction happens after all lines are created, so in this
-    // scenario (line 2 creation fails) there were no stock adjustments to undo.
-    // But the created parent + line 1 should be deleted as cleanup.
-    expect(db.deleteRecord).toHaveBeenCalledWith(expect.anything(), 'recLine1');
-    expect(db.deleteRecord).toHaveBeenCalledWith(expect.anything(), 'recBouquet1');
+    // Stock deduction happens AFTER all lines created, so failure on line 2
+    // means no stock adjustments to undo. But the created parent + line 1
+    // should be deleted as cleanup.
+    expect(premadeBouquetRepo.deleteLineById).toHaveBeenCalledWith('uuid-line-1');
+    expect(premadeBouquetRepo.deleteById).toHaveBeenCalledWith('uuid-bouquet-1');
   });
 });
 
 describe('returnPremadeBouquetToStock', () => {
-  it('increments stock for each line and deletes records', async () => {
-    db.getById.mockResolvedValue({
-      id: 'recBouquet1', Name: 'Spring Pink', Lines: ['recLine1', 'recLine2'],
+  it('increments stock for each line and deletes the bouquet (CASCADE handles lines)', async () => {
+    premadeBouquetRepo.getById.mockResolvedValue({
+      id: 'recBouquet1', _pgId: 'uuid-bouquet-1', Name: 'Spring Pink',
     });
-    listByIds.mockResolvedValue([
-      { id: 'recLine1', 'Stock Item': ['recStock1'], 'Flower Name': 'Rose', Quantity: 3 },
-      { id: 'recLine2', 'Stock Item': ['recStock2'], 'Flower Name': 'Eucalyptus', Quantity: 2 },
+    premadeBouquetRepo.getLinesByBouquetId.mockResolvedValue([
+      { id: 'recLine1', _pgId: 'uuid-line-1', 'Stock Item': ['recStock1'], 'Flower Name': 'Rose', Quantity: 3 },
+      { id: 'recLine2', _pgId: 'uuid-line-2', 'Stock Item': ['recStock2'], 'Flower Name': 'Eucalyptus', Quantity: 2 },
     ]);
     stockRepo.adjustQuantity.mockResolvedValue({ stockId: 'x', previousQty: 0, newQty: 3 });
 
@@ -173,13 +167,8 @@ describe('returnPremadeBouquetToStock', () => {
     // Stock adjusted with POSITIVE deltas (returning to inventory) via stockRepo
     expect(stockRepo.adjustQuantity).toHaveBeenCalledWith('recStock1', 3);
     expect(stockRepo.adjustQuantity).toHaveBeenCalledWith('recStock2', 2);
-    // Must not bypass the repo — that was the 2026-05-04 bug.
-    expect(db.atomicStockAdjust).not.toHaveBeenCalled();
-    // Lines deleted
-    expect(db.deleteRecord).toHaveBeenCalledWith(expect.anything(), 'recLine1');
-    expect(db.deleteRecord).toHaveBeenCalledWith(expect.anything(), 'recLine2');
-    // Bouquet deleted
-    expect(db.deleteRecord).toHaveBeenCalledWith(expect.anything(), 'recBouquet1');
+    // Bouquet deleted (CASCADE removes lines)
+    expect(premadeBouquetRepo.deleteById).toHaveBeenCalledWith('uuid-bouquet-1');
     // Broadcast
     expect(broadcast).toHaveBeenCalledWith(expect.objectContaining({
       type: 'premade_bouquet_returned',
@@ -192,16 +181,12 @@ describe('returnPremadeBouquetToStock', () => {
 
 describe('matchPremadeBouquetToOrder', () => {
   it('creates an order from premade lines WITHOUT re-deducting stock, then deletes premade', async () => {
-    // First call: getPremadeBouquet() inside matchPremadeBouquetToOrder
-    db.getById.mockResolvedValue({
-      id: 'recBouquet1',
-      Name: 'Spring Pink',
-      Lines: ['recLine1', 'recLine2'],
-      'Price Override': null,
+    premadeBouquetRepo.getById.mockResolvedValue({
+      id: 'recBouquet1', _pgId: 'uuid-bouquet-1', Name: 'Spring Pink', 'Price Override': null,
     });
-    listByIds.mockResolvedValue([
-      { id: 'recLine1', 'Stock Item': ['recStock1'], 'Flower Name': 'Rose', Quantity: 3, 'Cost Price Per Unit': 4, 'Sell Price Per Unit': 10 },
-      { id: 'recLine2', 'Stock Item': ['recStock2'], 'Flower Name': 'Eucalyptus', Quantity: 2, 'Cost Price Per Unit': 2, 'Sell Price Per Unit': 5 },
+    premadeBouquetRepo.getLinesByBouquetId.mockResolvedValue([
+      { id: 'recLine1', _pgId: 'uuid-line-1', 'Stock Item': ['recStock1'], 'Flower Name': 'Rose', Quantity: 3, 'Cost Price Per Unit': 4, 'Sell Price Per Unit': 10 },
+      { id: 'recLine2', _pgId: 'uuid-line-2', 'Stock Item': ['recStock2'], 'Flower Name': 'Eucalyptus', Quantity: 2, 'Cost Price Per Unit': 2, 'Sell Price Per Unit': 5 },
     ]);
     createOrder.mockResolvedValue({
       order: { id: 'recOrder1' },
@@ -232,13 +217,10 @@ describe('matchPremadeBouquetToOrder', () => {
       { skipStockDeduction: true },
     );
 
-    // Premade cleanup — lines and parent deleted
-    expect(db.deleteRecord).toHaveBeenCalledWith(expect.anything(), 'recLine1');
-    expect(db.deleteRecord).toHaveBeenCalledWith(expect.anything(), 'recLine2');
-    expect(db.deleteRecord).toHaveBeenCalledWith(expect.anything(), 'recBouquet1');
+    // Premade cleanup — bouquet deleted (CASCADE removes lines)
+    expect(premadeBouquetRepo.deleteById).toHaveBeenCalledWith('uuid-bouquet-1');
 
-    // No stock adjustments made directly from match flow
-    expect(db.atomicStockAdjust).not.toHaveBeenCalled();
+    // No direct stock adjustments made from match flow
     expect(stockRepo.adjustQuantity).not.toHaveBeenCalled();
 
     // Broadcast fired
@@ -254,11 +236,11 @@ describe('matchPremadeBouquetToOrder', () => {
   });
 
   it('carries the premade price override into the order when caller did not supply one', async () => {
-    db.getById.mockResolvedValue({
-      id: 'recBouquet1', Name: 'Spring Pink', Lines: ['recLine1'], 'Price Override': 150,
+    premadeBouquetRepo.getById.mockResolvedValue({
+      id: 'recBouquet1', _pgId: 'uuid-bouquet-1', Name: 'Spring Pink', 'Price Override': 150,
     });
-    listByIds.mockResolvedValue([
-      { id: 'recLine1', 'Stock Item': ['recStock1'], 'Flower Name': 'Rose', Quantity: 3, 'Cost Price Per Unit': 4, 'Sell Price Per Unit': 10 },
+    premadeBouquetRepo.getLinesByBouquetId.mockResolvedValue([
+      { id: 'recLine1', _pgId: 'uuid-line-1', 'Stock Item': ['recStock1'], 'Flower Name': 'Rose', Quantity: 3, 'Cost Price Per Unit': 4, 'Sell Price Per Unit': 10 },
     ]);
     createOrder.mockResolvedValue({ order: { id: 'recOrder1' }, orderLines: [], delivery: null });
 
@@ -276,8 +258,10 @@ describe('matchPremadeBouquetToOrder', () => {
   });
 
   it('rejects when the premade has no lines', async () => {
-    db.getById.mockResolvedValue({ id: 'recBouquet1', Lines: [] });
-    listByIds.mockResolvedValue([]);
+    premadeBouquetRepo.getById.mockResolvedValue({
+      id: 'recBouquet1', _pgId: 'uuid-bouquet-1',
+    });
+    premadeBouquetRepo.getLinesByBouquetId.mockResolvedValue([]);
 
     await expect(matchPremadeBouquetToOrder(
       'recBouquet1',

--- a/backend/src/__tests__/stockOrderRepo.integration.test.js
+++ b/backend/src/__tests__/stockOrderRepo.integration.test.js
@@ -1,0 +1,250 @@
+// stockOrderRepo integration tests — exercise against real Postgres (pglite).
+// Catches SQL syntax errors, default values, FK CASCADE behaviour, and
+// dual-lookup correctness. Phase 7 of the SQL migration.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import { stockOrders, stockOrderLines, stock } from '../db/schema.js';
+import { eq } from 'drizzle-orm';
+
+const dbHolder = { db: null };
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  isPostgresConfigured: true,
+  pool: null,
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+import * as stockOrderRepo from '../repos/stockOrderRepo.js';
+
+let harness;
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+});
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+describe('stockOrderRepo header CRUD', () => {
+  it('create() inserts with sensible defaults', async () => {
+    const po = await stockOrderRepo.create({
+      'Stock Order ID': 'PO-20260508-1',
+      'Created Date':   '2026-05-08',
+      Status:           'Draft',
+    });
+    expect(po.Status).toBe('Draft');
+    expect(po['Stock Order ID']).toBe('PO-20260508-1');
+    expect(po._pgId).toBeDefined();
+    expect(po['Created Date']).toBe('2026-05-08');
+  });
+
+  it('create() defaults Created Date to today when omitted', async () => {
+    const po = await stockOrderRepo.create({
+      'Stock Order ID': 'PO-NODATE',
+      Status:           'Draft',
+    });
+    expect(po['Created Date']).toBe(new Date().toISOString().split('T')[0]);
+  });
+
+  it('getById() resolves recXXX via airtable_id and uuid via primary key', async () => {
+    const [row] = await harness.db.insert(stockOrders).values({
+      airtableId:  'recABC123',
+      poNumber:    'PO-20260101-1',
+      createdDate: '2026-01-01',
+    }).returning();
+
+    const byAt = await stockOrderRepo.getById('recABC123');
+    expect(byAt._pgId).toBe(row.id);
+    expect(byAt.id).toBe('recABC123');
+
+    const byUuid = await stockOrderRepo.getById(row.id);
+    expect(byUuid._pgId).toBe(row.id);
+  });
+
+  it('getById() throws 404 for missing id', async () => {
+    await expect(stockOrderRepo.getById('recDOESNOTEXIST'))
+      .rejects.toMatchObject({ statusCode: 404 });
+  });
+
+  it('nextPoSequence() returns MAX(N)+1 for the date with gaps', async () => {
+    await harness.db.insert(stockOrders).values([
+      { poNumber: 'PO-20260508-1', createdDate: '2026-05-08' },
+      { poNumber: 'PO-20260508-3', createdDate: '2026-05-08' },  // gap at 2
+      { poNumber: 'PO-20260507-2', createdDate: '2026-05-07' },
+    ]);
+    const seq = await stockOrderRepo.nextPoSequence('2026-05-08');
+    expect(seq).toBe(4);
+  });
+
+  it('nextPoSequence() returns 1 when no POs exist for the date', async () => {
+    await harness.db.insert(stockOrders).values([
+      { poNumber: 'PO-20260507-2', createdDate: '2026-05-07' },
+    ]);
+    const seq = await stockOrderRepo.nextPoSequence('2026-05-08');
+    expect(seq).toBe(1);
+  });
+
+  it('nextPoSequence() rejects non-numeric tails (defensive)', async () => {
+    await harness.db.insert(stockOrders).values([
+      { poNumber: 'PO-20260508-5abc', createdDate: '2026-05-08' },  // malformed
+      { poNumber: 'PO-20260508-2', createdDate: '2026-05-08' },
+    ]);
+    const seq = await stockOrderRepo.nextPoSequence('2026-05-08');
+    expect(seq).toBe(3);  // ignores malformed, uses 2 as MAX
+  });
+
+  it('update() patches only provided fields', async () => {
+    const po = await stockOrderRepo.create({ 'Stock Order ID': 'PO-X', 'Created Date': '2026-05-08' });
+    const updated = await stockOrderRepo.update(po._pgId, {
+      Status: 'Sent', 'Assigned Driver': 'Timur',
+    });
+    expect(updated.Status).toBe('Sent');
+    expect(updated['Assigned Driver']).toBe('Timur');
+    expect(updated['Stock Order ID']).toBe('PO-X');  // unchanged
+  });
+
+  it('update() accepts recXXX id', async () => {
+    const [row] = await harness.db.insert(stockOrders).values({
+      airtableId:  'recUPD1',
+      poNumber:    'PO-U',
+      createdDate: '2026-05-08',
+    }).returning();
+    const updated = await stockOrderRepo.update('recUPD1', { Status: 'Sent' });
+    expect(updated.Status).toBe('Sent');
+    expect(updated._pgId).toBe(row.id);
+  });
+
+  it('list() filters by status and driver scope', async () => {
+    await harness.db.insert(stockOrders).values([
+      { poNumber: 'PO-A', createdDate: '2026-05-08', status: 'Draft', assignedDriver: 'Timur' },
+      { poNumber: 'PO-B', createdDate: '2026-05-08', status: 'Sent',  assignedDriver: 'Timur' },
+      { poNumber: 'PO-C', createdDate: '2026-05-08', status: 'Draft', assignedDriver: 'Nikita' },
+    ]);
+    const draftAll  = await stockOrderRepo.list({ status: 'Draft' });
+    expect(draftAll).toHaveLength(2);
+    const draftTimur = await stockOrderRepo.list({ status: 'Draft', role: 'driver', driverName: 'Timur' });
+    expect(draftTimur).toHaveLength(1);
+    expect(draftTimur[0]['Stock Order ID']).toBe('PO-A');
+  });
+
+  it('listByIds() accepts mixed recXXX/uuid arrays', async () => {
+    const [row1] = await harness.db.insert(stockOrders).values({
+      airtableId: 'recMIX1', poNumber: 'PO-1', createdDate: '2026-05-08',
+    }).returning();
+    const [row2] = await harness.db.insert(stockOrders).values({
+      poNumber: 'PO-2', createdDate: '2026-05-08',
+    }).returning();
+    const found = await stockOrderRepo.listByIds(['recMIX1', row2.id]);
+    expect(found).toHaveLength(2);
+  });
+});
+
+describe('stockOrderRepo line CRUD', () => {
+  it('CASCADE deletes lines when PO is deleted', async () => {
+    const po = await stockOrderRepo.create({ 'Stock Order ID': 'PO-CD', 'Created Date': '2026-05-08' });
+    await stockOrderRepo.createLine({
+      'Stock Orders':    [po._pgId],
+      'Flower Name':     'Rose',
+      'Quantity Needed': 25,
+    });
+    let lines = await stockOrderRepo.getLinesByPoId(po._pgId);
+    expect(lines).toHaveLength(1);
+
+    await stockOrderRepo.deleteById(po._pgId);
+    lines = await harness.db.select().from(stockOrderLines).where(eq(stockOrderLines.poId, po._pgId));
+    expect(lines).toHaveLength(0);
+  });
+
+  it('Stock Item link routes to stock_id (uuid) or stock_airtable_id (recXXX)', async () => {
+    const [s] = await harness.db.insert(stock).values({
+      displayName: 'Rose', currentQuantity: 10, active: true,
+    }).returning();
+
+    const po = await stockOrderRepo.create({ 'Stock Order ID': 'PO-S', 'Created Date': '2026-05-08' });
+    const line1 = await stockOrderRepo.createLine({
+      'Stock Orders': [po._pgId], 'Stock Item': [s.id], 'Flower Name': 'Rose',
+    });
+    const line2 = await stockOrderRepo.createLine({
+      'Stock Orders': [po._pgId], 'Stock Item': ['recXYZ789'], 'Flower Name': 'Tulip',
+    });
+
+    const [r1] = await harness.db.select().from(stockOrderLines).where(eq(stockOrderLines.id, line1._pgId));
+    const [r2] = await harness.db.select().from(stockOrderLines).where(eq(stockOrderLines.id, line2._pgId));
+    expect(r1.stockId).toBe(s.id);
+    expect(r1.stockAirtableId).toBeNull();
+    expect(r2.stockAirtableId).toBe('recXYZ789');
+    expect(r2.stockId).toBeNull();
+  });
+
+  it('updateLine maps Alt * fields to substitute_* columns', async () => {
+    const po = await stockOrderRepo.create({ 'Stock Order ID': 'PO-A', 'Created Date': '2026-05-08' });
+    const line = await stockOrderRepo.createLine({
+      'Stock Orders': [po._pgId], 'Flower Name': 'Rose',
+    });
+    await stockOrderRepo.updateLine(line._pgId, {
+      'Alt Flower Name':    'Pink Rose',
+      'Alt Cost':           4.5,
+      'Alt Quantity Found': 20,
+      'Alt Supplier':       'Market B',
+    });
+    const [r] = await harness.db.select().from(stockOrderLines).where(eq(stockOrderLines.id, line._pgId));
+    expect(r.substituteFlowerName).toBe('Pink Rose');
+    expect(Number(r.substituteCost)).toBe(4.5);
+    expect(r.substituteQuantityFound).toBe(20);
+    expect(r.substituteSupplier).toBe('Market B');
+  });
+
+  it('lineToWire reads substitute_* back as Alt * for API surface', async () => {
+    const po = await stockOrderRepo.create({ 'Stock Order ID': 'PO-W', 'Created Date': '2026-05-08' });
+    const line = await stockOrderRepo.createLine({
+      'Stock Orders':       [po._pgId],
+      'Flower Name':        'Rose',
+      'Alt Flower Name':    'Pink Rose',
+      'Alt Cost':           4.5,
+      'Alt Quantity Found': 20,
+    });
+    expect(line['Alt Flower Name']).toBe('Pink Rose');
+    expect(line['Alt Cost']).toBe(4.5);
+    expect(line['Alt Quantity Found']).toBe(20);
+  });
+
+  it('getLinesForPos returns Map<pgUuid, line[]>', async () => {
+    const po1 = await stockOrderRepo.create({ 'Stock Order ID': 'PO-M1', 'Created Date': '2026-05-08' });
+    const po2 = await stockOrderRepo.create({ 'Stock Order ID': 'PO-M2', 'Created Date': '2026-05-08' });
+    await stockOrderRepo.createLine({ 'Stock Orders': [po1._pgId], 'Flower Name': 'A', 'Quantity Needed': 1 });
+    await stockOrderRepo.createLine({ 'Stock Orders': [po1._pgId], 'Flower Name': 'B', 'Quantity Needed': 2 });
+    await stockOrderRepo.createLine({ 'Stock Orders': [po2._pgId], 'Flower Name': 'C', 'Quantity Needed': 3 });
+
+    const map = await stockOrderRepo.getLinesForPos([po1._pgId, po2._pgId]);
+    expect(map.get(po1._pgId)).toHaveLength(2);
+    expect(map.get(po2._pgId)).toHaveLength(1);
+  });
+
+  it('getLinesByPoId accepts recXXX or uuid', async () => {
+    const [row] = await harness.db.insert(stockOrders).values({
+      airtableId: 'recPO_LINES', poNumber: 'PO-L', createdDate: '2026-05-08',
+    }).returning();
+    await stockOrderRepo.createLine({
+      'Stock Orders': [row.id], 'Flower Name': 'Lily', 'Quantity Needed': 5,
+    });
+
+    const byAt = await stockOrderRepo.getLinesByPoId('recPO_LINES');
+    expect(byAt).toHaveLength(1);
+    const byUuid = await stockOrderRepo.getLinesByPoId(row.id);
+    expect(byUuid).toHaveLength(1);
+  });
+});
+
+describe('write-off retry idempotency (T9 review carry-over — captures pre-existing gap)', () => {
+  // The PO evaluate flow logs write-offs into stock_loss_log via fire-and-forget
+  // promises with NO marker-based skip guard. On EVAL_ERROR retry, write-offs
+  // re-run — duplicating loss rows. ADR-0003 marker idempotency was extended
+  // to receives (stock_purchases) only.
+  //
+  // This test documents the gap. Fixing it requires adding a marker to
+  // stockLossRepo.create + a lossMarkerExists analog. Tracked in BACKLOG.
+  it.todo('write-off should be idempotent on PO evaluate retry — pre-existing gap, see BACKLOG');
+});

--- a/backend/src/db/migrations/0011_phase7_stock_orders_premade.sql
+++ b/backend/src/db/migrations/0011_phase7_stock_orders_premade.sql
@@ -1,0 +1,90 @@
+CREATE TABLE IF NOT EXISTS stock_orders (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  airtable_id        TEXT,
+  po_number          TEXT NOT NULL DEFAULT '',
+  status             TEXT NOT NULL DEFAULT 'Draft',
+  created_date       TEXT NOT NULL DEFAULT '',
+  assigned_driver    TEXT NOT NULL DEFAULT '',
+  planned_date       TEXT,
+  notes              TEXT NOT NULL DEFAULT '',
+  supplier_payments  TEXT NOT NULL DEFAULT '',
+  driver_payment     TEXT NOT NULL DEFAULT '',
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS stock_orders_airtable_id_idx
+  ON stock_orders (airtable_id) WHERE airtable_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS stock_orders_po_number_idx
+  ON stock_orders (po_number) WHERE po_number <> '';
+CREATE INDEX IF NOT EXISTS stock_orders_status_idx        ON stock_orders (status);
+CREATE INDEX IF NOT EXISTS stock_orders_created_date_idx  ON stock_orders (created_date);
+CREATE INDEX IF NOT EXISTS stock_orders_driver_idx        ON stock_orders (assigned_driver) WHERE assigned_driver <> '';
+
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS stock_order_lines (
+  id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  airtable_id                 TEXT,
+  po_id                       UUID NOT NULL REFERENCES stock_orders(id) ON DELETE CASCADE,
+  stock_id                    UUID REFERENCES stock(id),
+  stock_airtable_id           TEXT,
+  flower_name                 TEXT NOT NULL DEFAULT '',
+  quantity_needed             INTEGER NOT NULL DEFAULT 0,
+  quantity_found              INTEGER NOT NULL DEFAULT 0,
+  lot_size                    INTEGER NOT NULL DEFAULT 0,
+  driver_status               TEXT NOT NULL DEFAULT 'Pending',
+  supplier                    TEXT NOT NULL DEFAULT '',
+  cost_price                  NUMERIC(10,4) NOT NULL DEFAULT 0,
+  sell_price                  NUMERIC(10,4) NOT NULL DEFAULT 0,
+  farmer                      TEXT NOT NULL DEFAULT '',
+  notes                       TEXT NOT NULL DEFAULT '',
+  substitute_flower_name      TEXT NOT NULL DEFAULT '',
+  substitute_status           TEXT NOT NULL DEFAULT '',
+  substitute_quantity_found   INTEGER NOT NULL DEFAULT 0,
+  substitute_cost             NUMERIC(10,4) NOT NULL DEFAULT 0,
+  substitute_supplier         TEXT NOT NULL DEFAULT '',
+  quantity_accepted           INTEGER NOT NULL DEFAULT 0,
+  write_off_qty               INTEGER NOT NULL DEFAULT 0,
+  eval_status                 TEXT NOT NULL DEFAULT '',
+  created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS stock_order_lines_airtable_id_idx
+  ON stock_order_lines (airtable_id) WHERE airtable_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS stock_order_lines_po_id_idx    ON stock_order_lines (po_id);
+CREATE INDEX IF NOT EXISTS stock_order_lines_stock_id_idx ON stock_order_lines (stock_id);
+
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS premade_bouquets (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  airtable_id     TEXT,
+  name            TEXT NOT NULL DEFAULT '',
+  created_by      TEXT NOT NULL DEFAULT '',
+  price_override  NUMERIC(10,2),
+  notes           TEXT NOT NULL DEFAULT '',
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS premade_bouquets_airtable_id_idx
+  ON premade_bouquets (airtable_id) WHERE airtable_id IS NOT NULL;
+
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS premade_bouquet_lines (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  airtable_id           TEXT,
+  bouquet_id            UUID NOT NULL REFERENCES premade_bouquets(id) ON DELETE CASCADE,
+  stock_id              UUID REFERENCES stock(id),
+  stock_airtable_id     TEXT,
+  flower_name           TEXT NOT NULL DEFAULT '',
+  quantity              INTEGER NOT NULL DEFAULT 0,
+  cost_price_per_unit   NUMERIC(10,4) NOT NULL DEFAULT 0,
+  sell_price_per_unit   NUMERIC(10,4) NOT NULL DEFAULT 0,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS premade_bouquet_lines_airtable_id_idx
+  ON premade_bouquet_lines (airtable_id) WHERE airtable_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS premade_bouquet_lines_bouquet_id_idx ON premade_bouquet_lines (bouquet_id);
+CREATE INDEX IF NOT EXISTS premade_bouquet_lines_stock_id_idx   ON premade_bouquet_lines (stock_id);

--- a/backend/src/db/schema.js
+++ b/backend/src/db/schema.js
@@ -494,7 +494,7 @@ export const stockOrders = pgTable('stock_orders', {
   poNumberIdx:    uniqueIndex('stock_orders_po_number_idx').on(t.poNumber).where(sql`${t.poNumber} <> ''`),
   statusIdx:      index('stock_orders_status_idx').on(t.status),
   createdDateIdx: index('stock_orders_created_date_idx').on(t.createdDate),
-  driverIdx:      index('stock_orders_driver_idx').on(t.assignedDriver),
+  driverIdx:      index('stock_orders_driver_idx').on(t.assignedDriver).where(sql`${t.assignedDriver} <> ''`),
 }));
 
 export const stockOrderLines = pgTable('stock_order_lines', {

--- a/backend/src/db/schema.js
+++ b/backend/src/db/schema.js
@@ -9,7 +9,7 @@ import {
   pgTable, text, timestamp, jsonb, bigserial, index, uuid,
   integer, numeric, boolean, date, uniqueIndex,
 } from 'drizzle-orm/pg-core';
-import { isNotNull, and } from 'drizzle-orm';
+import { isNotNull, and, sql } from 'drizzle-orm';
 
 // Single-row-per-key tracking. Phase 3+ writes rows like
 //   ('stock_cutover_at', '2026-05-...') when entity cutovers happen, so
@@ -474,4 +474,86 @@ export const productConfig = pgTable('product_config', {
   wixPairIdx:  uniqueIndex('product_config_wix_pair_idx').on(t.wixProductId, t.wixVariantId).where(and(isNotNull(t.wixProductId), isNotNull(t.wixVariantId))),
   productIdx:  index('product_config_wix_product_id_idx').on(t.wixProductId),
   activeIdx:   index('product_config_active_idx').on(t.active),
+}));
+
+// ── Phase 7: Stock Orders ──
+export const stockOrders = pgTable('stock_orders', {
+  id:                uuid('id').primaryKey().defaultRandom(),
+  airtableId:        text('airtable_id'),
+  poNumber:          text('po_number').notNull().default(''),
+  status:            text('status').notNull().default('Draft'),
+  createdDate:       text('created_date').notNull().default(''),
+  assignedDriver:    text('assigned_driver').notNull().default(''),
+  plannedDate:       text('planned_date'),
+  notes:             text('notes').notNull().default(''),
+  supplierPayments:  text('supplier_payments').notNull().default(''),
+  driverPayment:     text('driver_payment').notNull().default(''),
+  createdAt:         timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => ({
+  airtableIdx:    uniqueIndex('stock_orders_airtable_id_idx').on(t.airtableId).where(isNotNull(t.airtableId)),
+  poNumberIdx:    uniqueIndex('stock_orders_po_number_idx').on(t.poNumber).where(sql`${t.poNumber} <> ''`),
+  statusIdx:      index('stock_orders_status_idx').on(t.status),
+  createdDateIdx: index('stock_orders_created_date_idx').on(t.createdDate),
+  driverIdx:      index('stock_orders_driver_idx').on(t.assignedDriver),
+}));
+
+export const stockOrderLines = pgTable('stock_order_lines', {
+  id:                       uuid('id').primaryKey().defaultRandom(),
+  airtableId:               text('airtable_id'),
+  poId:                     uuid('po_id').notNull().references(() => stockOrders.id, { onDelete: 'cascade' }),
+  stockId:                  uuid('stock_id').references(() => stock.id),
+  stockAirtableId:          text('stock_airtable_id'),
+  flowerName:               text('flower_name').notNull().default(''),
+  quantityNeeded:           integer('quantity_needed').notNull().default(0),
+  quantityFound:            integer('quantity_found').notNull().default(0),
+  lotSize:                  integer('lot_size').notNull().default(0),
+  driverStatus:             text('driver_status').notNull().default('Pending'),
+  supplier:                 text('supplier').notNull().default(''),
+  costPrice:                numeric('cost_price', { precision: 10, scale: 4 }).notNull().default('0'),
+  sellPrice:                numeric('sell_price', { precision: 10, scale: 4 }).notNull().default('0'),
+  farmer:                   text('farmer').notNull().default(''),
+  notes:                    text('notes').notNull().default(''),
+  substituteFlowerName:     text('substitute_flower_name').notNull().default(''),
+  substituteStatus:         text('substitute_status').notNull().default(''),
+  substituteQuantityFound:  integer('substitute_quantity_found').notNull().default(0),
+  substituteCost:           numeric('substitute_cost', { precision: 10, scale: 4 }).notNull().default('0'),
+  substituteSupplier:       text('substitute_supplier').notNull().default(''),
+  quantityAccepted:         integer('quantity_accepted').notNull().default(0),
+  writeOffQty:              integer('write_off_qty').notNull().default(0),
+  evalStatus:               text('eval_status').notNull().default(''),
+  createdAt:                timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => ({
+  airtableIdx: uniqueIndex('stock_order_lines_airtable_id_idx').on(t.airtableId).where(isNotNull(t.airtableId)),
+  poIdx:       index('stock_order_lines_po_id_idx').on(t.poId),
+  stockIdx:    index('stock_order_lines_stock_id_idx').on(t.stockId),
+}));
+
+// ── Phase 7: Premade Bouquets ──
+export const premadeBouquets = pgTable('premade_bouquets', {
+  id:             uuid('id').primaryKey().defaultRandom(),
+  airtableId:     text('airtable_id'),
+  name:           text('name').notNull().default(''),
+  createdBy:      text('created_by').notNull().default(''),
+  priceOverride:  numeric('price_override', { precision: 10, scale: 2 }),
+  notes:          text('notes').notNull().default(''),
+  createdAt:      timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => ({
+  airtableIdx: uniqueIndex('premade_bouquets_airtable_id_idx').on(t.airtableId).where(isNotNull(t.airtableId)),
+}));
+
+export const premadeBouquetLines = pgTable('premade_bouquet_lines', {
+  id:                  uuid('id').primaryKey().defaultRandom(),
+  airtableId:          text('airtable_id'),
+  bouquetId:           uuid('bouquet_id').notNull().references(() => premadeBouquets.id, { onDelete: 'cascade' }),
+  stockId:             uuid('stock_id').references(() => stock.id),
+  stockAirtableId:     text('stock_airtable_id'),
+  flowerName:          text('flower_name').notNull().default(''),
+  quantity:            integer('quantity').notNull().default(0),
+  costPricePerUnit:    numeric('cost_price_per_unit', { precision: 10, scale: 4 }).notNull().default('0'),
+  sellPricePerUnit:    numeric('sell_price_per_unit', { precision: 10, scale: 4 }).notNull().default('0'),
+  createdAt:           timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+}, (t) => ({
+  airtableIdx: uniqueIndex('premade_bouquet_lines_airtable_id_idx').on(t.airtableId).where(isNotNull(t.airtableId)),
+  bouquetIdx:  index('premade_bouquet_lines_bouquet_id_idx').on(t.bouquetId),
+  stockIdx:    index('premade_bouquet_lines_stock_id_idx').on(t.stockId),
 }));

--- a/backend/src/repos/orderRepo.js
+++ b/backend/src/repos/orderRepo.js
@@ -1267,6 +1267,49 @@ export async function runParityCheck() {
   };
 }
 
+// Returns aggregated stock-item line data for non-cancelled orders within
+// [dateFrom, dateTo] (YYYY-MM-DD). Used by GET /stock/velocity to compute
+// days-of-supply. Postgres-only — replaces a frozen-Airtable read path.
+export async function getLinesForVelocity(dateFrom, dateTo) {
+  if (!db) throw new Error('orderRepo.getLinesForVelocity: no database configured');
+  const rows = await db
+    .select({
+      stockItemId: orderLines.stockItemId,
+      quantity:    orderLines.quantity,
+    })
+    .from(orderLines)
+    .innerJoin(orders, eq(orderLines.orderId, orders.id))
+    .where(and(
+      isNull(orders.deletedAt),
+      isNull(orderLines.deletedAt),
+      gte(orders.orderDate, dateFrom),
+      lte(orders.orderDate, dateTo),
+      sql`${orders.status} != ${ORDER_STATUS.CANCELLED}`,
+    ));
+  return rows;
+}
+
+// Returns line records for a list of order IDs (UUIDs). Used by
+// orderService.findOrdersNeedingSubstitution() to detect which orders
+// reference an originalStockId after a Substitute is received.
+export async function getLinesForOrders(orderIds) {
+  if (!orderIds?.length || !db) return [];
+  const rows = await db
+    .select({
+      id:          orderLines.id,
+      orderId:     orderLines.orderId,
+      stockItemId: orderLines.stockItemId,
+      quantity:    orderLines.quantity,
+      flowerName:  orderLines.flowerName,
+    })
+    .from(orderLines)
+    .where(and(
+      isNull(orderLines.deletedAt),
+      inArray(orderLines.orderId, orderIds),
+    ));
+  return rows;
+}
+
 // ── Internal exports for tests ──
 export const _internal = {
   ORDER_WRITE_ALLOWED,

--- a/backend/src/repos/premadeBouquetRepo.js
+++ b/backend/src/repos/premadeBouquetRepo.js
@@ -1,0 +1,198 @@
+// Premade Bouquet repository — persistence boundary for Premade Bouquets + their lines.
+// Phase 7. Postgres-only. Same dual-lookup + wire-format pattern as stockOrderRepo.
+
+import { db } from '../db/index.js';
+import { premadeBouquets, premadeBouquetLines } from '../db/schema.js';
+import { eq, asc, desc, inArray } from 'drizzle-orm';
+
+// ── Wire ↔ PG ──
+
+export function bouquetToWire(row) {
+  if (!row) return null;
+  return {
+    id:               row.airtableId || row.id,
+    _pgId:            row.id,
+    Name:             row.name,
+    'Created By':     row.createdBy,
+    'Price Override': row.priceOverride != null ? Number(row.priceOverride) : null,
+    Notes:            row.notes,
+    'Created At':     row.createdAt instanceof Date ? row.createdAt.toISOString() : row.createdAt,
+    Lines:            [],
+  };
+}
+
+function bouquetToPg(fields) {
+  const out = {};
+  if ('Name' in fields)            out.name          = (fields.Name || '').trim();
+  if ('Created By' in fields)      out.createdBy     = fields['Created By'] || '';
+  if ('Price Override' in fields)  out.priceOverride = fields['Price Override'] != null ? String(fields['Price Override']) : null;
+  if ('Notes' in fields)           out.notes         = fields.Notes || '';
+  return out;
+}
+
+export function lineToWire(row) {
+  if (!row) return null;
+  return {
+    id:                    row.airtableId || row.id,
+    _pgId:                 row.id,
+    'Premade Bouquets':    [row.bouquetId],
+    'Stock Item':          row.stockAirtableId
+                              ? [row.stockAirtableId]
+                              : row.stockId ? [row.stockId] : [],
+    'Flower Name':         row.flowerName,
+    Quantity:              row.quantity,
+    'Cost Price Per Unit': Number(row.costPricePerUnit),
+    'Sell Price Per Unit': Number(row.sellPricePerUnit),
+  };
+}
+
+function lineToPg(fields) {
+  const out = {};
+  if ('Flower Name' in fields)         out.flowerName        = fields['Flower Name'] || '';
+  if ('Quantity' in fields)            out.quantity          = Number(fields.Quantity) || 0;
+  if ('Cost Price Per Unit' in fields) out.costPricePerUnit  = String(Number(fields['Cost Price Per Unit']) || 0);
+  if ('Sell Price Per Unit' in fields) out.sellPricePerUnit  = String(Number(fields['Sell Price Per Unit']) || 0);
+  if ('Stock Item' in fields) {
+    const raw = Array.isArray(fields['Stock Item']) ? fields['Stock Item'][0] : null;
+    out.stockId = null;
+    out.stockAirtableId = null;
+    if (raw) {
+      if (raw.startsWith('rec')) out.stockAirtableId = raw;
+      else                       out.stockId         = raw;
+    }
+  }
+  return out;
+}
+
+async function findBouquetPgByAirtableOrUuid(id) {
+  if (!id || !db) return null;
+  const isAtId = typeof id === 'string' && id.startsWith('rec');
+  const where = isAtId ? eq(premadeBouquets.airtableId, id) : eq(premadeBouquets.id, id);
+  const [row] = await db.select().from(premadeBouquets).where(where).limit(1);
+  return row ?? null;
+}
+
+async function findLinePgByAirtableOrUuid(id) {
+  if (!id || !db) return null;
+  const isAtId = typeof id === 'string' && id.startsWith('rec');
+  const where = isAtId ? eq(premadeBouquetLines.airtableId, id) : eq(premadeBouquetLines.id, id);
+  const [row] = await db.select().from(premadeBouquetLines).where(where).limit(1);
+  return row ?? null;
+}
+
+// ── Bouquet CRUD ──
+
+export async function list() {
+  if (!db) return [];
+  const rows = await db.select().from(premadeBouquets).orderBy(desc(premadeBouquets.createdAt));
+  return rows.map(bouquetToWire);
+}
+
+export async function getById(id) {
+  const row = await findBouquetPgByAirtableOrUuid(id);
+  if (!row) {
+    const err = new Error(`Premade bouquet ${id} not found`);
+    err.statusCode = 404;
+    throw err;
+  }
+  return bouquetToWire(row);
+}
+
+export async function create(fields) {
+  if (!db) throw new Error('premadeBouquetRepo.create: no DATABASE_URL configured');
+  const values = bouquetToPg(fields);
+  if (!values.name) throw new Error('premadeBouquetRepo.create: name required');
+  const [row] = await db.insert(premadeBouquets).values(values).returning();
+  return bouquetToWire(row);
+}
+
+export async function update(id, fields) {
+  const row = await findBouquetPgByAirtableOrUuid(id);
+  if (!row) {
+    const err = new Error(`Premade bouquet ${id} not found`);
+    err.statusCode = 404;
+    throw err;
+  }
+  const patch = bouquetToPg(fields);
+  if (Object.keys(patch).length === 0) return bouquetToWire(row);
+  const [updated] = await db.update(premadeBouquets).set(patch)
+    .where(eq(premadeBouquets.id, row.id)).returning();
+  return bouquetToWire(updated);
+}
+
+export async function deleteById(id) {
+  const row = await findBouquetPgByAirtableOrUuid(id);
+  if (!row) return;
+  await db.delete(premadeBouquets).where(eq(premadeBouquets.id, row.id));
+  // CASCADE deletes lines.
+}
+
+// ── Line CRUD ──
+
+export async function createLine(fields) {
+  if (!db) throw new Error('premadeBouquetRepo.createLine: no DATABASE_URL configured');
+  const ref = Array.isArray(fields['Premade Bouquets']) ? fields['Premade Bouquets'][0] : null;
+  if (!ref) throw new Error('createLine: missing Premade Bouquets link');
+  const bouquet = await findBouquetPgByAirtableOrUuid(ref);
+  if (!bouquet) throw new Error(`createLine: bouquet ${ref} not found`);
+  const values = { bouquetId: bouquet.id, ...lineToPg(fields) };
+  const [row] = await db.insert(premadeBouquetLines).values(values).returning();
+  return lineToWire(row);
+}
+
+export async function getLineById(id) {
+  const row = await findLinePgByAirtableOrUuid(id);
+  if (!row) {
+    const err = new Error(`Premade bouquet line ${id} not found`);
+    err.statusCode = 404;
+    throw err;
+  }
+  return lineToWire(row);
+}
+
+export async function getLinesByBouquetId(bouquetId) {
+  if (!db) return [];
+  const isAtId = typeof bouquetId === 'string' && bouquetId.startsWith('rec');
+  let pgId = bouquetId;
+  if (isAtId) {
+    const b = await findBouquetPgByAirtableOrUuid(bouquetId);
+    pgId = b?.id;
+    if (!pgId) return [];
+  }
+  const rows = await db.select().from(premadeBouquetLines)
+    .where(eq(premadeBouquetLines.bouquetId, pgId))
+    .orderBy(asc(premadeBouquetLines.createdAt));
+  return rows.map(lineToWire);
+}
+
+// Used by /stock/:id PATCH cascade and orderService.createOrder price-sync.
+// Returns all lines whose stock matches the given id (recXXX or uuid).
+export async function getLinesByStockId(stockId) {
+  if (!stockId || !db) return [];
+  const isAtId = typeof stockId === 'string' && stockId.startsWith('rec');
+  const rows = await db.select().from(premadeBouquetLines)
+    .where(isAtId
+      ? eq(premadeBouquetLines.stockAirtableId, stockId)
+      : eq(premadeBouquetLines.stockId, stockId));
+  return rows.map(lineToWire);
+}
+
+export async function updateLine(id, fields) {
+  const row = await findLinePgByAirtableOrUuid(id);
+  if (!row) {
+    const err = new Error(`Premade bouquet line ${id} not found`);
+    err.statusCode = 404;
+    throw err;
+  }
+  const patch = lineToPg(fields);
+  if (Object.keys(patch).length === 0) return lineToWire(row);
+  const [updated] = await db.update(premadeBouquetLines).set(patch)
+    .where(eq(premadeBouquetLines.id, row.id)).returning();
+  return lineToWire(updated);
+}
+
+export async function deleteLineById(id) {
+  const row = await findLinePgByAirtableOrUuid(id);
+  if (!row) return;
+  await db.delete(premadeBouquetLines).where(eq(premadeBouquetLines.id, row.id));
+}

--- a/backend/src/repos/stockOrderRepo.js
+++ b/backend/src/repos/stockOrderRepo.js
@@ -1,0 +1,140 @@
+// Stock Order repository — persistence boundary for Stock Orders + their lines.
+// Phase 7 of the SQL migration. Postgres-only — no shadow window, direct cutover.
+//
+// Wire format: routes/services pass Airtable-shaped fields ({ Status, 'Stock Order ID', ... })
+// and receive the same shape back. The repo translates to/from snake_case PG columns.
+//
+// id semantics: returned `id` is `airtableId || uuid` so callers carrying recXXX
+// IDs from before the cutover keep working. `_pgId` carries the UUID for new
+// callers that want it. getById() / updateLine() / deleteLineById() all accept
+// either form and disambiguate by the 'rec' prefix.
+
+import { db } from '../db/index.js';
+import { stockOrders, stockOrderLines } from '../db/schema.js';
+import { eq, and, desc, asc, sql, inArray } from 'drizzle-orm';
+
+// ── Wire ↔ PG mapping ──
+
+export function poToWire(row) {
+  if (!row) return null;
+  return {
+    id:                  row.airtableId || row.id,
+    _pgId:               row.id,
+    Status:              row.status,
+    'Stock Order ID':    row.poNumber,
+    'Created Date':      row.createdDate,
+    'Assigned Driver':   row.assignedDriver,
+    'Planned Date':      row.plannedDate || null,
+    Notes:               row.notes,
+    'Supplier Payments': row.supplierPayments,
+    'Driver Payment':    row.driverPayment,
+    'Order Lines':       [],
+  };
+}
+
+function poToPg(fields) {
+  const out = {};
+  if ('Status' in fields)            out.status           = fields.Status || 'Draft';
+  if ('Stock Order ID' in fields)    out.poNumber         = fields['Stock Order ID'] || '';
+  if ('Created Date' in fields)      out.createdDate      = fields['Created Date'] || '';
+  if ('Assigned Driver' in fields)   out.assignedDriver   = fields['Assigned Driver'] || '';
+  if ('Planned Date' in fields)      out.plannedDate      = fields['Planned Date'] || null;
+  if ('Notes' in fields)             out.notes            = fields.Notes || '';
+  if ('Supplier Payments' in fields) out.supplierPayments = fields['Supplier Payments'] || '';
+  if ('Driver Payment' in fields)    out.driverPayment    = fields['Driver Payment'] || '';
+  return out;
+}
+
+async function findPgByAirtableOrUuid(id) {
+  if (!id || !db) return null;
+  const isAtId = typeof id === 'string' && id.startsWith('rec');
+  const where = isAtId ? eq(stockOrders.airtableId, id) : eq(stockOrders.id, id);
+  const [row] = await db.select().from(stockOrders).where(where).limit(1);
+  return row ?? null;
+}
+
+// ── Header CRUD ──
+
+export async function list({ status, role, driverName } = {}) {
+  if (!db) throw new Error('stockOrderRepo.list: no DATABASE_URL configured');
+  const filters = [];
+  if (status) filters.push(eq(stockOrders.status, status));
+  if (role === 'driver' && driverName) {
+    filters.push(eq(stockOrders.assignedDriver, driverName));
+  }
+  const rows = await db.select().from(stockOrders)
+    .where(filters.length ? and(...filters) : undefined)
+    .orderBy(desc(stockOrders.createdAt));
+  return rows.map(poToWire);
+}
+
+// Bulk fetch by airtableId or uuid — accepts mixed arrays.
+export async function listByIds(ids) {
+  if (!ids?.length || !db) return [];
+  const recs = ids.filter(x => typeof x === 'string' && x.startsWith('rec'));
+  const uuids = ids.filter(x => typeof x === 'string' && !x.startsWith('rec'));
+  const orParts = [];
+  if (recs.length)  orParts.push(inArray(stockOrders.airtableId, recs));
+  if (uuids.length) orParts.push(inArray(stockOrders.id, uuids));
+  if (!orParts.length) return [];
+  const where = orParts.length === 1 ? orParts[0] : sql`(${orParts[0]} OR ${orParts[1]})`;
+  const rows = await db.select().from(stockOrders).where(where);
+  return rows.map(poToWire);
+}
+
+export async function getById(id) {
+  const row = await findPgByAirtableOrUuid(id);
+  if (!row) {
+    const err = new Error(`Stock Order ${id} not found`);
+    err.statusCode = 404;
+    throw err;
+  }
+  return poToWire(row);
+}
+
+export async function create(fields) {
+  if (!db) throw new Error('stockOrderRepo.create: no DATABASE_URL configured');
+  const values = poToPg(fields);
+  if (!values.createdDate) values.createdDate = new Date().toISOString().split('T')[0];
+  const [row] = await db.insert(stockOrders).values(values).returning();
+  return poToWire(row);
+}
+
+export async function update(id, fields) {
+  const row = await findPgByAirtableOrUuid(id);
+  if (!row) {
+    const err = new Error(`Stock Order ${id} not found`);
+    err.statusCode = 404;
+    throw err;
+  }
+  const patch = poToPg(fields);
+  if (Object.keys(patch).length === 0) return poToWire(row);
+  const [updated] = await db.update(stockOrders).set(patch)
+    .where(eq(stockOrders.id, row.id)).returning();
+  return poToWire(updated);
+}
+
+export async function deleteById(id) {
+  const row = await findPgByAirtableOrUuid(id);
+  if (!row) return;
+  await db.delete(stockOrders).where(eq(stockOrders.id, row.id));
+  // ON DELETE CASCADE handles stock_order_lines.
+}
+
+// PO number sequence: MAX(N)+1 of existing PO-YYYYMMDD-N values for the date.
+// MAX-based (not COUNT-based) so backfilled historical POs that share today's
+// date don't corrupt the sequence for newly created POs.
+export async function nextPoSequence(date /* YYYY-MM-DD */) {
+  if (!db) throw new Error('stockOrderRepo.nextPoSequence: no DATABASE_URL configured');
+  const prefix = `PO-${date.replace(/-/g, '')}-`;
+  const rows = await db.select({ poNumber: stockOrders.poNumber })
+    .from(stockOrders)
+    .where(sql`${stockOrders.poNumber} LIKE ${prefix + '%'}`);
+  let maxN = 0;
+  for (const r of rows) {
+    const tail = r.poNumber.slice(prefix.length);
+    const n = parseInt(tail, 10);
+    if (!isNaN(n) && n > maxN) maxN = n;
+  }
+  return maxN + 1;
+}

--- a/backend/src/repos/stockOrderRepo.js
+++ b/backend/src/repos/stockOrderRepo.js
@@ -138,3 +138,159 @@ export async function nextPoSequence(date /* YYYY-MM-DD */) {
   }
   return maxN + 1;
 }
+
+// ── Line CRUD ──
+
+export function lineToWire(row) {
+  if (!row) return null;
+  return {
+    id:                    row.airtableId || row.id,
+    _pgId:                 row.id,
+    'Stock Orders':        [row.poId],
+    'Stock Item':          row.stockAirtableId
+                              ? [row.stockAirtableId]
+                              : row.stockId ? [row.stockId] : [],
+    'Flower Name':         row.flowerName,
+    'Quantity Needed':     row.quantityNeeded,
+    'Quantity Found':      row.quantityFound,
+    'Lot Size':            row.lotSize,
+    'Driver Status':       row.driverStatus,
+    Supplier:              row.supplier,
+    'Cost Price':          Number(row.costPrice),
+    'Sell Price':          Number(row.sellPrice),
+    Farmer:                row.farmer,
+    Notes:                 row.notes,
+    'Alt Flower Name':     row.substituteFlowerName,
+    'Alt Flower Status':   row.substituteStatus,
+    'Alt Quantity Found':  row.substituteQuantityFound,
+    'Alt Cost':            Number(row.substituteCost),
+    'Alt Supplier':        row.substituteSupplier,
+    'Quantity Accepted':   row.quantityAccepted,
+    'Write Off Qty':       row.writeOffQty,
+    'Eval Status':         row.evalStatus,
+  };
+}
+
+function lineToPg(fields) {
+  const out = {};
+  if ('Flower Name' in fields)         out.flowerName               = fields['Flower Name'] || '';
+  if ('Quantity Needed' in fields)     out.quantityNeeded           = Number(fields['Quantity Needed']) || 0;
+  if ('Quantity Found' in fields)      out.quantityFound            = Number(fields['Quantity Found']) || 0;
+  if ('Lot Size' in fields)            out.lotSize                  = Number(fields['Lot Size']) || 0;
+  if ('Driver Status' in fields)       out.driverStatus             = fields['Driver Status'] || 'Pending';
+  if ('Supplier' in fields)            out.supplier                 = fields.Supplier || '';
+  if ('Cost Price' in fields)          out.costPrice                = String(Number(fields['Cost Price']) || 0);
+  if ('Sell Price' in fields)          out.sellPrice                = String(Number(fields['Sell Price']) || 0);
+  if ('Farmer' in fields)              out.farmer                   = fields.Farmer || '';
+  if ('Notes' in fields)               out.notes                    = fields.Notes || '';
+  if ('Alt Flower Name' in fields)     out.substituteFlowerName     = fields['Alt Flower Name'] || '';
+  if ('Alt Flower Status' in fields)   out.substituteStatus         = fields['Alt Flower Status'] || '';
+  if ('Alt Quantity Found' in fields)  out.substituteQuantityFound  = Number(fields['Alt Quantity Found']) || 0;
+  if ('Alt Cost' in fields)            out.substituteCost           = String(Number(fields['Alt Cost']) || 0);
+  if ('Alt Supplier' in fields)        out.substituteSupplier       = fields['Alt Supplier'] || '';
+  if ('Quantity Accepted' in fields)   out.quantityAccepted         = Number(fields['Quantity Accepted']) || 0;
+  if ('Write Off Qty' in fields)       out.writeOffQty              = Number(fields['Write Off Qty']) || 0;
+  if ('Eval Status' in fields)         out.evalStatus               = fields['Eval Status'] || '';
+  if ('Stock Item' in fields) {
+    const raw = Array.isArray(fields['Stock Item']) ? fields['Stock Item'][0] : null;
+    out.stockId = null;
+    out.stockAirtableId = null;
+    if (raw) {
+      if (raw.startsWith('rec')) out.stockAirtableId = raw;
+      else                       out.stockId         = raw;
+    }
+  }
+  return out;
+}
+
+async function findLinePgByAirtableOrUuid(id) {
+  if (!id || !db) return null;
+  const isAtId = typeof id === 'string' && id.startsWith('rec');
+  const where = isAtId ? eq(stockOrderLines.airtableId, id) : eq(stockOrderLines.id, id);
+  const [row] = await db.select().from(stockOrderLines).where(where).limit(1);
+  return row ?? null;
+}
+
+export async function createLine(fields) {
+  if (!db) throw new Error('stockOrderRepo.createLine: no DATABASE_URL configured');
+  const poRef = Array.isArray(fields['Stock Orders']) ? fields['Stock Orders'][0] : null;
+  if (!poRef) throw new Error('createLine: missing Stock Orders link');
+  const po = await findPgByAirtableOrUuid(poRef);
+  if (!po) throw new Error(`createLine: PO ${poRef} not found`);
+  const values = { poId: po.id, ...lineToPg(fields) };
+  const [row] = await db.insert(stockOrderLines).values(values).returning();
+  return lineToWire(row);
+}
+
+export async function getLineById(id) {
+  const row = await findLinePgByAirtableOrUuid(id);
+  if (!row) {
+    const err = new Error(`Stock Order Line ${id} not found`);
+    err.statusCode = 404;
+    throw err;
+  }
+  return lineToWire(row);
+}
+
+export async function getLinesByPoId(poId) {
+  if (!db) return [];
+  const isAtId = typeof poId === 'string' && poId.startsWith('rec');
+  let pgPoId = poId;
+  if (isAtId) {
+    const po = await findPgByAirtableOrUuid(poId);
+    pgPoId = po?.id;
+    if (!pgPoId) return [];
+  }
+  const rows = await db.select().from(stockOrderLines)
+    .where(eq(stockOrderLines.poId, pgPoId))
+    .orderBy(asc(stockOrderLines.createdAt));
+  return rows.map(lineToWire);
+}
+
+// Bulk fetch lines across multiple POs — for /stock-orders?include=lines
+// and /pending-po. Returns lines grouped under each PO id.
+export async function getLinesForPos(poIds) {
+  if (!poIds?.length || !db) return new Map();
+  const recs = poIds.filter(x => typeof x === 'string' && x.startsWith('rec'));
+  const uuids = poIds.filter(x => typeof x === 'string' && !x.startsWith('rec'));
+
+  // Resolve recXXX → uuid
+  let pgIds = [...uuids];
+  if (recs.length) {
+    const resolved = await db.select({ id: stockOrders.id, airtableId: stockOrders.airtableId })
+      .from(stockOrders).where(inArray(stockOrders.airtableId, recs));
+    pgIds.push(...resolved.map(r => r.id));
+  }
+  if (!pgIds.length) return new Map();
+
+  const rows = await db.select().from(stockOrderLines)
+    .where(inArray(stockOrderLines.poId, pgIds))
+    .orderBy(asc(stockOrderLines.createdAt));
+
+  const byPo = new Map();
+  for (const r of rows) {
+    if (!byPo.has(r.poId)) byPo.set(r.poId, []);
+    byPo.get(r.poId).push(lineToWire(r));
+  }
+  return byPo;
+}
+
+export async function updateLine(id, fields) {
+  const row = await findLinePgByAirtableOrUuid(id);
+  if (!row) {
+    const err = new Error(`Stock Order Line ${id} not found`);
+    err.statusCode = 404;
+    throw err;
+  }
+  const patch = lineToPg(fields);
+  if (Object.keys(patch).length === 0) return lineToWire(row);
+  const [updated] = await db.update(stockOrderLines).set(patch)
+    .where(eq(stockOrderLines.id, row.id)).returning();
+  return lineToWire(updated);
+}
+
+export async function deleteLineById(id) {
+  const row = await findLinePgByAirtableOrUuid(id);
+  if (!row) return;
+  await db.delete(stockOrderLines).where(eq(stockOrderLines.id, row.id));
+}

--- a/backend/src/repos/stockOrderRepo.js
+++ b/backend/src/repos/stockOrderRepo.js
@@ -40,8 +40,8 @@ function poToPg(fields) {
   if ('Assigned Driver' in fields)   out.assignedDriver   = fields['Assigned Driver'] || '';
   if ('Planned Date' in fields)      out.plannedDate      = fields['Planned Date'] || null;
   if ('Notes' in fields)             out.notes            = fields.Notes || '';
-  if ('Supplier Payments' in fields) out.supplierPayments = fields['Supplier Payments'] || '';
-  if ('Driver Payment' in fields)    out.driverPayment    = fields['Driver Payment'] || '';
+  if ('Supplier Payments' in fields) out.supplierPayments = String(fields['Supplier Payments'] ?? '');
+  if ('Driver Payment' in fields)    out.driverPayment    = String(fields['Driver Payment'] ?? '');
   return out;
 }
 
@@ -133,8 +133,9 @@ export async function nextPoSequence(date /* YYYY-MM-DD */) {
   let maxN = 0;
   for (const r of rows) {
     const tail = r.poNumber.slice(prefix.length);
+    if (!/^\d+$/.test(tail)) continue;
     const n = parseInt(tail, 10);
-    if (!isNaN(n) && n > maxN) maxN = n;
+    if (n > maxN) maxN = n;
   }
   return maxN + 1;
 }

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -1,13 +1,13 @@
 import { Router } from 'express';
 import { authorize } from '../middleware/auth.js';
-import * as db from '../services/airtable.js';
 import * as stockRepo from '../repos/stockRepo.js';
 import * as orderRepo from '../repos/orderRepo.js';
 import * as customerRepo from '../repos/customerRepo.js';
 import * as stockLossRepo from '../repos/stockLossRepo.js';
-import { TABLES } from '../config/airtable.js';
+import * as stockPurchasesRepo from '../repos/stockPurchasesRepo.js';
+import * as stockOrderRepo from '../repos/stockOrderRepo.js';
+import * as premadeBouquetRepo from '../repos/premadeBouquetRepo.js';
 import { sanitizeFormulaValue } from '../utils/sanitize.js';
-import { listByIds } from '../utils/batchQuery.js';
 import { actorFromReq } from '../utils/actor.js';
 import { ORDER_STATUS, PO_STATUS, LOSS_REASON } from '../constants/statuses.js';
 
@@ -65,34 +65,14 @@ router.get('/velocity', async (req, res, next) => {
     const thirtyDaysAgo = new Date(Date.now() - 30 * 86400000).toISOString().split('T')[0];
     const today = new Date().toISOString().split('T')[0];
 
-    // Fetch non-cancelled orders in the last 30 days
-    const recentOrders = await db.list(TABLES.ORDERS, {
-      filterByFormula: `AND(NOT(IS_BEFORE({Order Date}, '${thirtyDaysAgo}')), NOT(IS_AFTER({Order Date}, '${today}')), {Status} != '${ORDER_STATUS.CANCELLED}')`,
-      fields: ['Order Lines'],
-    });
-
-    const lineIds = recentOrders.flatMap(o => o['Order Lines'] || []);
-
-    // Batch-fetch order lines (100 per request — Airtable formula length limit)
-    const lines = [];
-    for (let i = 0; i < lineIds.length; i += 100) {
-      const batch = lineIds.slice(i, i + 100);
-      if (batch.length === 0) continue;
-      const recs = await db.list(TABLES.ORDER_LINES, {
-        filterByFormula: `OR(${batch.map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-        fields: ['Stock Item', 'Quantity'],
-        maxRecords: 100,
-      });
-      lines.push(...recs);
-    }
+    const lines = await orderRepo.getLinesForVelocity(thirtyDaysAgo, today);
 
     // Sum qty sold per stock item over the 30-day window
     const qtySoldByStock = {};
     for (const line of lines) {
-      const stockId = line['Stock Item']?.[0];
-      if (stockId) {
-        qtySoldByStock[stockId] = (qtySoldByStock[stockId] || 0) + (line.Quantity || 0);
-      }
+      const id = line.stockItemId;
+      if (!id) continue;
+      qtySoldByStock[id] = (qtySoldByStock[id] || 0) + Number(line.quantity || 0);
     }
 
     // Build velocity map: stockId → { qtySold30d, avgDailyUsage }
@@ -120,51 +100,39 @@ router.get('/velocity', async (req, res, next) => {
 // an order needs more stems than are freely available.
 router.get('/premade-committed', async (req, res, next) => {
   try {
-    if (!TABLES.PREMADE_BOUQUETS || !TABLES.PREMADE_BOUQUET_LINES) {
-      return res.json({});
-    }
-    const bouquets = await db.list(TABLES.PREMADE_BOUQUETS, {
-      fields: ['Name', 'Lines'],
-      maxRecords: 500,
-    });
-    const allLineIds = bouquets.flatMap(b => b['Lines'] || []);
-    const allLines = allLineIds.length > 0
-      ? await listByIds(TABLES.PREMADE_BOUQUET_LINES, allLineIds, {
-          fields: ['Premade Bouquets', 'Stock Item', 'Quantity', 'Flower Name'],
-        })
-      : [];
-    const bouquetMap = {};
-    for (const b of bouquets) bouquetMap[b.id] = b;
-
-    // Keyed by whatever Stock Item ID Airtable stored (may be a phantom rec
-    // ID if the premade was created against a post-cutover UUID stock item).
+    const bouquets = await premadeBouquetRepo.list();
+    // Keyed by whatever Stock Item ID the line carries (may be a phantom rec
+    // ID from premade lines created in Airtable against a post-cutover UUID
+    // stock item — Airtable can't store UUIDs in linked fields).
     const rawCommitted = {};
-    for (const line of allLines) {
-      const stockId = line['Stock Item']?.[0];
-      if (!stockId) continue;
-      const qty = Number(line.Quantity || 0);
-      if (qty <= 0) continue;
-      const bouquetId = line['Premade Bouquets']?.[0];
-      const bouquet = bouquetId ? bouquetMap[bouquetId] : null;
-      if (!bouquet) continue;
-      if (!rawCommitted[stockId]) rawCommitted[stockId] = { qty: 0, bouquets: [], _flowerName: line['Flower Name'] || '' };
-      rawCommitted[stockId].qty += qty;
-      rawCommitted[stockId].bouquets.push({ bouquetId, name: bouquet.Name || '?', qty });
+    for (const bouquet of bouquets) {
+      const lines = await premadeBouquetRepo.getLinesByBouquetId(bouquet._pgId);
+      for (const line of lines) {
+        const stockId = line['Stock Item']?.[0];
+        if (!stockId) continue;
+        const qty = Number(line.Quantity || 0);
+        if (qty <= 0) continue;
+        if (!rawCommitted[stockId]) {
+          rawCommitted[stockId] = { qty: 0, bouquets: [], _flowerName: line['Flower Name'] || '' };
+        }
+        rawCommitted[stockId].qty += qty;
+        rawCommitted[stockId].bouquets.push({ bouquetId: bouquet.id, name: bouquet.Name || '?', qty });
+      }
     }
 
-    // Resolve each Airtable stock ID to the PG stock ID the frontend uses.
-    // Post-cutover stock items have UUID ids; premade lines created against them
-    // store phantom rec IDs in Airtable (Airtable can't store UUIDs in linked
-    // fields). For those, fall back to matching by flower name.
+    // Resolve each Stock Item ID to the PG stock ID the frontend uses. For
+    // phantom recXXX that don't resolve, fall back to matching by flower name.
     const allStock = await stockRepo.list({ pg: { includeInactive: true, includeEmpty: true } });
-    const stockById  = new Map(allStock.map(s => [s.id, s]));
+    const stockById   = new Map(allStock.map(s => [s.id, s]));
     const stockByName = new Map(allStock.map(s => [(s['Display Name'] || '').toLowerCase(), s]));
 
     const committed = {};
     for (const [atId, entry] of Object.entries(rawCommitted)) {
       const { _flowerName, ...data } = entry;
-      let pgId = stockById.has(atId) ? atId : stockByName.get((_flowerName || '').toLowerCase())?.id;
-      if (!pgId) continue; // can't resolve — omit rather than pollute the map
+      const pgId = stockById.has(atId)
+        ? atId
+        : stockByName.get((_flowerName || '').toLowerCase())?.id;
+      if (!pgId) continue;
       if (!committed[pgId]) committed[pgId] = { qty: 0, bouquets: [] };
       committed[pgId].qty += data.qty;
       committed[pgId].bouquets.push(...data.bouquets);
@@ -240,104 +208,89 @@ router.get('/committed', async (req, res, next) => {
 // Used by bouquet builders so florists can see what's coming and plan accordingly.
 router.get('/pending-po', async (req, res, next) => {
   try {
-    const pendingPOs = await db.list(TABLES.STOCK_ORDERS, {
-      filterByFormula: `OR({Status} = '${PO_STATUS.DRAFT}', {Status} = '${PO_STATUS.SENT}', {Status} = '${PO_STATUS.SHOPPING}', {Status} = '${PO_STATUS.REVIEWING}', {Status} = '${PO_STATUS.EVALUATING}', {Status} = '${PO_STATUS.EVAL_ERROR}')`,
-      fields: ['Status', 'Stock Order ID', 'Order Lines', 'Planned Date'],
-    });
+    const pendingStatuses = [
+      PO_STATUS.DRAFT, PO_STATUS.SENT, PO_STATUS.SHOPPING,
+      PO_STATUS.REVIEWING, PO_STATUS.EVALUATING, PO_STATUS.EVAL_ERROR,
+    ];
 
-    if (pendingPOs.length === 0) return res.json({});
+    // List all pending POs across statuses (small N — typically <30).
+    const allPendingPOs = [];
+    for (const s of pendingStatuses) {
+      const pos = await stockOrderRepo.list({ status: s });
+      allPendingPOs.push(...pos);
+    }
+    if (allPendingPOs.length === 0) return res.json({});
 
-    const allLineIds = pendingPOs.flatMap(po => po['Order Lines'] || []);
-    if (allLineIds.length === 0) return res.json({});
-
-    // Batch-fetch PO lines (Airtable formula length limit)
+    const poIds = allPendingPOs.map(po => po._pgId).filter(Boolean);
+    const linesByPo = await stockOrderRepo.getLinesForPos(poIds);
     const allLines = [];
-    const CHUNK = 100;
-    for (let i = 0; i < allLineIds.length; i += CHUNK) {
-      const chunk = allLineIds.slice(i, i + CHUNK);
-      const chunkLines = await db.list(TABLES.STOCK_ORDER_LINES, {
-        filterByFormula: `OR(${chunk.map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-        fields: ['Stock Item', 'Quantity Needed', 'Flower Name', 'Stock Orders', 'Lot Size', 'Cost Price', 'Sell Price', 'Supplier'],
-      });
-      allLines.push(...chunkLines);
+    for (const po of allPendingPOs) {
+      const ls = linesByPo.get(po._pgId) || [];
+      for (const l of ls) allLines.push({ ...l, _poPgId: po._pgId });
     }
 
-    // Build PO lookup
     const poMap = {};
-    for (const po of pendingPOs) {
-      poMap[po.id] = { id: po.id, number: po['Stock Order ID'] || '', status: po.Status, plannedDate: po['Planned Date'] || null };
+    for (const po of allPendingPOs) {
+      poMap[po._pgId] = {
+        id: po.id, number: po['Stock Order ID'] || '',
+        status: po.Status, plannedDate: po['Planned Date'] || null,
+      };
     }
 
-    // Collect unlinked flower names for batch resolution
-    const unlinked = []; // { lineIdx, flowerName }
-    for (let i = 0; i < allLines.length; i++) {
-      if (!allLines[i]['Stock Item']?.[0] && allLines[i]['Flower Name']) {
-        unlinked.push({ idx: i, name: allLines[i]['Flower Name'].trim() });
-      }
-    }
+    // Auto-resolve unlinked lines (Flower Name → Stock Item).
+    const unlinked = allLines
+      .map((l, idx) => ({ idx, line: l }))
+      .filter(({ line }) => !line['Stock Item']?.[0] && line['Flower Name']);
 
-    // Resolve unlinked lines by matching Flower Name → Stock Item Display Name.
-    // If no match found, auto-create a stock item with qty=0 so the flower
-    // appears in the bouquet picker. Also link the PO line for future consistency.
+    const nameToId = {};
     if (unlinked.length > 0) {
-      const uniqueNames = [...new Set(unlinked.map(u => u.name))];
-      const nameToId = {};
+      const uniqueNames = [...new Set(unlinked.map(u => u.line['Flower Name'].trim()))];
       for (const name of uniqueNames) {
         try {
-          const safe = sanitizeFormulaValue(name);
           const matches = await stockRepo.list({
-            filterByFormula: `AND({Display Name} = '${safe}', {Active} = TRUE())`,
-            fields: ['Display Name', 'Current Cost Price', 'Current Sell Price'],
-            maxRecords: 1,
             pg: { active: true, includeEmpty: true, displayName: name },
+            maxRecords: 1,
           });
           if (matches.length > 0) {
             nameToId[name] = matches[0].id;
-            // Backfill missing prices on existing zero-qty items from PO line data
+            // Backfill missing prices on existing zero-qty items from PO line data.
             const existing = matches[0];
             if (!existing['Current Cost Price'] && !existing['Current Sell Price']) {
-              const poLine = allLines[unlinked.find(x => x.name === name)?.idx];
-              if (poLine && (Number(poLine['Cost Price']) || Number(poLine['Sell Price']))) {
+              const samplePoLine = unlinked.find(x => x.line['Flower Name']?.trim() === name)?.line;
+              if (samplePoLine && (Number(samplePoLine['Cost Price']) || Number(samplePoLine['Sell Price']))) {
                 stockRepo.update(existing.id, {
-                  'Current Cost Price': Number(poLine['Cost Price']) || 0,
-                  'Current Sell Price': Number(poLine['Sell Price']) || 0,
-                  ...(poLine.Supplier ? { Supplier: poLine.Supplier } : {}),
+                  'Current Cost Price': Number(samplePoLine['Cost Price']) || 0,
+                  'Current Sell Price': Number(samplePoLine['Sell Price']) || 0,
+                  ...(samplePoLine.Supplier ? { Supplier: samplePoLine.Supplier } : {}),
                 }, { actor: actorFromReq(req) }).catch(err =>
-                  console.error(`[STOCK] Price backfill failed for ${existing.id}:`, err.message)
-                );
+                  console.error(`[STOCK] Price backfill failed for ${existing.id}:`, err.message));
               }
             }
           } else {
             // Auto-create stock item so the flower shows up in pickers.
-            // Pull cost/sell from the PO line that triggered this.
-            const poLine = allLines[unlinked.find(x => x.name === name)?.idx];
+            const samplePoLine = unlinked.find(x => x.line['Flower Name']?.trim() === name)?.line;
             const created = await stockRepo.create({
-              'Display Name': name,
-              'Purchase Name': name,
-              'Current Quantity': 0,
-              'Current Cost Price': Number(poLine?.['Cost Price']) || 0,
-              'Current Sell Price': Number(poLine?.['Sell Price']) || 0,
-              Supplier: poLine?.Supplier || '',
-              Category: 'Other',
-              Active: true,
+              'Display Name':       name,
+              'Purchase Name':      name,
+              'Current Quantity':   0,
+              'Current Cost Price': Number(samplePoLine?.['Cost Price']) || 0,
+              'Current Sell Price': Number(samplePoLine?.['Sell Price']) || 0,
+              Supplier:             samplePoLine?.Supplier || '',
+              Category:             'Other',
+              Active:               true,
             }, { actor: actorFromReq(req) });
             nameToId[name] = created.id;
             console.log(`[STOCK] Auto-created "${name}" (${created.id}) from pending PO line`);
           }
         } catch { /* skip */ }
       }
-      // Link resolved/created stock items back to PO lines (fire-and-forget)
-      // Stays on direct db.update — this writes to STOCK_ORDER_LINES, not the
-      // stock table itself, so it isn't part of the Phase 3 cutover.
+      // Persist the auto-link via stockOrderRepo (was direct Airtable update).
       for (const u of unlinked) {
-        if (nameToId[u.name]) {
-          allLines[u.idx]._resolvedStockId = nameToId[u.name];
-          const lineId = allLines[u.idx].id;
-          if (lineId) {
-            db.update(TABLES.STOCK_ORDER_LINES, lineId, { 'Stock Item': [nameToId[u.name]] }).catch(err =>
-              console.error(`[STOCK] Failed to link PO line ${lineId} to stock ${nameToId[u.name]}:`, err.message)
-            );
-          }
+        const stockId = nameToId[u.line['Flower Name'].trim()];
+        if (stockId && u.line.id) {
+          allLines[u.idx]._resolvedStockId = stockId;
+          stockOrderRepo.updateLine(u.line.id, { 'Stock Item': [stockId] }).catch(err =>
+            console.error(`[STOCK] Failed to link PO line ${u.line.id} to stock ${stockId}:`, err.message));
         }
       }
     }
@@ -357,21 +310,15 @@ router.get('/pending-po', async (req, res, next) => {
 
       if (!result[stockId]) result[stockId] = { ordered: 0, plannedDate: null, pos: [], flowerName: '' };
       result[stockId].ordered += qty;
-      // Keep the first non-empty flower name.
-      // Airtable may return an array if Flower Name is a lookup field —
-      // normalise to a plain string so the frontend never receives an array.
       if (!result[stockId].flowerName && line['Flower Name']) {
-        const raw = line['Flower Name'];
-        result[stockId].flowerName = Array.isArray(raw) ? (raw[0] || '') : String(raw);
+        result[stockId].flowerName = String(line['Flower Name']);
       }
 
-      const poId = line['Stock Orders']?.[0];
-      const po = poId ? poMap[poId] : null;
-      if (po) {
-        result[stockId].pos.push({ id: po.id, number: po.number, quantity: qty, plannedDate: po.plannedDate });
-        // Track earliest planned date across all POs for this item
-        if (po.plannedDate && (!result[stockId].plannedDate || po.plannedDate < result[stockId].plannedDate)) {
-          result[stockId].plannedDate = po.plannedDate;
+      const poInfo = poMap[line._poPgId];
+      if (poInfo) {
+        result[stockId].pos.push({ id: poInfo.id, number: poInfo.number, quantity: qty, plannedDate: poInfo.plannedDate });
+        if (poInfo.plannedDate && (!result[stockId].plannedDate || poInfo.plannedDate < result[stockId].plannedDate)) {
+          result[stockId].plannedDate = poInfo.plannedDate;
         }
       }
     }
@@ -391,7 +338,6 @@ router.get('/pending-po', async (req, res, next) => {
       }
     }
     if (Object.keys(backfillCandidates).length > 0) {
-      // Batch-fetch to check current prices before overwriting
       const ids = Object.keys(backfillCandidates);
       const CHUNK = 100;
       for (let i = 0; i < ids.length; i += CHUNK) {
@@ -410,8 +356,7 @@ router.get('/pending-po', async (req, res, next) => {
                 ...(!hasSell && src.sell > 0 ? { 'Current Sell Price': src.sell } : {}),
                 ...(src.supplier ? { Supplier: src.supplier } : {}),
               }, { actor: actorFromReq(req) }).catch(err =>
-                console.error(`[STOCK] Batch backfill failed for ${item.id}:`, err.message)
-              );
+                console.error(`[STOCK] Batch backfill failed for ${item.id}:`, err.message));
             }
           }
         } catch { /* skip batch */ }
@@ -492,7 +437,8 @@ router.get('/:id/usage', async (req, res, next) => {
         fields: ['Display Name', 'Current Quantity'],
         pg: { active: true, includeEmpty: true },
       });
-      // PG mode returns all active stock (no formula support) — filter JS-side.
+      // PG mode returns all active stock (no formula support) — filter JS-side
+      // for the exact base name or "<base> (" dated-batch prefix.
       siblingStocks = allForName.filter(s => {
         const n = s['Display Name'] || '';
         return n === baseName || n.startsWith(baseName + ' (');
@@ -587,44 +533,38 @@ router.get('/:id/usage', async (req, res, next) => {
       console.error('stock usage: loss log fetch failed', err);
     }
 
-    // 3. Purchase records — fetch and filter by Flower link in JS.
-    // Purchases created by the PO evaluate flow carry a Notes marker like
-    // "PO #recXXX L#recYYY primary". Parse it out and resolve the PO's
-    // display ID (e.g. "PO-20260415-1") so the trace shows a human reference
-    // instead of raw Airtable record IDs.
+    // 3. Purchase records — Postgres. Purchases created by the PO evaluate
+    // flow carry a Notes marker. ADR-0003: the format changed in Phase 7 from
+    // "PO #recXXX L#recYYY primary" (Airtable era) to "PO #PO-20260508-1 L#<uuid>
+    // primary" (PG era — embeds the human-readable PO number directly).
+    // The regex matches both; resolution branches on whether the PO ref looks
+    // like a recXXX (lookup needed) or a PO-NNNNNNNN-N string (use directly).
     let usagePurchases = [];
     try {
-      const allPurchases = await db.list(TABLES.STOCK_PURCHASES, {
-        filterByFormula: `{Supplier} != ''`,
-        sort: [{ field: 'Purchase Date', direction: 'desc' }],
-        maxRecords: 500,
-      });
+      const allPurchases = await stockPurchasesRepo.list({});
       const linePurchases = allPurchases.filter(p => siblingIds.has(p.Flower?.[0]));
 
-      // Parse PO marker from Notes; batch-fetch the parent POs to resolve
-      // Stock Order ID. The marker is a stable format produced by the
-      // evaluate endpoint; we leave Notes unchanged for idempotency.
-      const poMarkerRe = /PO #(rec[A-Za-z0-9]+)\s+L#(rec[A-Za-z0-9]+)\s+(primary|substitute|alt)/;
-      const poIdSet = new Set();
+      const poMarkerRe = /PO #([A-Za-z0-9_\-]+)\s+L#([A-Za-z0-9_\-]+)\s+(primary|substitute|alt)/;
+      const poRefSet = new Set();
       for (const p of linePurchases) {
         const m = p.Notes?.match(poMarkerRe);
-        if (m) poIdSet.add(m[1]);
+        if (m && m[1].startsWith('rec')) poRefSet.add(m[1]);
       }
       const poMap = {};
-      if (poIdSet.size > 0) {
+      if (poRefSet.size > 0) {
         try {
-          const poRecs = await listByIds(TABLES.STOCK_ORDERS, [...poIdSet], {
-            fields: ['Stock Order ID'],
-          });
+          const poRecs = await stockOrderRepo.listByIds([...poRefSet]);
           for (const po of poRecs) poMap[po.id] = po['Stock Order ID'] || '';
         } catch { /* best effort — fall back to raw Notes */ }
       }
 
       usagePurchases = linePurchases.map(p => {
         const m = p.Notes?.match(poMarkerRe);
-        const poRecordId = m?.[1] || null;
-        const poDisplayId = poRecordId ? (poMap[poRecordId] || '') : '';
-        const variant = m?.[3] || ''; // primary | substitute | alt
+        const poRef = m?.[1] || null;
+        const poDisplayId = poRef
+          ? (poRef.startsWith('rec') ? (poMap[poRef] || '') : poRef)
+          : '';
+        const variant = m?.[3] || '';
         return {
           type: 'purchase',
           date: p['Purchase Date'] || null,
@@ -636,7 +576,7 @@ router.get('/:id/usage', async (req, res, next) => {
           variant,
         };
       });
-    } catch { /* table may not exist */ }
+    } catch { /* best effort */ }
 
     // 4. Active premade bouquet lines — stems physically locked in a premade
     // that hasn't been sold/dissolved yet. These were deducted from qty when
@@ -646,36 +586,23 @@ router.get('/:id/usage', async (req, res, next) => {
     // returned to stock via a reverse atomicStockAdjust — both of which are
     // already represented in the 'order' and 'purchase' trails respectively).
     let usagePremades = [];
-    if (TABLES.PREMADE_BOUQUETS && TABLES.PREMADE_BOUQUET_LINES) {
-      try {
-        const bouquets = await db.list(TABLES.PREMADE_BOUQUETS, {
-          fields: ['Name', 'Lines'],
-          maxRecords: 500,
-        });
-        const allLineIds = bouquets.flatMap(b => b['Lines'] || []);
-        const allLines = allLineIds.length > 0
-          ? await listByIds(TABLES.PREMADE_BOUQUET_LINES, allLineIds, {
-              fields: ['Premade Bouquets', 'Stock Item', 'Quantity', 'Flower Name'],
-            })
-          : [];
-        const bouquetMap = {};
-        for (const b of bouquets) bouquetMap[b.id] = b;
-        usagePremades = allLines
-          .filter(l => siblingIds.has(l['Stock Item']?.[0]))
-          .map(l => {
-            const bouquetId = l['Premade Bouquets']?.[0];
-            const bouquet = bouquetId ? bouquetMap[bouquetId] : null;
-            return {
-              type: 'premade',
-              date: null, // no timestamp on premade lines in Airtable
-              quantity: -(Number(l.Quantity) || 0),
-              bouquetId: bouquetId || '',
-              bouquetName: bouquet?.Name || '?',
-              flowerName: l['Flower Name'] || displayName,
-            };
+    try {
+      const allBouquets = await premadeBouquetRepo.list();
+      for (const bouquet of allBouquets) {
+        const lines = await premadeBouquetRepo.getLinesByBouquetId(bouquet._pgId);
+        for (const l of lines) {
+          if (!siblingIds.has(l['Stock Item']?.[0])) continue;
+          usagePremades.push({
+            type: 'premade',
+            date: null,
+            quantity: -(Number(l.Quantity) || 0),
+            bouquetId: bouquet.id,
+            bouquetName: bouquet.Name || '?',
+            flowerName: l['Flower Name'] || displayName,
           });
-      } catch { /* premade tables may not exist in some envs */ }
-    }
+        }
+      }
+    } catch { /* best effort */ }
 
     // Combine and sort chronologically (newest first).
     // Premade entries have null date — they sort to the top as "ongoing".
@@ -723,24 +650,20 @@ router.patch('/:id', async (req, res, next) => {
     }
 
     // Cascade price changes to Premade Bouquet Lines that reference this stock
-    // item. Can't filterByFormula against a linked-record field (Airtable
-    // returns display names via ARRAYJOIN — see CLAUDE.md pitfalls), so list
-    // all lines and filter in memory. Volume is small (<500 lines in practice).
+    // item. Direct FK query via repo — no linked-record formula gymnastics.
     const costChanged = 'Current Cost Price' in safeFields;
     const sellChanged = 'Current Sell Price' in safeFields;
-    if ((costChanged || sellChanged) && TABLES.PREMADE_BOUQUET_LINES) {
-      const allPremadeLines = await db.list(TABLES.PREMADE_BOUQUET_LINES, {
-        fields: ['Stock Item', 'Cost Price Per Unit', 'Sell Price Per Unit'],
-        maxRecords: 500,
-      });
-      const matching = allPremadeLines.filter(
-        l => Array.isArray(l['Stock Item']) && l['Stock Item'][0] === req.params.id,
-      );
-      for (const line of matching) {
-        const patch = {};
-        if (costChanged) patch['Cost Price Per Unit'] = Number(safeFields['Current Cost Price']) || 0;
-        if (sellChanged) patch['Sell Price Per Unit'] = Number(safeFields['Current Sell Price']) || 0;
-        await db.update(TABLES.PREMADE_BOUQUET_LINES, line.id, patch);
+    if (costChanged || sellChanged) {
+      try {
+        const matchingLines = await premadeBouquetRepo.getLinesByStockId(req.params.id);
+        for (const line of matchingLines) {
+          const patch = {};
+          if (costChanged) patch['Cost Price Per Unit'] = Number(safeFields['Current Cost Price']) || 0;
+          if (sellChanged) patch['Sell Price Per Unit'] = Number(safeFields['Current Sell Price']) || 0;
+          await premadeBouquetRepo.updateLine(line.id, patch);
+        }
+      } catch (err) {
+        console.error('[STOCK] premade price-sync failed:', err.message);
       }
     }
 

--- a/backend/src/routes/stockOrders.js
+++ b/backend/src/routes/stockOrders.js
@@ -403,13 +403,12 @@ router.post('/:id/send', authorize('stock-orders', ['owner']), async (req, res, 
     // reassignment) skip the check because their lines were already validated
     // on the previous send. Without this gate, blank Draft lines would reach
     // the driver as "what am I buying?" rows.
-    const po = await db.getById(TABLES.STOCK_ORDERS, req.params.id);
+    const po = await stockOrderRepo.getById(req.params.id);
     if (po.Status === PO_STATUS.DRAFT) {
-      const lineIds = po['Order Lines'] || [];
-      if (lineIds.length === 0) {
+      const lines = await stockOrderRepo.getLinesByPoId(po._pgId);
+      if (lines.length === 0) {
         return res.status(400).json({ error: 'Cannot send an empty PO. Add at least one line first.' });
       }
-      const lines = await listByIds(TABLES.STOCK_ORDER_LINES, lineIds);
       const blankCount = lines.filter(l => {
         const hasStockItem = Array.isArray(l['Stock Item']) && l['Stock Item'].length > 0;
         const hasFlowerName = String(l['Flower Name'] || '').trim() !== '';
@@ -421,7 +420,7 @@ router.post('/:id/send', authorize('stock-orders', ['owner']), async (req, res, 
         });
       }
     }
-    const updated = await db.update(TABLES.STOCK_ORDERS, req.params.id, {
+    const updated = await stockOrderRepo.update(req.params.id, {
       Status: PO_STATUS.SENT,
       'Assigned Driver': resolvedDriver,
     });
@@ -439,11 +438,11 @@ router.post('/:id/send', authorize('stock-orders', ['owner']), async (req, res, 
 // Goes to Reviewing first (owner can adjust), then owner or auto → Evaluating
 router.post('/:id/driver-complete', authorize('stock-orders'), async (req, res, next) => {
   try {
-    const po = await db.getById(TABLES.STOCK_ORDERS, req.params.id);
+    const po = await stockOrderRepo.getById(req.params.id);
     if (![PO_STATUS.SENT, PO_STATUS.SHOPPING].includes(po.Status)) {
       return res.status(400).json({ error: `PO is "${po.Status}", cannot complete shopping.` });
     }
-    const updated = await db.update(TABLES.STOCK_ORDERS, req.params.id, {
+    const updated = await stockOrderRepo.update(req.params.id, {
       Status: PO_STATUS.REVIEWING,
     });
 
@@ -459,11 +458,11 @@ router.post('/:id/driver-complete', authorize('stock-orders'), async (req, res, 
 // POST /api/stock-orders/:id/approve-review — owner approves, moves to Evaluating
 router.post('/:id/approve-review', authorize('stock-orders', ['owner']), async (req, res, next) => {
   try {
-    const po = await db.getById(TABLES.STOCK_ORDERS, req.params.id);
+    const po = await stockOrderRepo.getById(req.params.id);
     if (po.Status !== PO_STATUS.REVIEWING) {
       return res.status(400).json({ error: `PO is "${po.Status}", not "${PO_STATUS.REVIEWING}".` });
     }
-    const updated = await db.update(TABLES.STOCK_ORDERS, req.params.id, { Status: PO_STATUS.EVALUATING });
+    const updated = await stockOrderRepo.update(req.params.id, { Status: PO_STATUS.EVALUATING });
     broadcast({ type: 'stock_evaluation_ready', stockOrderId: req.params.id });
     res.json(updated);
   } catch (err) {

--- a/backend/src/routes/stockOrders.js
+++ b/backend/src/routes/stockOrders.js
@@ -11,6 +11,8 @@ import * as db from '../services/airtable.js';
 import * as stockRepo from '../repos/stockRepo.js';
 import * as stockLossRepo from '../repos/stockLossRepo.js';
 import * as stockPurchasesRepo from '../repos/stockPurchasesRepo.js';
+import * as stockOrderRepo from '../repos/stockOrderRepo.js';
+import * as orderService from '../services/orderService.js';
 import { TABLES } from '../config/airtable.js';
 import { broadcast } from '../services/notifications.js';
 import { sanitizeFormulaValue } from '../utils/sanitize.js';
@@ -30,28 +32,24 @@ const VALID_STATUSES = VALID_PO_STATUSES;
 async function resolveOrCreateStockItem(flowerName, { costPrice = 0, sellPrice = 0, supplier = '' } = {}) {
   const name = flowerName.trim();
   const matches = await stockRepo.list({
-    filterByFormula: '', // ignored in PG mode
     maxRecords: 1,
     pg: { displayName: name, active: true, includeEmpty: true },
   });
   if (matches.length > 0) {
-    // id is airtableId || uuid — only safe to link in AT if it starts with 'rec'
-    return matches[0].id.startsWith('rec') ? matches[0].id : null;
+    return matches[0].id.startsWith('rec') ? matches[0].id : matches[0]._pgId || matches[0].id;
   }
-  // Not found — create a zero-qty stock card so it shows in the picker
   const newItem = await stockRepo.create({
-    'Display Name': name,
-    'Purchase Name': name,
-    'Current Quantity': 0,
+    'Display Name':       name,
+    'Purchase Name':      name,
+    'Current Quantity':   0,
     'Current Cost Price': Number(costPrice) || 0,
     'Current Sell Price': Number(sellPrice) || 0,
-    Supplier: supplier || '',
-    Category: 'Other',
-    Active: true,
+    Supplier:             supplier || '',
+    Category:             'Other',
+    Active:               true,
   });
   console.log(`[STOCK-ORDER] Auto-created stock item "${name}" (${newItem.id}) from PO line`);
-  // New PG-only item — no Airtable ID, don't link in AT
-  return null;
+  return newItem.id.startsWith('rec') ? newItem.id : newItem._pgId || newItem.id;
 }
 
 // Airtable may return Flower Name as an array (lookup field) or a string
@@ -78,11 +76,10 @@ const router = Router();
 // /settings, so this exposes only the minimal fields they need.
 router.get('/meta/lookups', authorize('stock-orders'), async (req, res, next) => {
   try {
-    const stock = await db.list(TABLES.STOCK, {
-      filterByFormula: '{Active}',
-      fields: ['Display Name', 'Supplier', 'Current Cost Price'],
+    const items = await stockRepo.list({
+      pg: { active: true, includeEmpty: true },
     });
-    const flowers = stock.map(s => ({
+    const flowers = items.map(s => ({
       id:       s.id,
       name:     s['Display Name'] || '',
       supplier: s.Supplier || '',
@@ -100,49 +97,22 @@ router.get('/meta/lookups', authorize('stock-orders'), async (req, res, next) =>
 router.get('/', authorize('stock-orders'), async (req, res, next) => {
   try {
     const { status, include } = req.query;
-    const filters = [];
-    if (status) {
-      if (!VALID_STATUSES.includes(status)) return res.status(400).json({ error: 'Invalid status value' });
-      filters.push(`{Status} = '${sanitizeFormulaValue(status)}'`);
+    if (status && !VALID_PO_STATUSES.includes(status)) {
+      return res.status(400).json({ error: 'Invalid status value' });
     }
-    // Driver scope: only POs where Assigned Driver matches this driver's badge.
-    // This is what was missing — without it every driver saw every PO.
-    if (req.role === 'driver' && req.driverName) {
-      filters.push(`{Assigned Driver} = '${sanitizeFormulaValue(req.driverName)}'`);
-    }
-    const formula = filters.length > 0 ? `AND(${filters.join(', ')})` : '';
-
-    const orders = await db.list(TABLES.STOCK_ORDERS, {
-      filterByFormula: formula || undefined,
-      sort: [{ field: 'Created Date', direction: 'desc' }],
+    const orders = await stockOrderRepo.list({
+      status: status || undefined,
+      role:   req.role,
+      driverName: req.driverName,
     });
 
-    // Optionally include lines in a single batch fetch instead of N+1 calls
     if (include === 'lines' && orders.length > 0) {
-      const allLineIds = orders.flatMap(o => o['Order Lines'] || []);
-      const allLines = [];
-      if (allLineIds.length > 0) {
-        // Airtable formula limit: batch into chunks of 100 IDs
-        const CHUNK = 100;
-        for (let i = 0; i < allLineIds.length; i += CHUNK) {
-          const chunk = allLineIds.slice(i, i + CHUNK);
-          const chunkLines = await db.list(TABLES.STOCK_ORDER_LINES, {
-            filterByFormula: `OR(${chunk.map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-          });
-          allLines.push(...chunkLines);
-        }
-      }
-      // Normalise Flower Name on every line — Airtable may return arrays
-      // from lookup fields, but frontends expect a plain string.
-      for (const l of allLines) {
-        if (l['Flower Name'] != null) l['Flower Name'] = normaliseFlowerName(l['Flower Name']);
-        if (l['Alt Flower Name'] != null) l['Alt Flower Name'] = normaliseFlowerName(l['Alt Flower Name']);
-      }
-      // Index lines by ID for fast lookup
-      const lineMap = new Map(allLines.map(l => [l.id, l]));
+      const poIds = orders.map(o => o._pgId).filter(Boolean);
+      const linesByPo = await stockOrderRepo.getLinesForPos(poIds);
       const result = orders.map(o => ({
         ...o,
-        lines: (o['Order Lines'] || []).map(id => lineMap.get(id)).filter(Boolean),
+        lines: linesByPo.get(o._pgId) || [],
+        'Order Lines': (linesByPo.get(o._pgId) || []).map(l => l.id),
       }));
       return res.json(result);
     }
@@ -156,23 +126,12 @@ router.get('/', authorize('stock-orders'), async (req, res, next) => {
 // GET /api/stock-orders/:id — single PO with its lines
 router.get('/:id', authorize('stock-orders'), async (req, res, next) => {
   try {
-    const order = await db.getById(TABLES.STOCK_ORDERS, req.params.id);
-    // Same scope rule as the list endpoint: drivers can only fetch their own PO.
+    const order = await stockOrderRepo.getById(req.params.id);
     if (req.role === 'driver' && req.driverName && order['Assigned Driver'] !== req.driverName) {
       return res.status(404).json({ error: 'PO not found.' });
     }
-    const lineIds = order['Order Lines'] || [];
-    let lines = [];
-    if (lineIds.length > 0) {
-      lines = await db.list(TABLES.STOCK_ORDER_LINES, {
-        filterByFormula: `OR(${lineIds.map(id => `RECORD_ID() = "${id}"`).join(',')})`,
-      });
-      for (const l of lines) {
-        if (l['Flower Name'] != null) l['Flower Name'] = normaliseFlowerName(l['Flower Name']);
-        if (l['Alt Flower Name'] != null) l['Alt Flower Name'] = normaliseFlowerName(l['Alt Flower Name']);
-      }
-    }
-    res.json({ ...order, lines });
+    const lines = await stockOrderRepo.getLinesByPoId(order._pgId);
+    res.json({ ...order, lines, 'Order Lines': lines.map(l => l.id) });
   } catch (err) {
     next(err);
   }

--- a/backend/src/routes/stockOrders.js
+++ b/backend/src/routes/stockOrders.js
@@ -151,34 +151,20 @@ router.post('/', authorize('stock-orders', ['owner']), async (req, res, next) =>
     }
 
     const today = new Date().toISOString().split('T')[0];
-
-    // Generate PO number: PO-YYYYMMDD-N (date prefix + sequence)
-    const existingPOs = await db.list(TABLES.STOCK_ORDERS, {
-      filterByFormula: `DATESTR({Created Date}) = '${today}'`,
-      fields: ['Created Date'],
-    });
-    const seq = existingPOs.length + 1;
+    const seq = await stockOrderRepo.nextPoSequence(today);
     const poNumber = `PO-${today.replace(/-/g, '')}-${seq}`;
 
-    // Create the PO header
-    const orderFields = {
-      Status: PO_STATUS.DRAFT,
-      'Created Date': today,
+    const order = await stockOrderRepo.create({
+      Status:           PO_STATUS.DRAFT,
+      'Created Date':   today,
       'Stock Order ID': poNumber,
-      Notes: notes || '',
-    };
-    if (driver) orderFields['Assigned Driver'] = driver;
-    if (plannedDate) orderFields['Planned Date'] = plannedDate;
+      Notes:            notes || '',
+      ...(driver       ? { 'Assigned Driver': driver } : {}),
+      ...(plannedDate  ? { 'Planned Date': plannedDate } : {}),
+    });
 
-    const order = await db.create(TABLES.STOCK_ORDERS, orderFields);
-
-    // Create lines — use lot size from the PO form (owner can set/override),
-    // falling back to the stock item's configured lot size, then 1.
     const createdLines = [];
-    for (const line of (lines || [])) {
-      // Auto-link or auto-create: if no stockItemId but flowerName is given,
-      // find a matching stock item. If not found, create one with qty=0 so it
-      // appears in the stock picker with an "on order" badge immediately.
+    for (const line of lines || []) {
       let resolvedStockItemId = line.stockItemId || null;
       if (!resolvedStockItemId && line.flowerName) {
         try {
@@ -192,25 +178,25 @@ router.post('/', authorize('stock-orders', ['owner']), async (req, res, next) =>
       let lotSize = Number(line.lotSize) || 0;
       if (!lotSize && resolvedStockItemId) {
         try {
-          const stockItem = await db.getById(TABLES.STOCK, resolvedStockItemId);
+          const stockItem = await stockRepo.getById(resolvedStockItemId);
           lotSize = Number(stockItem['Lot Size']) || 0;
         } catch { /* stock item may have been deleted */ }
       }
       const lineFields = {
-        'Stock Orders': [order.id],
+        'Stock Orders':    [order._pgId],
         ...(resolvedStockItemId ? { 'Stock Item': [resolvedStockItemId] } : {}),
-        'Flower Name': line.flowerName || '',
+        'Flower Name':     line.flowerName || '',
         'Quantity Needed': Number(line.quantity) || 0,
         ...(lotSize > 0 ? { 'Lot Size': lotSize } : {}),
-        'Driver Status': PO_LINE_STATUS.PENDING,
-        Supplier: line.supplier || '',
-        'Cost Price': Number(line.costPrice) || 0,
-        'Sell Price': Number(line.sellPrice) || 0,
+        'Driver Status':   PO_LINE_STATUS.PENDING,
+        Supplier:          line.supplier || '',
+        'Cost Price':      Number(line.costPrice) || 0,
+        'Sell Price':      Number(line.sellPrice) || 0,
       };
       if (line.farmer) lineFields.Farmer = line.farmer;
-      if (line.notes) lineFields.Notes = line.notes;
+      if (line.notes)  lineFields.Notes = line.notes;
 
-      const lineRec = await db.create(TABLES.STOCK_ORDER_LINES, lineFields);
+      const lineRec = await stockOrderRepo.createLine(lineFields);
       createdLines.push(lineRec);
     }
 
@@ -235,11 +221,11 @@ router.patch('/:id', authorize('stock-orders'), async (req, res, next) => {
     }
 
     if (Object.keys(fields).length === 0) {
-      return res.json(await db.getById(TABLES.STOCK_ORDERS, req.params.id));
+      return res.json(await stockOrderRepo.getById(req.params.id));
     }
 
     if (fields.Status) {
-      const current = await db.getById(TABLES.STOCK_ORDERS, req.params.id);
+      const current = await stockOrderRepo.getById(req.params.id);
       const valid = ALLOWED_TRANSITIONS[current.Status];
       if (!valid || !valid.includes(fields.Status)) {
         return res.status(400).json({
@@ -248,10 +234,8 @@ router.patch('/:id', authorize('stock-orders'), async (req, res, next) => {
       }
     }
 
-    const updated = await db.update(TABLES.STOCK_ORDERS, req.params.id, fields);
+    const updated = await stockOrderRepo.update(req.params.id, fields);
 
-    // SSE: driver app needs to refetch on ANY header change while the PO is live,
-    // and owner needs a re-notify if the driver reassignment moved the PO to someone else.
     if ('Assigned Driver' in fields) {
       broadcast({
         type: 'stock_pickup_assigned',
@@ -278,8 +262,7 @@ const PO_OWNER_ONLY_STATUSES = [PO_STATUS.REVIEWING, PO_STATUS.EVALUATING, PO_ST
 
 router.patch('/:id/lines/:lineId', authorize('stock-orders'), async (req, res, next) => {
   try {
-    // Edit-window guard
-    const po = await db.getById(TABLES.STOCK_ORDERS, req.params.id);
+    const po = await stockOrderRepo.getById(req.params.id);
     if (po.Status === PO_STATUS.COMPLETE) {
       return res.status(409).json({
         error: `PO is "${PO_STATUS.COMPLETE}" — closed books. Create an adjustment instead.`,
@@ -302,15 +285,11 @@ router.patch('/:id/lines/:lineId', authorize('stock-orders'), async (req, res, n
       if (key in req.body) fields[key] = req.body[key];
     }
     if (Object.keys(fields).length === 0) {
-      return res.json(await db.getById(TABLES.STOCK_ORDER_LINES, req.params.lineId));
+      return res.json(await stockOrderRepo.getLineById(req.params.lineId));
     }
 
-    // Guard: if the PATCH tries to shorten Flower Name to fewer than 2 chars
-    // while the line has a linked Stock Item, reject it — this is almost
-    // certainly a race from the keystroke-by-keystroke search input, not an
-    // intentional rename. The full name will arrive in a subsequent PATCH.
     if ('Flower Name' in fields && typeof fields['Flower Name'] === 'string' && fields['Flower Name'].length < 2) {
-      const existing = await db.getById(TABLES.STOCK_ORDER_LINES, req.params.lineId);
+      const existing = await stockOrderRepo.getLineById(req.params.lineId);
       const hasStockItem = !!existing['Stock Item']?.[0];
       const currentName = existing['Flower Name'] || '';
       if (hasStockItem && currentName.length >= 2) {
@@ -319,25 +298,18 @@ router.patch('/:id/lines/:lineId', authorize('stock-orders'), async (req, res, n
       }
     }
 
-    const updated = await db.update(TABLES.STOCK_ORDER_LINES, req.params.lineId, fields);
+    const updated = await stockOrderRepo.updateLine(req.params.lineId, fields);
 
-    if ('Driver Status' in fields) {
-      const po = await db.getById(TABLES.STOCK_ORDERS, req.params.id);
-      if (po.Status === PO_STATUS.SENT) {
-        await db.update(TABLES.STOCK_ORDERS, req.params.id, { Status: PO_STATUS.SHOPPING });
-      }
+    if ('Driver Status' in fields && po.Status === PO_STATUS.SENT) {
+      await stockOrderRepo.update(req.params.id, { Status: PO_STATUS.SHOPPING });
     }
 
-    // SSE broadcast: notify owner and driver of line changes in real time
     broadcast({
       type: 'stock_order_line_updated',
       stockOrderId: req.params.id,
       lineId: req.params.lineId,
     });
 
-    // Normalise Flower Name in response
-    if (updated['Flower Name'] != null) updated['Flower Name'] = normaliseFlowerName(updated['Flower Name']);
-    if (updated['Alt Flower Name'] != null) updated['Alt Flower Name'] = normaliseFlowerName(updated['Alt Flower Name']);
     res.json(updated);
   } catch (err) {
     next(err);
@@ -351,7 +323,7 @@ const EDITABLE_PO_STATUSES = [PO_STATUS.DRAFT, PO_STATUS.SENT, PO_STATUS.SHOPPIN
 
 router.post('/:id/lines', authorize('stock-orders', ['owner']), async (req, res, next) => {
   try {
-    const po = await db.getById(TABLES.STOCK_ORDERS, req.params.id);
+    const po = await stockOrderRepo.getById(req.params.id);
     if (!EDITABLE_PO_STATUSES.includes(po.Status)) {
       return res.status(400).json({ error: `Cannot add lines to a "${po.Status}" PO.` });
     }
@@ -364,7 +336,6 @@ router.post('/:id/lines', authorize('stock-orders', ['owner']), async (req, res,
     if (!rawStockItemId && !flowerName?.trim() && po.Status !== PO_STATUS.DRAFT) {
       return res.status(400).json({ error: 'PO line must have a stock item or flower name.' });
     }
-    // Auto-link or auto-create stock item
     let resolvedStockItemId = rawStockItemId || null;
     if (!resolvedStockItemId && flowerName) {
       try {
@@ -373,19 +344,18 @@ router.post('/:id/lines', authorize('stock-orders', ['owner']), async (req, res,
         console.error(`[STOCK-ORDER] Auto-link/create failed for "${flowerName}":`, err.message);
       }
     }
-    const line = await db.create(TABLES.STOCK_ORDER_LINES, {
-      'Stock Orders': [req.params.id],
-      'Stock Item': resolvedStockItemId ? [resolvedStockItemId] : undefined,
-      'Flower Name': flowerName || '',
+    const line = await stockOrderRepo.createLine({
+      'Stock Orders':    [po._pgId],
+      ...(resolvedStockItemId ? { 'Stock Item': [resolvedStockItemId] } : {}),
+      'Flower Name':     flowerName || '',
       'Quantity Needed': Number(quantity) || 1,
-      Supplier: supplier || '',
-      'Cost Price': Number(costPrice) || 0,
-      'Sell Price': Number(sellPrice) || 0,
-      'Lot Size': Number(lotSize) || 0,
-      'Driver Status': PO_LINE_STATUS.PENDING,
+      Supplier:          supplier || '',
+      'Cost Price':      Number(costPrice) || 0,
+      'Sell Price':      Number(sellPrice) || 0,
+      'Lot Size':        Number(lotSize) || 0,
+      'Driver Status':   PO_LINE_STATUS.PENDING,
     });
     broadcast({ type: 'stock_order_line_updated', stockOrderId: req.params.id, lineId: line.id });
-    if (line['Flower Name'] != null) line['Flower Name'] = normaliseFlowerName(line['Flower Name']);
     res.json(line);
   } catch (err) {
     next(err);
@@ -396,18 +366,11 @@ router.post('/:id/lines', authorize('stock-orders', ['owner']), async (req, res,
 // Removes all its lines first, then the PO header.
 router.delete('/:id', authorize('stock-orders', ['owner']), async (req, res, next) => {
   try {
-    const po = await db.getById(TABLES.STOCK_ORDERS, req.params.id);
+    const po = await stockOrderRepo.getById(req.params.id);
     if (po.Status !== PO_STATUS.DRAFT) {
       return res.status(400).json({ error: `Only Draft POs can be deleted. This PO is "${po.Status}".` });
     }
-    // Delete all lines first
-    const lineIds = po['Order Lines'] || [];
-    for (const lineId of lineIds) {
-      await db.deleteRecord(TABLES.STOCK_ORDER_LINES, lineId).catch(err =>
-        console.error(`[PO] Failed to delete line ${lineId} during PO delete:`, err.message)
-      );
-    }
-    await db.deleteRecord(TABLES.STOCK_ORDERS, req.params.id);
+    await stockOrderRepo.deleteById(req.params.id);  // CASCADE handles lines
     broadcast({ type: 'stock_order_deleted', stockOrderId: req.params.id });
     res.json({ deleted: true });
   } catch (err) {
@@ -418,11 +381,11 @@ router.delete('/:id', authorize('stock-orders', ['owner']), async (req, res, nex
 // DELETE /api/stock-orders/:id/lines/:lineId — remove a line from an editable PO
 router.delete('/:id/lines/:lineId', authorize('stock-orders', ['owner']), async (req, res, next) => {
   try {
-    const po = await db.getById(TABLES.STOCK_ORDERS, req.params.id);
+    const po = await stockOrderRepo.getById(req.params.id);
     if (!EDITABLE_PO_STATUSES.includes(po.Status)) {
       return res.status(400).json({ error: `Cannot remove lines from a "${po.Status}" PO.` });
     }
-    await db.deleteRecord(TABLES.STOCK_ORDER_LINES, req.params.lineId);
+    await stockOrderRepo.deleteLineById(req.params.lineId);
     broadcast({ type: 'stock_order_line_updated', stockOrderId: req.params.id, lineId: req.params.lineId });
     res.json({ deleted: true });
   } catch (err) {

--- a/backend/src/routes/stockOrders.js
+++ b/backend/src/routes/stockOrders.js
@@ -7,18 +7,15 @@
 
 import { Router } from 'express';
 import { authorize } from '../middleware/auth.js';
-import * as db from '../services/airtable.js';
 import * as stockRepo from '../repos/stockRepo.js';
 import * as stockLossRepo from '../repos/stockLossRepo.js';
 import * as stockPurchasesRepo from '../repos/stockPurchasesRepo.js';
 import * as stockOrderRepo from '../repos/stockOrderRepo.js';
 import * as orderService from '../services/orderService.js';
-import { TABLES } from '../config/airtable.js';
 import { broadcast } from '../services/notifications.js';
 import { sanitizeFormulaValue } from '../utils/sanitize.js';
-import { PO_STATUS, VALID_PO_STATUSES, PO_LINE_STATUS, LOSS_REASON, ORDER_STATUS } from '../constants/statuses.js';
+import { PO_STATUS, VALID_PO_STATUSES, PO_LINE_STATUS, LOSS_REASON } from '../constants/statuses.js';
 import { getConfig, getDriverOfDay } from '../services/configService.js';
-import { listByIds } from '../utils/batchQuery.js';
 
 const VALID_STATUSES = VALID_PO_STATUSES;
 
@@ -50,14 +47,6 @@ async function resolveOrCreateStockItem(flowerName, { costPrice = 0, sellPrice =
   });
   console.log(`[STOCK-ORDER] Auto-created stock item "${name}" (${newItem.id}) from PO line`);
   return newItem.id.startsWith('rec') ? newItem.id : newItem._pgId || newItem.id;
-}
-
-// Airtable may return Flower Name as an array (lookup field) or a string
-// (text field). Normalise to a plain string so downstream code (.trim(),
-// template literals, formula values) never receives an array.
-function normaliseFlowerName(raw) {
-  if (Array.isArray(raw)) return String(raw[0] || '');
-  return String(raw || '');
 }
 
 const ALLOWED_TRANSITIONS = {
@@ -470,11 +459,10 @@ router.post('/:id/approve-review', authorize('stock-orders', ['owner']), async (
   }
 });
 
-// Idempotency helper — returns true if a STOCK_PURCHASES row already exists
-// for this PO + line + variant (primary/alt). Used on retry after a partial
-// failure, so a second receiveIntoStock does NOT double-credit the batch.
-async function purchaseAlreadyRecorded(poId, lineId, variant) {
-  const marker = `PO #${poId} L#${lineId} ${variant}`;
+// Idempotency helper — returns true if a STOCK_PURCHASES row with this exact
+// notes marker already exists. Caller constructs the marker (see ADR-0003 for
+// format). Used on retry after a partial failure to skip double-credit.
+async function purchaseAlreadyRecorded(marker) {
   try {
     return await stockPurchasesRepo.noteMarkerExists(marker);
   } catch (e) {
@@ -610,19 +598,25 @@ async function receiveIntoStock(stockItemId, qty, costPrice, sellPrice, supplier
 router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), async (req, res, next) => {
   try {
     // H1: Guard against double-evaluate — allow Evaluating (first attempt) or Eval Error (retry)
-    const po = await db.getById(TABLES.STOCK_ORDERS, req.params.id);
+    const po = await stockOrderRepo.getById(req.params.id);
     if (po.Status !== PO_STATUS.EVALUATING && po.Status !== PO_STATUS.EVAL_ERROR) {
-      return res.status(409).json({ error: `PO is "${po.Status}", not "${PO_STATUS.EVALUATING}". Already processed?` });
+      return res.status(409).json({
+        error: `PO is "${po.Status}", not "${PO_STATUS.EVALUATING}". Already processed?`,
+      });
     }
 
+    // poDisplayId is the human-readable PO number (PO-YYYYMMDD-N) — embedded
+    // in the stock_purchases.notes idempotency marker per ADR-0003.
+    const poDisplayId = po['Stock Order ID'] || po.id;
     const { lines } = req.body;
+
     // On first attempt use today's date. On Eval Error retry, reuse the date
     // from lines already processed in the first attempt so all stock entries
     // for this PO share the same receive date (the day flowers actually arrived).
     let evalDate = new Date().toISOString().split('T')[0];
     if (po.Status === PO_STATUS.EVAL_ERROR) {
       try {
-        const prevDate = await stockPurchasesRepo.findDateByPoMarker(req.params.id);
+        const prevDate = await stockPurchasesRepo.findDateByPoMarker(poDisplayId);
         if (prevDate) evalDate = prevDate;
       } catch { /* fall back to today */ }
     }
@@ -630,7 +624,7 @@ router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), as
 
     for (const evalLine of (lines || [])) {
       try {
-        const line = await db.getById(TABLES.STOCK_ORDER_LINES, evalLine.lineId);
+        const line = await stockOrderRepo.getLineById(evalLine.lineId);
 
         // Skip lines already processed on a previous attempt (idempotency guard)
         if (line['Eval Status'] === PO_LINE_STATUS.PROCESSED) {
@@ -652,80 +646,79 @@ router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), as
         // find a matching stock record and link it. This handles lines created
         // from freetext input (no stock item selected in the PO form).
         if (!stockItemId && (accepted > 0 || writeOff > 0)) {
-          const flowerName = normaliseFlowerName(line['Flower Name']).trim();
+          const flowerName = String(line['Flower Name'] || '').trim();
           if (!flowerName) {
             throw new Error(
-              `Line "${evalLine.lineId}" has no Stock Item and no Flower Name — cannot resolve.`
+              `Line "${evalLine.lineId}" has no Stock Item and no Flower Name — cannot resolve.`,
             );
           }
-          const safe = sanitizeFormulaValue(flowerName);
-          const matches = await db.list(TABLES.STOCK, {
-            filterByFormula: `AND({Display Name} = '${safe}', {Active} = TRUE())`,
+          const matches = await stockRepo.list({
+            pg: { displayName: flowerName, active: true, includeEmpty: true },
             maxRecords: 1,
           });
           if (matches.length > 0) {
             stockItemId = matches[0].id;
-            await db.update(TABLES.STOCK_ORDER_LINES, evalLine.lineId, { 'Stock Item': [stockItemId] });
+            await stockOrderRepo.updateLine(evalLine.lineId, { 'Stock Item': [stockItemId] });
             console.log(`[STOCK-ORDER] Auto-linked "${flowerName}" → stock item ${stockItemId}`);
           } else {
             // Create a new stock item so the line can be received
             const markup = Number(getConfig('targetMarkup')) || 1;
             const autoSell = sellPrice || Math.round(costPrice * markup * 100) / 100;
             const created = await stockRepo.create({
-              'Display Name': flowerName,
-              'Purchase Name': flowerName,
-              Category: 'Other',
-              'Current Quantity': 0,
+              'Display Name':       flowerName,
+              'Purchase Name':      flowerName,
+              Category:             'Other',
+              'Current Quantity':   0,
               'Current Cost Price': costPrice,
               'Current Sell Price': autoSell,
-              Supplier: supplier,
-              Unit: 'Stems',
-              Active: true,
+              Supplier:             supplier,
+              Unit:                 'Stems',
+              Active:               true,
             });
             stockItemId = created.id;
-            await db.update(TABLES.STOCK_ORDER_LINES, evalLine.lineId, { 'Stock Item': [stockItemId] });
+            await stockOrderRepo.updateLine(evalLine.lineId, { 'Stock Item': [stockItemId] });
             console.log(`[STOCK-ORDER] Created & linked stock item for "${flowerName}" (${stockItemId})`);
           }
         }
-        // Alt quantities without a stock item require at least an Alt Flower Name
-        // so we know what substitute stock card to create.
+
+        // Substitute quantities without a stock item require at least an Alt
+        // Flower Name so we know what substitute stock card to create.
         if (!stockItemId && (altAcceptedPre > 0 || altWriteOffPre > 0) && !line['Alt Flower Name']) {
           throw new Error(
-            `Line "${normaliseFlowerName(line['Flower Name']) || evalLine.lineId}" has no linked Stock Item and no Alt Flower Name — ` +
-            `link a Stock Item or add substitute details, then retry.`
+            `Line "${line['Flower Name'] || evalLine.lineId}" has no linked Stock Item and no Alt Flower Name — ` +
+            `link a Stock Item or add substitute details, then retry.`,
           );
         }
 
-        // Primary supplier: receive into stock with batch logic.
-        // Idempotency: on retry after a partial failure, skip if the
-        // STOCK_PURCHASES row for this (PO, line, primary) already exists.
-        // Otherwise receiveIntoStock would credit the batch a second time.
+        // Primary receive — idempotency marker uses the human-readable PO
+        // number per ADR-0003. line._pgId is the canonical UUID; fall back to
+        // evalLine.lineId (recXXX or uuid) when _pgId isn't surfaced.
         if (stockItemId && accepted > 0) {
-          const already = await purchaseAlreadyRecorded(req.params.id, evalLine.lineId, 'primary');
+          const primaryMarker = `PO #${poDisplayId} L#${line._pgId || evalLine.lineId} primary`;
+          const already = await purchaseAlreadyRecorded(primaryMarker);
           if (!already) {
             const finalItemId = await receiveIntoStock(stockItemId, accepted, costPrice, sellPrice, supplier, evalDate);
-
-            // Marker must match purchaseAlreadyRecorded() exactly.
             const batchItem = await stockRepo.getById(finalItemId).catch(() => null);
             await stockPurchasesRepo.create({
               purchaseDate:      evalDate,
               supplier,
               stockId:           batchItem?._pgId || null,
-              stockAirtableId:   finalItemId.startsWith('rec') ? finalItemId : null,
+              stockAirtableId:   typeof finalItemId === 'string' && finalItemId.startsWith('rec') ? finalItemId : null,
               quantityPurchased: accepted,
               pricePerUnit:      costPrice,
-              notes:             `PO #${req.params.id} L#${evalLine.lineId} primary`,
+              notes:             primaryMarker,
             });
           } else {
             console.log(`[STOCK-ORDER] Skipping primary receive for line ${evalLine.lineId} — already recorded`);
           }
         }
 
-        // Alt supplier: substitute becomes its own stock card (Phase A substitution policy).
-        // Find-or-create a Stock record by exact Alt Flower Name, receive the
-        // accepted qty there at the REAL per-stem cost the driver paid (not
-        // the original planned cost). Sell price derives from targetMarkup.
-        // Skip entirely if florist accepted 0 of the substitute (edge case 6).
+        // Substitute supplier: Substitute becomes its own stock card (Phase A
+        // substitution policy). Find-or-create a Stock record by exact Alt
+        // Flower Name, receive the accepted qty there at the REAL per-stem
+        // cost the driver paid (not the original planned cost). Sell price
+        // derives from targetMarkup. Skip entirely if florist accepted 0 of
+        // the Substitute (edge case 6).
         const altAccepted = Number(evalLine.altQuantityAccepted) || 0;
         const altWriteOff = Number(evalLine.altWriteOffQty) || 0;
         const altSupplier = line['Alt Supplier'] || '';
@@ -738,22 +731,23 @@ router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), as
 
         let substituteStockId = null;
         if (altAccepted > 0 && altFlowerName) {
-          const alreadyAlt = await purchaseAlreadyRecorded(req.params.id, evalLine.lineId, 'alt');
+          const altMarker = `PO #${poDisplayId} L#${line._pgId || evalLine.lineId} alt`;
+          const alreadyAlt = await purchaseAlreadyRecorded(altMarker);
           if (!alreadyAlt) {
             // Fetch the originally-ordered stock item once so the helper can
-            // copy Category/Unit/Reorder Threshold as defaults.
-            // If the PO line has no Stock Item link (e.g. new flower not yet
-            // in stock), pass null — the helper uses sensible defaults.
+            // copy Category/Unit/Reorder Threshold as defaults. If the PO
+            // line has no Stock Item link (e.g. new flower not yet in stock),
+            // pass null — the helper uses sensible defaults.
             const originalStockItem = stockItemId
               ? await stockRepo.getById(stockItemId).catch(() => null)
               : null;
             substituteStockId = await findOrCreateSubstituteStock(
-              altFlowerName, altSupplier, altCostPerStem, originalStockItem, stockItemId, evalDate
+              altFlowerName, altSupplier, altCostPerStem, originalStockItem, stockItemId, evalDate,
             );
             const markup = Number(getConfig('targetMarkup')) || 1;
             const altSellPerStem = Math.round(altCostPerStem * markup * 100) / 100;
             const altFinalId = await receiveIntoStock(
-              substituteStockId, altAccepted, altCostPerStem, altSellPerStem, altSupplier, evalDate
+              substituteStockId, altAccepted, altCostPerStem, altSellPerStem, altSupplier, evalDate,
             );
             substituteStockId = altFinalId; // may be a new batch id
 
@@ -762,22 +756,20 @@ router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), as
               purchaseDate:      evalDate,
               supplier:          altSupplier,
               stockId:           altBatchItem?._pgId || null,
-              stockAirtableId:   altFinalId.startsWith('rec') ? altFinalId : null,
+              stockAirtableId:   typeof altFinalId === 'string' && altFinalId.startsWith('rec') ? altFinalId : null,
               quantityPurchased: altAccepted,
               pricePerUnit:      altCostPerStem,
-              notes:             `PO #${req.params.id} L#${evalLine.lineId} alt - substitute for "${normaliseFlowerName(line['Flower Name'])}"`,
+              notes:             `${altMarker} - substitute for "${line['Flower Name'] || ''}"`,
             });
           } else {
             console.log(`[STOCK-ORDER] Skipping alt receive for line ${evalLine.lineId} — already recorded`);
           }
         }
 
-        // Log write-offs per source (primary vs substitute) via Postgres repo.
+        // Log write-offs per source (primary vs Substitute) via Postgres repo.
         // Primary write-offs land on the original stock item. Substitute
-        // write-offs land on the substitute card (or on the original if
-        // we never created a substitute because accepted = 0).
-        // stockItemId and substituteStockId are Airtable recXXX IDs here;
-        // resolve each to a PG UUID via stockRepo.getById before writing.
+        // write-offs land on the substitute card (or on the original if we
+        // never created a substitute because accepted = 0).
         if (stockItemId && writeOff > 0) {
           const reason = evalLine.writeOffReason || LOSS_REASON.DAMAGED;
           stockRepo.getById(stockItemId)
@@ -785,7 +777,7 @@ router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), as
               date:     evalDate,
               stockId:  item._pgId || null,
               quantity: writeOff,
-              reason:   reason === LOSS_REASON.WILTED || reason === LOSS_REASON.DAMAGED || reason === LOSS_REASON.ARRIVED_BROKEN ? reason : LOSS_REASON.OTHER,
+              reason:   [LOSS_REASON.WILTED, LOSS_REASON.DAMAGED, LOSS_REASON.ARRIVED_BROKEN].includes(reason) ? reason : LOSS_REASON.OTHER,
               notes:    'PO evaluation write-off (primary)',
             }))
             .catch(err => console.error('[STOCK-ORDER] Failed to log primary write-off:', err.message));
@@ -802,7 +794,7 @@ router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), as
                 date:     evalDate,
                 stockId:  item._pgId || null,
                 quantity: altWriteOff,
-                reason:   altReason === LOSS_REASON.WILTED || altReason === LOSS_REASON.DAMAGED || altReason === LOSS_REASON.ARRIVED_BROKEN ? altReason : LOSS_REASON.OTHER,
+                reason:   [LOSS_REASON.WILTED, LOSS_REASON.DAMAGED, LOSS_REASON.ARRIVED_BROKEN].includes(altReason) ? altReason : LOSS_REASON.OTHER,
                 notes:    'PO evaluation write-off (substitute)',
               }))
               .catch(err => console.error('[STOCK-ORDER] Failed to log alt write-off:', err.message));
@@ -810,19 +802,19 @@ router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), as
         }
 
         // Mark line as fully processed + save acceptance data (single write)
-        await db.update(TABLES.STOCK_ORDER_LINES, evalLine.lineId, {
+        await stockOrderRepo.updateLine(evalLine.lineId, {
           'Quantity Accepted': accepted,
-          'Write Off Qty': writeOff,
-          'Eval Status': PO_LINE_STATUS.PROCESSED,
+          'Write Off Qty':     writeOff,
+          'Eval Status':       PO_LINE_STATUS.PROCESSED,
         });
 
         lineResults.push({
-          lineId: evalLine.lineId,
-          status: 'ok',
-          substituteStockId: substituteStockId || null,
-          originalStockId: stockItemId || null,
-          originalFlowerName: normaliseFlowerName(line['Flower Name']),
-          receivedQty: altAccepted || 0,
+          lineId:             evalLine.lineId,
+          status:             'ok',
+          substituteStockId:  substituteStockId || null,
+          originalStockId:    stockItemId || null,
+          originalFlowerName: line['Flower Name'] || '',
+          receivedQty:        altAccepted || 0,
         });
       } catch (lineErr) {
         console.error(`[STOCK-ORDER] Evaluate line ${evalLine.lineId} failed:`, lineErr.message);
@@ -833,7 +825,7 @@ router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), as
     const failed = lineResults.filter(r => r.status === 'error');
     if (failed.length > 0) {
       // Partial failure: mark PO with error state so owner can see and retry
-      await db.update(TABLES.STOCK_ORDERS, req.params.id, { Status: PO_STATUS.EVAL_ERROR });
+      await stockOrderRepo.update(req.params.id, { Status: PO_STATUS.EVAL_ERROR });
       return res.status(207).json({
         success: false,
         message: `${failed.length} of ${lineResults.length} lines failed. PO marked as "Eval Error" — retry will skip already-processed lines.`,
@@ -842,68 +834,33 @@ router.post('/:id/evaluate', authorize('stock-orders', ['owner', 'florist']), as
     }
 
     // All lines processed — mark PO as complete
-    await db.update(TABLES.STOCK_ORDERS, req.params.id, { Status: PO_STATUS.COMPLETE });
+    await stockOrderRepo.update(req.params.id, { Status: PO_STATUS.COMPLETE });
 
-    // Phase B: detect orders needing reconciliation after substitution.
-    // For each substitute received, check if open orders are waiting for the original.
-    const substitutionsMade = lineResults.filter(
-      r => r.status === 'ok' && r.substituteStockId && r.originalStockId
-    );
+    // Phase B: detect orders needing reconciliation after Substitution.
+    // Delegated to orderService.findOrdersNeedingSubstitution (extracted in T5;
+    // queries Postgres via orderRepo + customerRepo). Non-blocking — a failure
+    // here must not affect the evaluate response.
+    const substitutionsMade = lineResults
+      .filter(r => r.status === 'ok' && r.substituteStockId && r.originalStockId)
+      .map(r => ({
+        originalStockId:    r.originalStockId,
+        originalFlowerName: r.originalFlowerName,
+        substituteStockId:  r.substituteStockId,
+        receivedQty:        r.receivedQty,
+      }));
+
     if (substitutionsMade.length > 0) {
       try {
-        const today = new Date().toISOString().split('T')[0];
-        // Fetch non-terminal future orders (same logic as GET /stock/committed)
-        const openOrders = await db.list(TABLES.ORDERS, {
-          filterByFormula: `AND({Status} != '${ORDER_STATUS.DELIVERED}', {Status} != '${ORDER_STATUS.PICKED_UP}', {Status} != '${ORDER_STATUS.CANCELLED}', IS_AFTER({Required By}, '${today}'))`,
-          fields: ['Order Lines', 'Customer', 'Required By', 'App Order ID', 'Status'],
-          maxRecords: 500,
-        });
-        const allSubLineIds = openOrders.flatMap(o => o['Order Lines'] || []);
-        const allSubLines = allSubLineIds.length > 0
-          ? await listByIds(TABLES.ORDER_LINES, allSubLineIds, {
-              fields: ['Order', 'Stock Item', 'Quantity', 'Flower Name'],
-            })
-          : [];
-        const custIds = [...new Set(openOrders.flatMap(o => o.Customer || []))];
-        const custs = custIds.length > 0
-          ? await listByIds(TABLES.CUSTOMERS, custIds, { fields: ['Name', 'Nickname'] })
-          : [];
-        const custMap = {};
-        for (const c of custs) custMap[c.id] = c;
-        const orderInfoMap = {};
-        for (const o of openOrders) {
-          const cid = o.Customer?.[0];
-          orderInfoMap[o.id] = {
-            appOrderId: o['App Order ID'] || '',
-            customerName: custMap[cid]?.Name || custMap[cid]?.Nickname || '',
-            requiredBy: o['Required By'] || null,
-          };
-        }
-
-        for (const sub of substitutionsMade) {
-          const affectedOrders = [];
-          for (const line of allSubLines) {
-            if (line['Stock Item']?.[0] !== sub.originalStockId) continue;
-            const oid = line.Order?.[0];
-            const oi = oid ? orderInfoMap[oid] : null;
-            if (oi) {
-              affectedOrders.push({
-                orderId: oid,
-                appOrderId: oi.appOrderId,
-                customerName: oi.customerName,
-                requiredBy: oi.requiredBy,
-                qty: Number(line.Quantity || 0),
-              });
-            }
-          }
-          if (affectedOrders.length > 0) {
+        const enriched = await orderService.findOrdersNeedingSubstitution(substitutionsMade);
+        for (const sub of enriched) {
+          if (sub.affectedOrders.length > 0) {
             broadcast({
-              type: 'substitute_reconciliation_needed',
-              originalStockId: sub.originalStockId,
+              type:               'substitute_reconciliation_needed',
+              originalStockId:    sub.originalStockId,
               originalFlowerName: sub.originalFlowerName,
-              substituteStockId: sub.substituteStockId,
-              affectedOrders,
-              substituteQty: sub.receivedQty,
+              substituteStockId:  sub.substituteStockId,
+              affectedOrders:     sub.affectedOrders,
+              substituteQty:      sub.receivedQty,
             });
           }
         }

--- a/backend/src/routes/test.js
+++ b/backend/src/routes/test.js
@@ -22,9 +22,10 @@
 import { Router } from 'express';
 import { resetToFixture, _snapshotAllTables, _getTable } from '../services/airtable-mock.js';
 import { db, isPgliteMode } from '../db/index.js';
-import { auditLog, parityLog, stock, orders, orderLines, deliveries, customers, keyPeople, legacyOrders } from '../db/schema.js';
+import { auditLog, parityLog, stock, orders, orderLines, deliveries, customers, keyPeople, legacyOrders, stockOrders, stockOrderLines, premadeBouquets, premadeBouquetLines } from '../db/schema.js';
 import { TABLES } from '../config/airtable.js';
 import { sql } from 'drizzle-orm';
+import { seedPhase7 } from '../__tests__/helpers/phase7-seed.js';
 
 const router = Router();
 
@@ -172,15 +173,19 @@ router.post('/reset', async (_req, res, next) => {
     resetToFixture();
 
     let seeded = { stock: 0, orders: 0, lines: 0, deliveries: 0, customers: 0 };
+    let phase7Seeded = { stockOrders: 0, stockOrderLines: 0, premadeBouquets: 0, premadeBouquetLines: 0 };
     if (db) {
       // Truncate PG tables so each spec starts with empty audit/parity logs
       // and zero rows in the migrated tables. The mock Airtable side is
       // already wiped + reseeded by resetToFixture above.
-      await db.execute(sql`TRUNCATE TABLE legacy_orders, key_people, customers, audit_log, parity_log, stock, orders, order_lines, deliveries RESTART IDENTITY CASCADE`);
+      await db.execute(sql`TRUNCATE TABLE legacy_orders, key_people, customers, audit_log, parity_log, stock, orders, order_lines, deliveries, stock_orders, stock_order_lines, premade_bouquets, premade_bouquet_lines RESTART IDENTITY CASCADE`);
       seeded = await seedPgFromFixture();
+      // Phase 7 fixtures (POs + premade bouquets) live in PG only — seed
+      // after stock so line.stock_id can reference real rows.
+      phase7Seeded = await seedPhase7(db);
     }
 
-    res.json({ ok: true, mode: isPgliteMode ? 'pglite' : 'real-pg', seeded });
+    res.json({ ok: true, mode: isPgliteMode ? 'pglite' : 'real-pg', seeded, phase7Seeded });
   } catch (err) {
     next(err);
   }
@@ -190,14 +195,20 @@ router.get('/state', async (_req, res, next) => {
   try {
     const airtableState = _snapshotAllTables();
     const counts = {};
+    const pg = {};
     if (db) {
-      const tables = { auditLog, parityLog, stock, orders, orderLines, deliveries, customers, keyPeople, legacyOrders };
+      const tables = {
+        auditLog, parityLog, stock, orders, orderLines, deliveries,
+        customers, keyPeople, legacyOrders,
+        stockOrders, stockOrderLines, premadeBouquets, premadeBouquetLines,
+      };
       for (const [name, tbl] of Object.entries(tables)) {
         const rows = await db.select().from(tbl);
         counts[name] = rows.length;
+        pg[name]    = rows;  // full row dump — useful for E2E invariants like `pg.stockOrders.length === 2`
       }
     }
-    res.json({ airtable: airtableState, postgresCounts: counts });
+    res.json({ airtable: airtableState, postgresCounts: counts, pg });
   } catch (err) {
     next(err);
   }

--- a/backend/src/services/__fixtures__/airtable-test-base.json
+++ b/backend/src/services/__fixtures__/airtable-test-base.json
@@ -7,12 +7,14 @@
       "Phone": "+48 555 100 001",
       "Email": "maria.test@example.com",
       "Language": "pl",
-      "Home address": "ul. Floriańska 1, 31-019 Kraków",
+      "Home address": "ul. Floria\u0144ska 1, 31-019 Krak\u00f3w",
       "Sex / Business": "Female",
       "Segment (client)": "VIP",
       "Communication method": "Phone",
       "Order Source": "Phone",
-      "App Orders": ["recMockOrd1"]
+      "App Orders": [
+        "recMockOrd1"
+      ]
     },
     {
       "id": "recMockCust2",
@@ -21,34 +23,38 @@
       "Phone": "+48 555 100 002",
       "Email": "anna.test@example.com",
       "Language": "pl",
-      "Home address": "ul. Grodzka 5, 31-006 Kraków",
+      "Home address": "ul. Grodzka 5, 31-006 Krak\u00f3w",
       "Sex / Business": "Female",
       "Segment (client)": "Regular",
       "Communication method": "WhatsApp",
       "Order Source": "Wix",
-      "App Orders": ["recMockOrd2"]
+      "App Orders": [
+        "recMockOrd2"
+      ]
     },
     {
       "id": "recMockCust3",
-      "Name": "Tomasz Wiśniewski",
+      "Name": "Tomasz Wi\u015bniewski",
       "Nickname": "Tomek",
       "Phone": "+48 555 100 003",
       "Email": "tomasz.test@example.com",
       "Language": "pl",
-      "Home address": "ul. Karmelicka 8, 31-128 Kraków",
+      "Home address": "ul. Karmelicka 8, 31-128 Krak\u00f3w",
       "Sex / Business": "Male",
       "Segment (client)": "Rare",
       "Communication method": "Phone",
       "Order Source": "In-store",
-      "App Orders": ["recMockOrd3"]
+      "App Orders": [
+        "recMockOrd3"
+      ]
     },
     {
       "id": "recMockCust4",
-      "Name": "Kawiarnia Pod Lipą",
+      "Name": "Kawiarnia Pod Lip\u0105",
       "Phone": "+48 555 100 004",
       "Email": "biuro.test@example.com",
       "Language": "pl",
-      "Home address": "ul. Szewska 12, 31-009 Kraków",
+      "Home address": "ul. Szewska 12, 31-009 Krak\u00f3w",
       "Sex / Business": "Business",
       "Segment (client)": "Business",
       "Communication method": "Email",
@@ -62,7 +68,7 @@
       "Phone": "+48 555 100 005",
       "Email": "iwona.test@example.com",
       "Language": "pl",
-      "Home address": "ul. Bracka 3, 31-005 Kraków",
+      "Home address": "ul. Bracka 3, 31-005 Krak\u00f3w",
       "Sex / Business": "Female",
       "Segment (client)": "Regular",
       "Communication method": "Phone",
@@ -223,7 +229,9 @@
     {
       "id": "recMockOrd1",
       "App Order ID": "BLO-20260427-1",
-      "Customer": ["recMockCust1"],
+      "Customer": [
+        "recMockCust1"
+      ],
       "Customer Request": "Romantic bouquet for anniversary, mostly roses",
       "Source": "Phone",
       "Delivery Type": "Delivery",
@@ -232,7 +240,7 @@
       "Delivery Time": "afternoon",
       "Notes Original": "Wife loves red roses",
       "Florist Note": "",
-      "Greeting Card Text": "С годовщиной, любимая!",
+      "Greeting Card Text": "\u0421 \u0433\u043e\u0434\u043e\u0432\u0449\u0438\u043d\u043e\u0439, \u043b\u044e\u0431\u0438\u043c\u0430\u044f!",
       "Payment Status": "Paid",
       "Payment Method": "Cash",
       "Payment 1 Amount": 235,
@@ -240,13 +248,20 @@
       "Delivery Fee": 25,
       "Status": "New",
       "Created By": "Owner",
-      "Order Lines": ["recMockLine1", "recMockLine2"],
-      "Deliveries": ["recMockDel1"]
+      "Order Lines": [
+        "recMockLine1",
+        "recMockLine2"
+      ],
+      "Deliveries": [
+        "recMockDel1"
+      ]
     },
     {
       "id": "recMockOrd2",
       "App Order ID": "BLO-20260427-2",
-      "Customer": ["recMockCust2"],
+      "Customer": [
+        "recMockCust2"
+      ],
       "Customer Request": "Spring vibes, tulips and daisies",
       "Source": "Wix",
       "Delivery Type": "Delivery",
@@ -260,13 +275,19 @@
       "Delivery Fee": 20,
       "Status": "Ready",
       "Created By": "Wix Webhook",
-      "Order Lines": ["recMockLine3"],
-      "Deliveries": ["recMockDel2"]
+      "Order Lines": [
+        "recMockLine3"
+      ],
+      "Deliveries": [
+        "recMockDel2"
+      ]
     },
     {
       "id": "recMockOrd3",
       "App Order ID": "BLO-20260427-3",
-      "Customer": ["recMockCust3"],
+      "Customer": [
+        "recMockCust3"
+      ],
       "Customer Request": "Pickup, simple bouquet",
       "Source": "In-store",
       "Delivery Type": "Pickup",
@@ -276,15 +297,21 @@
       "Delivery Fee": 0,
       "Status": "New",
       "Created By": "Owner",
-      "Order Lines": ["recMockLine4"],
+      "Order Lines": [
+        "recMockLine4"
+      ],
       "Deliveries": []
     }
   ],
   "tblMockOrderLines": [
     {
       "id": "recMockLine1",
-      "Order": ["recMockOrd1"],
-      "Stock Item": ["recMockStock1"],
+      "Order": [
+        "recMockOrd1"
+      ],
+      "Stock Item": [
+        "recMockStock1"
+      ],
       "Flower Name": "Red Rose",
       "Quantity": 12,
       "Cost Price Per Unit": 4.5,
@@ -293,8 +320,12 @@
     },
     {
       "id": "recMockLine2",
-      "Order": ["recMockOrd1"],
-      "Stock Item": ["recMockStock3"],
+      "Order": [
+        "recMockOrd1"
+      ],
+      "Stock Item": [
+        "recMockStock3"
+      ],
       "Flower Name": "White Lily",
       "Quantity": 5,
       "Cost Price Per Unit": 6.0,
@@ -303,8 +334,12 @@
     },
     {
       "id": "recMockLine3",
-      "Order": ["recMockOrd2"],
-      "Stock Item": ["recMockStock2"],
+      "Order": [
+        "recMockOrd2"
+      ],
+      "Stock Item": [
+        "recMockStock2"
+      ],
       "Flower Name": "Pink Tulip",
       "Quantity": 8,
       "Cost Price Per Unit": 3.0,
@@ -313,8 +348,12 @@
     },
     {
       "id": "recMockLine4",
-      "Order": ["recMockOrd3"],
-      "Stock Item": ["recMockStock4"],
+      "Order": [
+        "recMockOrd3"
+      ],
+      "Stock Item": [
+        "recMockStock4"
+      ],
       "Flower Name": "Yellow Daisy",
       "Quantity": 6,
       "Cost Price Per Unit": 2.0,
@@ -325,8 +364,10 @@
   "tblMockDeliveries": [
     {
       "id": "recMockDel1",
-      "Linked Order": ["recMockOrd1"],
-      "Delivery Address": "ul. Floriańska 1, 31-019 Kraków",
+      "Linked Order": [
+        "recMockOrd1"
+      ],
+      "Delivery Address": "ul. Floria\u0144ska 1, 31-019 Krak\u00f3w",
       "Recipient Name": "Maria Kowalska",
       "Recipient Phone": "+48 555 100 001",
       "Delivery Date": "2026-04-28",
@@ -340,8 +381,10 @@
     },
     {
       "id": "recMockDel2",
-      "Linked Order": ["recMockOrd2"],
-      "Delivery Address": "ul. Grodzka 5, 31-006 Kraków",
+      "Linked Order": [
+        "recMockOrd2"
+      ],
+      "Delivery Address": "ul. Grodzka 5, 31-006 Krak\u00f3w",
       "Recipient Name": "Anna Nowak",
       "Recipient Phone": "+48 555 100 002",
       "Delivery Date": "2026-04-28",
@@ -351,61 +394,6 @@
       "Delivery Method": "Driver",
       "Driver Payout": 12,
       "Status": "Pending"
-    }
-  ],
-  "tblMockStockOrders": [
-    {
-      "id": "recMockPO1",
-      "Stock Order ID": "PO-20260427-1",
-      "Status": "Draft",
-      "Assigned Driver": "Timur",
-      "Created Date": "2026-04-27",
-      "Planned Date": "2026-04-29",
-      "Stock Order Lines": ["recMockPOLine1", "recMockPOLine2"]
-    },
-    {
-      "id": "recMockPO2",
-      "Stock Order ID": "PO-20260427-2",
-      "Status": "Sent",
-      "Assigned Driver": "Nikita",
-      "Created Date": "2026-04-27",
-      "Planned Date": "2026-04-28",
-      "Stock Order Lines": ["recMockPOLine3"]
-    }
-  ],
-  "tblMockStockOrderLines": [
-    {
-      "id": "recMockPOLine1",
-      "Stock Orders": ["recMockPO1"],
-      "Stock Item": ["recMockStock7"],
-      "Flower Name": "Peony",
-      "Quantity Needed": 30,
-      "Supplier": "FlowerNet",
-      "Cost Price": 8.0,
-      "Sell Price": 28,
-      "Lot Size": 5
-    },
-    {
-      "id": "recMockPOLine2",
-      "Stock Orders": ["recMockPO1"],
-      "Stock Item": ["recMockStock9"],
-      "Flower Name": "Sunflower",
-      "Quantity Needed": 15,
-      "Supplier": "Hurt-Kwiat",
-      "Cost Price": 4.0,
-      "Sell Price": 14,
-      "Lot Size": 10
-    },
-    {
-      "id": "recMockPOLine3",
-      "Stock Orders": ["recMockPO2"],
-      "Stock Item": ["recMockStock5"],
-      "Flower Name": "Blue Iris",
-      "Quantity Needed": 20,
-      "Supplier": "FlowerNet",
-      "Cost Price": 5.5,
-      "Sell Price": 18,
-      "Lot Size": 10
     }
   ],
   "tblMockAppConfig": [
@@ -432,7 +420,5 @@
   "tblMockStockPurchases": [],
   "tblMockLegacyOrders": [],
   "tblMockProductConfig": [],
-  "tblMockSyncLog": [],
-  "tblMockPremadeBouquets": [],
-  "tblMockPremadeBouquetLines": []
+  "tblMockSyncLog": []
 }

--- a/backend/src/services/airtableSchema.js
+++ b/backend/src/services/airtableSchema.js
@@ -30,31 +30,15 @@ import { TABLES } from '../config/airtable.js';
 // or service starts writing it. Stale entries are harmless (they just
 // mean "still expected to exist") but missing entries defeat the guard.
 const EXPECTED_WRITE_FIELDS = {
-  [TABLES.STOCK_ORDER_LINES]: [
-    'Stock Orders', 'Stock Item', 'Flower Name', 'Quantity Needed',
-    'Supplier', 'Cost Price', 'Sell Price', 'Lot Size', 'Farmer',
-    'Driver Status', 'Quantity Found',
-    'Alt Supplier', 'Alt Quantity Found', 'Alt Flower Name', 'Alt Cost',
-    'Quantity Accepted', 'Write Off Qty', 'Notes',
-    'Price Needs Review', 'Eval Status',
-  ],
-  [TABLES.STOCK_ORDERS]: [
-    'Status', 'Assigned Driver', 'Created Date', 'Planned Date',
-    'Stock Order ID', 'Supplier Payments', 'Driver Payment',
-  ],
   [TABLES.STOCK]: [
     'Display Name', 'Purchase Name', 'Category',
     'Current Quantity', 'Current Cost Price', 'Current Sell Price',
     'Supplier', 'Unit', 'Reorder Threshold', 'Active', 'Last Restocked',
     'Substitute For',
   ],
-  [TABLES.PREMADE_BOUQUETS]: [
-    'Name', 'Created By', 'Price Override', 'Notes', 'Lines',
-  ],
-  [TABLES.PREMADE_BOUQUET_LINES]: [
-    'Premade Bouquets', 'Stock Item', 'Flower Name', 'Quantity',
-    'Cost Price Per Unit', 'Sell Price Per Unit',
-  ],
+  // Phase 7 (2026-05-08) migrated STOCK_ORDERS, STOCK_ORDER_LINES,
+  // PREMADE_BOUQUETS, PREMADE_BOUQUET_LINES to Postgres. Tables are frozen
+  // — no backend writes hit them anymore, so no schema-drift risk to guard.
   [TABLES.CUSTOMERS]: [
     'Name', 'Nickname', 'Phone', 'Email', 'Link', 'Language',
     'Home address', 'Sex / Business',

--- a/backend/src/services/orderService.js
+++ b/backend/src/services/orderService.js
@@ -747,15 +747,19 @@ export async function findOrdersNeedingSubstitution(substitutionsMade) {
   // Pull customer names
   const custIds = [...new Set(openOrders.map(o => o.Customer?.[0]).filter(Boolean))];
   const customers = custIds.length ? await customerRepo.findMany(custIds) : [];
-  const custByPgId = {};
+  // orders.customer_id may be a recXXX (pre-cutover) or uuid (post-cutover).
+  // findMany() returns customers with id (uuid) and airtableId (recXXX or null).
+  // Key by both so the lookup matches whatever format was stored on orders.
+  const custByEitherId = {};
   for (const c of customers) {
-    if (c._pgId) custByPgId[c._pgId] = c;
+    if (c.id)         custByEitherId[c.id]         = c;
+    if (c.airtableId) custByEitherId[c.airtableId] = c;
   }
 
   const orderInfo = {};
   for (const o of openOrders) {
     const cid = o.Customer?.[0];
-    const cust = cid ? custByPgId[cid] : null;
+    const cust = cid ? custByEitherId[cid] : null;
     orderInfo[o._pgId] = {
       appOrderId:   o['App Order ID'] || '',
       customerName: cust?.Name || cust?.Nickname || '',

--- a/backend/src/services/orderService.js
+++ b/backend/src/services/orderService.js
@@ -6,6 +6,7 @@ import * as stockRepo from '../repos/stockRepo.js';
 import * as orderRepo from '../repos/orderRepo.js';
 import * as customerRepo from '../repos/customerRepo.js';
 import * as stockLossRepo from '../repos/stockLossRepo.js';
+import * as premadeBouquetRepo from '../repos/premadeBouquetRepo.js';
 import { TABLES } from '../config/airtable.js';
 import { broadcast } from './notifications.js';
 import { notifyNewOrder, notifyDeliveryComplete } from './telegram.js';
@@ -251,24 +252,23 @@ export async function createOrder(params, config, opts = {}) {
         for (const { stockId, patch } of stockUpdates) {
           await stockRepo.update(stockId, patch);
         }
-        // Cascade to Premade Bouquet Lines. Same pattern as PATCH /stock:id —
-        // fetch all lines once and filter in memory by Stock Item link
-        // (filterByFormula on linked records returns display names, not IDs).
-        if (TABLES.PREMADE_BOUQUET_LINES) {
-          const allPremadeLines = await db.list(TABLES.PREMADE_BOUQUET_LINES, {
-            fields: ['Stock Item'],
-            maxRecords: 500,
-          });
+        // Cascade price changes to Premade Bouquet Lines via the repo.
+        // Uses getLinesByStockId per affected stock item to avoid a full-table scan.
+        try {
           const stockToPatch = new Map(stockUpdates.map(u => [u.stockId, u.patch]));
-          for (const pbl of allPremadeLines) {
-            const linkedStockId = Array.isArray(pbl['Stock Item']) ? pbl['Stock Item'][0] : null;
-            const stockPatch = linkedStockId ? stockToPatch.get(linkedStockId) : null;
-            if (!stockPatch) continue;
-            const linePatch = {};
-            if ('Current Cost Price' in stockPatch) linePatch['Cost Price Per Unit'] = stockPatch['Current Cost Price'];
-            if ('Current Sell Price' in stockPatch) linePatch['Sell Price Per Unit'] = stockPatch['Current Sell Price'];
-            await db.update(TABLES.PREMADE_BOUQUET_LINES, pbl.id, linePatch);
+          for (const [stockId, stockPatch] of stockToPatch) {
+            const matchingLines = await premadeBouquetRepo.getLinesByStockId(stockId);
+            for (const pbl of matchingLines) {
+              const linePatch = {};
+              if ('Current Cost Price' in stockPatch) linePatch['Cost Price Per Unit'] = stockPatch['Current Cost Price'];
+              if ('Current Sell Price' in stockPatch) linePatch['Sell Price Per Unit'] = stockPatch['Current Sell Price'];
+              if (Object.keys(linePatch).length > 0) {
+                await premadeBouquetRepo.updateLine(pbl.id, linePatch);
+              }
+            }
           }
+        } catch (err) {
+          console.error('[ORDER] premade price-sync cascade failed:', err.message);
         }
       }
     }
@@ -714,4 +714,73 @@ export async function editBouquetLines(orderId, { lines = [], removedLines = [] 
   }
 
   return { updated: true, createdLines };
+}
+
+/**
+ * After a Stock Order evaluation creates Substitutes, find which open orders
+ * (delivery date in the future, non-terminal) have lines pointing at the
+ * original Stock Item — those orders need owner reconciliation.
+ *
+ * @param {Array} substitutionsMade - [{ originalStockId, originalFlowerName, substituteStockId, receivedQty }]
+ * @returns {Array} - same shape with `affectedOrders: [{ orderId, appOrderId, customerName, requiredBy, qty }]` populated
+ */
+export async function findOrdersNeedingSubstitution(substitutionsMade) {
+  if (!Array.isArray(substitutionsMade) || substitutionsMade.length === 0) return [];
+
+  const today = new Date().toISOString().split('T')[0];
+  const openOrders = await orderRepo.list({
+    pg: {
+      excludeStatuses: [ORDER_STATUS.DELIVERED, ORDER_STATUS.PICKED_UP, ORDER_STATUS.CANCELLED],
+      requiredByFrom:  today,
+      limit:           500,
+    },
+  });
+
+  if (!openOrders.length) {
+    return substitutionsMade.map(s => ({ ...s, affectedOrders: [] }));
+  }
+
+  // Pull lines for these orders (UUIDs only — _pgId is the canonical FK)
+  const orderUuids = openOrders.map(o => o._pgId).filter(Boolean);
+  const allLines = await orderRepo.getLinesForOrders(orderUuids);
+
+  // Pull customer names
+  const custIds = [...new Set(openOrders.map(o => o.Customer?.[0]).filter(Boolean))];
+  const customers = custIds.length ? await customerRepo.findMany(custIds) : [];
+  const custByPgId = {};
+  for (const c of customers) {
+    if (c._pgId) custByPgId[c._pgId] = c;
+  }
+
+  const orderInfo = {};
+  for (const o of openOrders) {
+    const cid = o.Customer?.[0];
+    const cust = cid ? custByPgId[cid] : null;
+    orderInfo[o._pgId] = {
+      appOrderId:   o['App Order ID'] || '',
+      customerName: cust?.Name || cust?.Nickname || '',
+      requiredBy:   o['Required By'] || null,
+    };
+  }
+
+  return substitutionsMade.map(sub => {
+    const affectedOrders = [];
+    for (const line of allLines) {
+      // stockItemId on order_lines is text — may hold recXXX or uuid.
+      // sub.originalStockId comes from stockOrderRepo.lineToWire which uses
+      // stock_airtable_id || stock_id, so the format matches whichever was
+      // originally assigned to both sides.
+      if (line.stockItemId !== sub.originalStockId) continue;
+      const oi = orderInfo[line.orderId];
+      if (!oi) continue;
+      affectedOrders.push({
+        orderId:      line.orderId,
+        appOrderId:   oi.appOrderId,
+        customerName: oi.customerName,
+        requiredBy:   oi.requiredBy,
+        qty:          Number(line.quantity || 0),
+      });
+    }
+    return { ...sub, affectedOrders };
+  });
 }

--- a/backend/src/services/premadeBouquetService.js
+++ b/backend/src/services/premadeBouquetService.js
@@ -1,81 +1,41 @@
-// Premade bouquet business logic.
+// Premade bouquet business logic. Phase 7: persistence via premadeBouquetRepo.
 //
 // A premade bouquet is a composition the florist builds BEFORE any order exists.
-// Stock is deducted at creation time (the flowers are physically in the bouquet).
-// Later the bouquet can either:
-//   1. Be matched to a client — at which point a real Order is created from its
-//      lines, the premade record is deleted, and stock is NOT re-deducted.
-//   2. Be returned to stock — the flowers go back to inventory and the premade
-//      record is deleted. No order is ever created.
-//
-// Design trade-off: we deliberately keep premade bouquets in a SEPARATE table
-// (not as Orders with a flag) because:
-//   - They have no customer, no delivery, no payment — all irrelevant until sold
-//   - The "return to stock" flow must not leave an order record behind
-//   - It's cleaner to archive/delete premades than to filter special statuses
-//     from every order query across the whole app.
+// Stock is deducted at creation time. The bouquet can later be:
+//   1. Matched to a client — Order created from its lines, premade record deleted.
+//   2. Returned to stock — flowers go back to inventory, premade record deleted.
 
-import * as db from './airtable.js';
+import * as premadeBouquetRepo from '../repos/premadeBouquetRepo.js';
 import * as stockRepo from '../repos/stockRepo.js';
-import { TABLES } from '../config/airtable.js';
 import { broadcast } from './notifications.js';
-import { listByIds } from '../utils/batchQuery.js';
 import { autoMatchStock, createOrder } from './orderService.js';
 
-/**
- * Fetch a premade bouquet with its lines enriched.
- * @returns {Promise<Object>} bouquet with `lines` array attached
- */
 export async function getPremadeBouquet(id) {
-  const bouquet = await db.getById(TABLES.PREMADE_BOUQUETS, id);
-  const lineIds = bouquet['Lines'] || [];
-  const lines = lineIds.length > 0
-    ? await listByIds(TABLES.PREMADE_BOUQUET_LINES, lineIds)
-    : [];
+  const bouquet = await premadeBouquetRepo.getById(id);
+  const lines = await premadeBouquetRepo.getLinesByBouquetId(bouquet._pgId);
   bouquet.lines = lines;
+  bouquet.Lines = lines.map(l => l.id);
   bouquet['Computed Sell Total'] = lines.reduce(
-    (s, l) => s + Number(l['Sell Price Per Unit'] || 0) * Number(l.Quantity || 0),
-    0,
-  );
+    (s, l) => s + Number(l['Sell Price Per Unit'] || 0) * Number(l.Quantity || 0), 0);
   bouquet['Computed Cost Total'] = lines.reduce(
-    (s, l) => s + Number(l['Cost Price Per Unit'] || 0) * Number(l.Quantity || 0),
-    0,
-  );
+    (s, l) => s + Number(l['Cost Price Per Unit'] || 0) * Number(l.Quantity || 0), 0);
   bouquet['Final Price'] = bouquet['Price Override'] || bouquet['Computed Sell Total'];
   return bouquet;
 }
 
-/**
- * List all premade bouquets with enriched lines + computed totals.
- */
 export async function listPremadeBouquets() {
-  const bouquets = await db.list(TABLES.PREMADE_BOUQUETS, {
-    sort: [{ field: 'Created At', direction: 'desc' }],
-    maxRecords: 200,
-  });
+  const bouquets = await premadeBouquetRepo.list();
   if (bouquets.length === 0) return [];
 
-  const allLineIds = bouquets.flatMap(b => b['Lines'] || []);
-  const allLines = await listByIds(TABLES.PREMADE_BOUQUET_LINES, allLineIds);
-  const linesByBouquet = {};
-  for (const line of allLines) {
-    const bid = line['Premade Bouquets']?.[0];
-    if (!bid) continue;
-    if (!linesByBouquet[bid]) linesByBouquet[bid] = [];
-    linesByBouquet[bid].push(line);
-  }
-
+  // Bulk fetch all lines via individual queries (small N — premades are 0–20 rows in practice)
   for (const bouquet of bouquets) {
-    const lines = linesByBouquet[bouquet.id] || [];
+    const lines = await premadeBouquetRepo.getLinesByBouquetId(bouquet._pgId);
     bouquet.lines = lines;
+    bouquet.Lines = lines.map(l => l.id);
     bouquet['Computed Sell Total'] = lines.reduce(
-      (s, l) => s + Number(l['Sell Price Per Unit'] || 0) * Number(l.Quantity || 0),
-      0,
-    );
+      (s, l) => s + Number(l['Sell Price Per Unit'] || 0) * Number(l.Quantity || 0), 0);
     bouquet['Computed Cost Total'] = lines.reduce(
-      (s, l) => s + Number(l['Cost Price Per Unit'] || 0) * Number(l.Quantity || 0),
-      0,
-    );
+      (s, l) => s + Number(l['Cost Price Per Unit'] || 0) * Number(l.Quantity || 0), 0);
     bouquet['Final Price'] = bouquet['Price Override'] || bouquet['Computed Sell Total'];
     bouquet['Bouquet Summary'] = lines
       .map(l => `${Number(l.Quantity || 0)}× ${l['Flower Name'] || '?'}`)
@@ -84,20 +44,9 @@ export async function listPremadeBouquets() {
   return bouquets;
 }
 
-/**
- * Create a premade bouquet + lines + deduct stock atomically with rollback.
- * @param {Object} params
- * @param {string} params.name
- * @param {Array}  params.lines - [{ flowerName, stockItemId?, quantity, costPricePerUnit, sellPricePerUnit }]
- * @param {number} [params.priceOverride]
- * @param {string} [params.notes]
- * @param {string} [params.createdBy]
- * @returns {Promise<{ bouquet, lines }>}
- */
 export async function createPremadeBouquet(params) {
   const { name, lines, priceOverride, notes, createdBy } = params;
 
-  // Validation
   if (!name || typeof name !== 'string' || !name.trim()) {
     const err = new Error('Premade bouquet name is required.');
     err.statusCode = 400;
@@ -109,32 +58,27 @@ export async function createPremadeBouquet(params) {
     throw err;
   }
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (typeof line.quantity !== 'number' || line.quantity <= 0) {
+    if (typeof lines[i].quantity !== 'number' || lines[i].quantity <= 0) {
       const err = new Error(`lines[${i}].quantity must be a positive number.`);
       err.statusCode = 400;
       throw err;
     }
   }
 
-  // Rollback tracking
   let bouquet = null;
   const createdLineIds = [];
   const stockAdjustments = [];
 
   try {
-    // 1. Create the parent record
-    bouquet = await db.create(TABLES.PREMADE_BOUQUETS, {
-      Name: name.trim(),
-      'Created By': createdBy || null,
+    bouquet = await premadeBouquetRepo.create({
+      Name:             name.trim(),
+      'Created By':     createdBy || '',
       'Price Override': priceOverride || null,
-      Notes: notes || '',
+      Notes:            notes || '',
     });
 
-    // 2a. Auto-match unlinked lines to stock by Display Name
     await autoMatchStock(lines);
 
-    // 2a-bis. Reject orphan lines — same rationale as orderService.createOrder().
     const orphans = lines.filter(l => !l.stockItemId);
     if (orphans.length > 0) {
       const names = orphans.map(o => o.flowerName || '(unnamed)').join(', ');
@@ -146,20 +90,18 @@ export async function createPremadeBouquet(params) {
       throw err;
     }
 
-    // 2b. Create the line records (price snapshotting)
     for (const line of lines) {
-      const created = await db.create(TABLES.PREMADE_BOUQUET_LINES, {
-        'Premade Bouquets':    [bouquet.id],
+      const created = await premadeBouquetRepo.createLine({
+        'Premade Bouquets':    [bouquet._pgId],
         'Stock Item':          [line.stockItemId],
         'Flower Name':         line.flowerName,
         Quantity:              line.quantity,
         'Cost Price Per Unit': line.costPricePerUnit || 0,
         'Sell Price Per Unit': line.sellPricePerUnit || 0,
       });
-      createdLineIds.push(created.id);
+      createdLineIds.push(created._pgId);
     }
 
-    // 3. Deduct stock via stockRepo (routes to current STOCK_BACKEND).
     for (const line of lines) {
       if (line.stockItemId) {
         await stockRepo.adjustQuantity(line.stockItemId, -line.quantity);
@@ -167,13 +109,7 @@ export async function createPremadeBouquet(params) {
       }
     }
 
-    // 4. Broadcast
-    broadcast({
-      type: 'premade_bouquet_created',
-      bouquetId: bouquet.id,
-      name: bouquet.Name,
-    });
-
+    broadcast({ type: 'premade_bouquet_created', bouquetId: bouquet.id, name: bouquet.Name });
     return await getPremadeBouquet(bouquet.id);
   } catch (err) {
     console.error('[PREMADE] Creation failed, rolling back:', err.message);
@@ -184,64 +120,44 @@ export async function createPremadeBouquet(params) {
       catch (e) { rollbackErrors.push(`stock ${adj.stockId}: ${e.message}`); }
     }
     for (const lineId of createdLineIds) {
-      try { await db.deleteRecord(TABLES.PREMADE_BOUQUET_LINES, lineId); }
+      try { await premadeBouquetRepo.deleteLineById(lineId); }
       catch (e) { rollbackErrors.push(`line ${lineId}: ${e.message}`); }
     }
     if (bouquet) {
-      try { await db.deleteRecord(TABLES.PREMADE_BOUQUETS, bouquet.id); }
-      catch (e) { rollbackErrors.push(`bouquet ${bouquet.id}: ${e.message}`); }
+      try { await premadeBouquetRepo.deleteById(bouquet._pgId); }
+      catch (e) { rollbackErrors.push(`bouquet ${bouquet._pgId}: ${e.message}`); }
     }
-    if (rollbackErrors.length > 0) {
-      console.error('[PREMADE] Rollback errors:', rollbackErrors);
-    }
+    if (rollbackErrors.length > 0) console.error('[PREMADE] Rollback errors:', rollbackErrors);
     throw err;
   }
 }
 
-/**
- * Update top-level fields (name, price override, notes). Does NOT edit lines.
- */
 export async function updatePremadeBouquet(id, patch) {
   const fields = {};
-  if (patch.name !== undefined) fields.Name = patch.name;
+  if (patch.name !== undefined)          fields.Name             = patch.name;
   if (patch.priceOverride !== undefined) fields['Price Override'] = patch.priceOverride || null;
-  if (patch.notes !== undefined) fields.Notes = patch.notes;
-  await db.update(TABLES.PREMADE_BOUQUETS, id, fields);
+  if (patch.notes !== undefined)         fields.Notes            = patch.notes;
+  await premadeBouquetRepo.update(id, fields);
   return await getPremadeBouquet(id);
 }
 
-/**
- * Edit bouquet lines — handle removals (return to stock), new lines, qty changes.
- * Mirrors editBouquetLines() in orderService.js but for premade bouquets.
- * @param {string} id - premade bouquet record ID
- * @param {Object} params
- * @param {Array}  params.lines - [{ id?, stockItemId, flowerName, quantity, _originalQty?, costPricePerUnit, sellPricePerUnit }]
- * @param {Array}  params.removedLines - [{ lineId?, stockItemId, quantity }]
- * @returns {{ updated: true, createdLines }}
- */
 export async function editPremadeBouquetLines(id, { lines = [], removedLines = [] }) {
-  // Verify bouquet exists
-  await db.getById(TABLES.PREMADE_BOUQUETS, id);
+  const bouquet = await premadeBouquetRepo.getById(id);
 
-  // 1. Handle removed lines — always return to stock (no writeoff for premade)
   for (const rem of removedLines) {
     if (rem.stockItemId && rem.quantity > 0) {
       await stockRepo.adjustQuantity(rem.stockItemId, rem.quantity);
     }
     if (rem.lineId) {
-      await db.deleteRecord(TABLES.PREMADE_BOUQUET_LINES, rem.lineId).catch(err =>
-        console.error(`[PREMADE] Failed to delete removed line ${rem.lineId}:`, err.message)
+      await premadeBouquetRepo.deleteLineById(rem.lineId).catch(err =>
+        console.error(`[PREMADE] Failed to delete removed line ${rem.lineId}:`, err.message),
       );
     }
   }
 
-  // 2a. Auto-match new unlinked lines
   const newUnmatched = lines.filter(l => !l.id && !l.stockItemId && l.flowerName);
-  if (newUnmatched.length > 0) {
-    await autoMatchStock(newUnmatched);
-  }
+  if (newUnmatched.length > 0) await autoMatchStock(newUnmatched);
 
-  // 2a-bis. Reject orphan new lines
   const orphans = lines.filter(l => !l.id && !l.stockItemId);
   if (orphans.length > 0) {
     const names = orphans.map(o => o.flowerName || '(unnamed)').join(', ');
@@ -253,25 +169,22 @@ export async function editPremadeBouquetLines(id, { lines = [], removedLines = [
     throw err;
   }
 
-  // 2b. Process new/updated lines
   const createdLines = [];
   for (const line of lines) {
     if (line.id) {
-      // Existing line — update quantity, adjust stock for delta
       if (line._originalQty != null && line.quantity !== line._originalQty) {
         const delta = line._originalQty - line.quantity;
         if (line.stockItemId && delta !== 0) {
           await stockRepo.adjustQuantity(line.stockItemId, delta);
         }
-        await db.update(TABLES.PREMADE_BOUQUET_LINES, line.id, { Quantity: line.quantity });
+        await premadeBouquetRepo.updateLine(line.id, { Quantity: line.quantity });
       }
     } else {
-      // New line — create + deduct stock
-      const created = await db.create(TABLES.PREMADE_BOUQUET_LINES, {
-        'Premade Bouquets': [id],
+      const created = await premadeBouquetRepo.createLine({
+        'Premade Bouquets':    [bouquet._pgId],
         ...(line.stockItemId ? { 'Stock Item': [line.stockItemId] } : {}),
-        'Flower Name': line.flowerName,
-        Quantity: line.quantity,
+        'Flower Name':         line.flowerName,
+        Quantity:              line.quantity,
         'Cost Price Per Unit': line.costPricePerUnit || 0,
         'Sell Price Per Unit': line.sellPricePerUnit || 0,
       });
@@ -285,68 +198,41 @@ export async function editPremadeBouquetLines(id, { lines = [], removedLines = [
   return { updated: true, createdLines };
 }
 
-/**
- * Return all flowers in a premade bouquet to stock, then delete the records.
- * Mirrors cancelWithStockReturn() in orderService.js.
- * @returns {{ message, returnedItems }}
- */
 export async function returnPremadeBouquetToStock(id) {
-  const bouquet = await db.getById(TABLES.PREMADE_BOUQUETS, id);
-  const lineIds = bouquet['Lines'] || [];
+  const bouquet = await premadeBouquetRepo.getById(id);
+  const lines = await premadeBouquetRepo.getLinesByBouquetId(bouquet._pgId);
   const returnedItems = [];
 
-  if (lineIds.length > 0) {
-    const lines = await listByIds(TABLES.PREMADE_BOUQUET_LINES, lineIds);
-    for (const line of lines) {
-      const stockId = line['Stock Item']?.[0];
-      const qty = Number(line.Quantity || 0);
-      if (stockId && qty > 0) {
-        try {
-          const { newQty } = await stockRepo.adjustQuantity(stockId, qty);
-          returnedItems.push({
-            stockId,
-            flowerName: line['Flower Name'] || '?',
-            quantityReturned: qty,
-            newStockQty: newQty,
-          });
-        } catch (err) {
-          if (err.statusCode === 404) {
-            console.warn(`[PREMADE] Stock item ${stockId} not found during return — skipping quantity restore for "${line['Flower Name'] || '?'}"`);
-          } else {
-            throw err;
-          }
+  for (const line of lines) {
+    const stockId = line['Stock Item']?.[0];
+    const qty = Number(line.Quantity || 0);
+    if (stockId && qty > 0) {
+      try {
+        const { newQty } = await stockRepo.adjustQuantity(stockId, qty);
+        returnedItems.push({
+          stockId,
+          flowerName:       line['Flower Name'] || '?',
+          quantityReturned: qty,
+          newStockQty:      newQty,
+        });
+      } catch (err) {
+        if (err.statusCode === 404) {
+          console.warn(`[PREMADE] Stock item ${stockId} not found during return — skipping quantity restore for "${line['Flower Name'] || '?'}"`);
+        } else {
+          throw err;
         }
       }
-      // Delete the line record
-      await db.deleteRecord(TABLES.PREMADE_BOUQUET_LINES, line.id).catch(err =>
-        console.error(`[PREMADE] Failed to delete returned line ${line.id}:`, err.message)
-      );
     }
   }
 
-  // Delete the bouquet record itself
-  await db.deleteRecord(TABLES.PREMADE_BOUQUETS, id);
+  // CASCADE deletes lines when the bouquet is deleted
+  await premadeBouquetRepo.deleteById(bouquet._pgId);
 
-  broadcast({
-    type: 'premade_bouquet_returned',
-    bouquetId: id,
-    name: bouquet.Name || '',
-  });
-
+  broadcast({ type: 'premade_bouquet_returned', bouquetId: id, name: bouquet.Name || '' });
   return { message: 'Premade bouquet returned to stock.', returnedItems };
 }
 
-/**
- * Match a premade bouquet to a customer — creates a real Order from the premade's
- * lines, deletes the premade, and does NOT re-deduct stock.
- *
- * @param {string} id - premade bouquet record ID
- * @param {Object} orderData - the fields a normal order needs (customer, deliveryType, delivery, etc.)
- * @param {Object} config - { getConfig, getDriverOfDay, generateOrderId }
- * @returns {Promise<{ order, orderLines, delivery, premadeBouquetId }>}
- */
 export async function matchPremadeBouquetToOrder(id, orderData, config) {
-  // 1. Load the premade + its lines
   const premade = await getPremadeBouquet(id);
   if (!premade.lines || premade.lines.length === 0) {
     const err = new Error('Premade bouquet has no lines — cannot match to order.');
@@ -354,56 +240,35 @@ export async function matchPremadeBouquetToOrder(id, orderData, config) {
     throw err;
   }
 
-  // 2. Convert premade lines to order-line format expected by createOrder.
-  //    Prices are taken from the premade snapshots so the customer pays exactly
-  //    what the florist/owner saw when composing/advertising the bouquet.
   const orderLines = premade.lines.map(l => ({
-    stockItemId: l['Stock Item']?.[0] || null,
-    flowerName: l['Flower Name'] || '',
-    quantity: Number(l.Quantity || 0),
+    stockItemId:      l['Stock Item']?.[0] || null,
+    flowerName:       l['Flower Name'] || '',
+    quantity:         Number(l.Quantity || 0),
     costPricePerUnit: Number(l['Cost Price Per Unit'] || 0),
     sellPricePerUnit: Number(l['Sell Price Per Unit'] || 0),
   }));
 
-  // 3. If the premade had a Price Override and the caller didn't supply one,
-  //    carry it over so the advertised price stays as the sale price.
   const priceOverride = orderData.priceOverride != null
     ? orderData.priceOverride
     : (premade['Price Override'] || null);
 
-  // 4. Create the order with stock deduction SKIPPED — stock was already
-  //    deducted when the premade was built.
   const result = await createOrder(
     {
       ...orderData,
       orderLines,
       priceOverride,
-      // Preserve any notes the florist captured at composition time
       notes: orderData.notes || premade.Notes || '',
     },
     config,
     { skipStockDeduction: true },
   );
 
-  // 5. Delete the premade records now that they've been "consumed" into the order.
-  //    If this fails, we log but don't throw — the order is already created and
-  //    the user shouldn't see a failure for a bookkeeping cleanup issue.
   try {
-    for (const line of premade.lines) {
-      await db.deleteRecord(TABLES.PREMADE_BOUQUET_LINES, line.id).catch(err =>
-        console.error(`[PREMADE] Failed to delete consumed line ${line.id}:`, err.message)
-      );
-    }
-    await db.deleteRecord(TABLES.PREMADE_BOUQUETS, id);
+    await premadeBouquetRepo.deleteById(premade._pgId);  // CASCADE removes lines
   } catch (cleanupErr) {
     console.error('[PREMADE] Cleanup after match failed:', cleanupErr.message);
   }
 
-  broadcast({
-    type: 'premade_bouquet_matched',
-    bouquetId: id,
-    orderId: result.order?.id || null,
-  });
-
+  broadcast({ type: 'premade_bouquet_matched', bouquetId: id, orderId: result.order?.id || null });
   return { ...result, premadeBouquetId: id };
 }

--- a/scripts/e2e-test.js
+++ b/scripts/e2e-test.js
@@ -262,7 +262,8 @@ async function section1Boot() {
   assert('Mock has 3 orders', state.body.airtable.tblMockOrders?.length === 3);
   assert('Mock has 4 order lines', state.body.airtable.tblMockOrderLines?.length === 4);
   assert('Mock has 2 deliveries', state.body.airtable.tblMockDeliveries?.length === 2);
-  assert('Mock has 2 POs', state.body.airtable.tblMockStockOrders?.length === 2);
+  // Phase 7: POs migrated to PG. Seeded by /test/reset via seedPhase7().
+  assert('PG has 2 POs', state.body.pg?.stockOrders?.length === 2);
 
   eq('PG audit_log empty after reset', state.body.postgresCounts.auditLog, 0);
   eq('PG parity_log empty after reset', state.body.postgresCounts.parityLog, 0);


### PR DESCRIPTION
## Summary

- Migrates the last two Airtable-writing domains (STOCK_ORDERS / STOCK_ORDER_LINES / PREMADE_BOUQUETS / PREMADE_BOUQUET_LINES) to Postgres via migration 0011
- Two new repos with dual-lookup (recXXX or uuid): `stockOrderRepo`, `premadeBouquetRepo`
- Fixes 5 live Airtable read bypasses in `stock.js` + 2 in `orderService.js` — all reading from frozen Airtable since 2026-05-02
- New PO marker format embeds the human-readable PO number (see ADR-0003) — old `recXXX` markers degrade gracefully
- `findOrdersNeedingSubstitution` extracted to `orderService.js` and uses orderRepo + customerRepo (was reading frozen Airtable)
- pglite fixture seed (`phase7-seed.js`) replaces airtable-mock PO/premade tables
- Backfill script: `backend/scripts/backfill-phase7.js` (DESTRUCTIVE, idempotent)

After this PR, **no Stock Orders / Premade Bouquets code path reads from or writes to Airtable.** Pre-existing bypasses in `orders.js`, `intake.js`, and `public.js` (read STOCK / DELIVERIES / ORDER_LINES from frozen Airtable) remain — to be addressed before PR 2 (Airtable retirement). PR 2 (separate plan) will delete `airtable.js` / `airtableSchema.js` / `config/airtable.js` / the `airtable` npm dependency / dead `STOCK_BACKEND` + `ORDER_BACKEND` flag logic + boot guard, then cancel the Airtable subscription.

## Verification (2026-05-08)

Per CLAUDE.md "Pre-PR Verification" matrix:

### Backend Vitest
```
Test Files  34 passed (34)
     Tests  343 passed | 1 todo (344)
```
The 1 todo captures a pre-existing write-off retry idempotency gap surfaced by the T9 Opus review. Standing investigation entry filed in BACKLOG; fix sketch is "extend ADR-0003 marker pattern to write-offs in stockLossRepo". Predates Phase 7.

### Shared Vitest
```
Test Files  13 passed (13)
     Tests  130 passed (130)
```

### Vite builds (all three apps green)
- `apps/florist`: `✓ built in 1.11s`
- `apps/dashboard`: `✓ built in 1.23s`
- `apps/delivery`: `✓ built in 549ms`

### E2E (`npm run harness && npm run test:e2e`)
```
  Total: 186 passed, 0 failed, 2.0s elapsed
```
Covers all 24 sections + Phase 5 customer CRUD + Phase 7 boot invariant `pg.stockOrders.length === 2`.

## Known Pitfalls touched (per CLAUDE.md)
- PO status state machine (Draft → Sent → Shopping → Reviewing → Evaluating → Complete + Eval Error retry) — preserved exactly. T8 + T9 had per-task Opus code-quality reviews.
- Stock math — unchanged. `effective = qty` formula intact.
- Idempotency on PO evaluate retry — receives gated by ADR-0003 markers (existing behaviour preserved); write-off gap captured by the `it.todo` test.

## Plan + ADR
- Plan: `docs/superpowers/plans/2026-05-08-phase7-stock-orders-premade.md`
- ADR-0003 (new): `docs/adr/0003-po-marker-format-dual-format.md` — dual-format PO marker compatibility
- ADR-0002 (corrected): `docs/adr/0002-demand-entry-aggregate-model.md` — receiveIntoStock creates a new Batch and zeroes the Demand Entry, not in-place rename

## Out of scope (PR 2)
Delete `airtable.js` / `airtable-real.js` / `airtable-mock.js` / `airtable-mock-formula.js` / `airtableSchema.js` / `config/airtable.js`. Drop `airtable` npm dep. Strip `STOCK_BACKEND` + `ORDER_BACKEND` flag logic + boot guard. Final Airtable snapshot. Cancel subscription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
