### PR TITLE
fix(public): warm products cache from /categories (Available Today menu)

### DIFF
--- a/backend/src/__tests__/publicRoutes.test.js
+++ b/backend/src/__tests__/publicRoutes.test.js
@@ -1,0 +1,116 @@
+// Regression test for the cold-cache bug in /api/public/categories.
+// Pre-fix: `productCount` for the `available-today` auto category was `null`
+// when the in-memory products cache was cold (process restart or TTL elapsed).
+// masterPage.js on the Wix storefront does `productCount > 0`, so `null > 0`
+// hid the menu entry even when qualifying products existed. The route now
+// shares the products fetcher and warms the cache inline.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+vi.mock('../repos/productConfigRepo.js', () => ({
+  list: vi.fn(),
+}));
+vi.mock('../services/airtable.js', () => ({
+  list: vi.fn(),
+}));
+vi.mock('../services/configService.js', () => ({
+  getConfig: vi.fn(),
+  getActiveSeasonalCategory: vi.fn(() => null),
+  getActiveSeasonalSlots: vi.fn(() => []),
+}));
+vi.mock('../config/airtable.js', () => ({
+  TABLES: { STOCK: 'Stock' },
+}));
+
+const productConfigRepo = await import('../repos/productConfigRepo.js');
+const airtable          = await import('../services/airtable.js');
+const configService     = await import('../services/configService.js');
+
+async function buildApp() {
+  // Re-import the router fresh so the module-level cache resets between tests.
+  vi.resetModules();
+  const app = express();
+  const m = await import('../routes/public.js');
+  app.use('/api/public', m.default);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  configService.getConfig.mockImplementation((key) => {
+    if (key === 'storefrontCategories') {
+      return {
+        permanent: [{ name: 'All Bouquets', slug: 'all-bouquets' }],
+        seasonal: [],
+        auto: [{ name: 'Available Today', slug: 'available-today', translations: {} }],
+      };
+    }
+    return null;
+  });
+});
+
+describe('GET /api/public/categories', () => {
+  it('returns numeric productCount for available-today on cold cache (regression)', async () => {
+    productConfigRepo.list.mockResolvedValue([
+      {
+        'Wix Product ID': 'prod-1',
+        'Product Name': 'Mix of the day - L',
+        'Variant Name': 'L',
+        'Wix Variant ID': 'var-1',
+        'Price': 250,
+        'Lead Time Days': 0,
+        'Min Stems': 0,
+        'Category': ['Available Today'],
+        'Active': true,
+      },
+      {
+        'Wix Product ID': 'prod-2',
+        'Product Name': 'Mix of the day - M',
+        'Variant Name': 'M',
+        'Wix Variant ID': 'var-2',
+        'Price': 180,
+        'Lead Time Days': 0,
+        'Min Stems': 0,
+        'Category': ['Available Today'],
+        'Active': true,
+      },
+    ]);
+    airtable.list.mockResolvedValue([]); // no stock rows needed — Min Stems=0 + no Key Flower → inStock via Infinity
+
+    const app = await buildApp();
+    const res = await request(app).get('/api/public/categories');
+
+    expect(res.status).toBe(200);
+    const at = res.body.auto.find(a => a.slug === 'available-today');
+    expect(at).toBeDefined();
+    expect(at.productCount).toBe(2);
+    // Pre-fix this was `null`. Guarding against regression to null.
+    expect(at.productCount).not.toBeNull();
+  });
+
+  it('returns 0 (not null) when no qualifying products exist', async () => {
+    productConfigRepo.list.mockResolvedValue([
+      {
+        'Wix Product ID': 'prod-3',
+        'Product Name': 'Slow lead',
+        'Wix Variant ID': 'var-3',
+        'Variant Name': 'std',
+        'Price': 100,
+        'Lead Time Days': 2,
+        'Min Stems': 0,
+        'Category': ['All Bouquets'],
+        'Active': true,
+      },
+    ]);
+    airtable.list.mockResolvedValue([]);
+
+    const app = await buildApp();
+    const res = await request(app).get('/api/public/categories');
+
+    expect(res.status).toBe(200);
+    const at = res.body.auto.find(a => a.slug === 'available-today');
+    expect(at.productCount).toBe(0);
+  });
+});

--- a/backend/src/routes/public.js
+++ b/backend/src/routes/public.js
@@ -16,15 +16,20 @@ const router = Router();
 const cache = {};
 const CACHE_TTL = 60_000; // ms
 
+async function getCachedOrBuild(key, fetcher) {
+  const now = Date.now();
+  if (cache[key] && now - cache[key].ts < CACHE_TTL) {
+    return cache[key].data;
+  }
+  const data = await fetcher();
+  cache[key] = { data, ts: now };
+  return data;
+}
+
 function cached(key, fetcher) {
   return async (_req, res, next) => {
     try {
-      const now = Date.now();
-      if (cache[key] && now - cache[key].ts < CACHE_TTL) {
-        return res.json(cache[key].data);
-      }
-      const data = await fetcher();
-      cache[key] = { data, ts: now };
+      const data = await getCachedOrBuild(key, fetcher);
       res.json(data);
     } catch (err) {
       next(err);
@@ -35,7 +40,7 @@ function cached(key, fetcher) {
 // ── GET /api/public/products ───────────────────────────────
 // Returns all active products grouped for storefront display.
 // Wix Velo calls this to populate category repeaters.
-router.get('/products', cached('products', async () => {
+async function buildProductsPayload() {
   const rows = await productConfigRepo.list({ activeOnly: true });
 
   // Also fetch stock quantities for inStock check
@@ -129,7 +134,9 @@ router.get('/products', cached('products', async () => {
     products,
     updatedAt: new Date().toISOString(),
   };
-}));
+}
+
+router.get('/products', cached('products', buildProductsPayload));
 
 // ── GET /api/public/stock-availability ─────────────────────
 // Lightweight stock check — Wix Velo uses this for real-time badge updates.
@@ -189,7 +196,8 @@ router.get('/delivery-pricing', (req, res) => {
 // ── GET /api/public/categories ─────────────────────────────
 // Category structure for Wix nav — permanent + active seasonal + auto.
 // Returns a slug-keyed `categoryMap` so Velo can look up any category's translations.
-router.get('/categories', (_req, res) => {
+router.get('/categories', async (_req, res, next) => {
+  try {
   const sc = getConfig('storefrontCategories') || {};
   const activeSlots = getActiveSeasonalSlots();
   const seasonal  = activeSlots[0]?.category || null;
@@ -208,12 +216,15 @@ router.get('/categories', (_req, res) => {
   ];
   const allCategories = [...new Set([...permanentNames, ...allSeasonal])];
 
-  // Count "Available Today" products from the products cache (no extra Airtable call).
+  // Count "Available Today" products via the shared products payload — warms
+  // the cache if cold so masterPage.js (which only calls /categories) sees the
+  // real count instead of `null`. Without this, the menu hid Available Today
+  // on any cold-cache page load even though qualifying products existed.
   // Must match push criteria: availableToday (LT=0 + inStock) AND tagged with "Available Today" category.
-  const productsCached = cache['products']?.data;
-  const availTodayCount = productsCached
-    ? productsCached.products.filter(p => p.availableToday && p.category.includes('Available Today')).length
-    : null; // null = cache not warmed yet, frontend should treat as unknown
+  const productsPayload = await getCachedOrBuild('products', buildProductsPayload);
+  const availTodayCount = productsPayload.products.filter(
+    p => p.availableToday && p.category.includes('Available Today')
+  ).length;
 
   // Build auto array as objects with productCount (not bare strings)
   const autoObjects = auto.map(a => {
@@ -259,6 +270,9 @@ router.get('/categories', (_req, res) => {
     categoryMap,
     seasonalSlugs,
   });
+  } catch (err) {
+    next(err);
+  }
 });
 
 // ── Helpers ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `/api/public/categories` returned `productCount: null` for `available-today` whenever the products cache was cold. masterPage.js does `productCount > 0`, so the Available Today menu silently disappeared on cold-cache page loads even when qualifying products existed.
- Refactored: extracted `buildProductsPayload()`, added `getCachedOrBuild()` helper, `/categories` now shares the fetcher and warms the cache inline.
- Added regression test (`backend/src/__tests__/publicRoutes.test.js`) covering cold-cache + zero cases.

## Verification
- `cd backend && npx vitest run` — 345/345 pass (35 files).
- Manual harness repro: cold curl of `/api/public/categories` returns numeric `productCount` (0 for empty fixture); pre-fix returned `null`.
- Production repro confirmed before fix: cold curl returned `null` while `/api/public/products` showed 3 qualifying bouquets.

## Test plan
- [ ] CI green (vitest + e2e)
- [ ] After merge + Railway deploy, hit `/api/public/categories` cold → `productCount` numeric
- [ ] Confirm Available Today menu reappears on Wix storefront

🤖 Generated with [Claude Code](https://claude.com/claude-code)