### PR TITLE
chore(workflow): thread Matt design discipline into /feature + add /audit

### DIFF
--- a/.claude/commands/audit.md
+++ b/.claude/commands/audit.md
@@ -1,0 +1,26 @@
+---
+description: "Architecture audit. Surfaces deep-module opportunities + shallow wrappers in named area. Pre-redesign or quarterly. No code edits — produces refactor issues."
+---
+
+# /audit `<area>`
+
+Wraps `improve-codebase-architecture` against `<area>` (file path, directory, or `CONTEXT.md` term). Read-only — surfaces candidates, files refactor issues, never edits code.
+
+## Sequence
+
+1. Read `CONTEXT.md` glossary + any ADRs in the area.
+2. `Explore` subagent walks modules. Note friction: bouncing between many small modules to understand one concept, modules where interface is nearly as complex as implementation, pure functions extracted only for testability with the real bugs hiding in callers, tightly-coupled modules leaking across seams.
+3. **Deletion test** per suspect module: deletion scatters complexity across N callers (deep, keep) vs vanishes it (shallow wrapper, merge inline).
+4. Present numbered candidate list. Per candidate: **files** / **problem** / **solution** (plain English) / **benefits** in locality + leverage + testability. Use CONTEXT.md vocabulary for domain, `improve-codebase-architecture/LANGUAGE.md` vocabulary for architecture (module/interface/seam/depth, not "component"/"service"/"boundary").
+5. **ADR conflicts.** Surface only when friction warrants reopening the ADR. Mark `_contradicts ADR-NNNN — but worth reopening because…_`. Don't list every refactor an ADR forbids.
+6. User picks candidates → convert chosen ones to refactor issues via `to-issues` (label `enhancement`, `needs-triage`). No interfaces designed yet — that's the implementing PR's job.
+
+## When to invoke
+
+- Before any major redesign (Stock overhaul, CRM rework, dashboard restructure).
+- Quarterly cadence.
+- When a module has been touched ≥5 times in 30 days (shallow-seam smell — repeated edits in one place often mean the abstraction is wrong).
+
+## Output
+
+Numbered candidate list in chat → user picks → issues filed. **No code edits in this command.**

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -1,111 +1,51 @@
 ---
-description: "Tuned superpowers chain for flower-studio: brainstorm → plan → worktree → subagent-driven exec → finish. Cost-disciplined defaults (Sonnet executors, batched reviews, tight prompts, MVP-sized plans)."
+description: "One workflow: grill → PRD → plan → vertical-slice issues → worktree → execute → ship. Matt design + superpowers execution. Use for any change > one-line."
 ---
 
-# /feature — tuned superpowers for flower-studio
+# /feature — flower-studio default workflow
 
-Run the full superpowers chain with the cost-discipline rules from `CLAUDE.md` enforced as hard defaults. Use this for any feature/bugfix that takes more than a one-line change. For typo fixes, dependency bumps, or doc-only PRs, skip and edit directly.
-
-The user invoked this with `/feature <one-line description>` (or no args; ask once if missing).
-
-## Hard-coded defaults (do not deviate without owner sign-off)
-
-These override the generic superpowers skill defaults. They exist to keep a feature inside one 5h Opus window instead of two.
-
-### Model selection per subagent role
-
-When spawning subagents via the `Agent` tool, **pass `model` explicitly**:
-
-| Role | Model | Why |
-|------|-------|-----|
-| `code-architect` / `writing-plans` driver / brainstorming partner | `opus` | Reasoning-heavy. Bad designs cost more than the model premium. |
-| `code-reviewer` (final pass + phase-boundary passes) | `opus` | Catches the bugs that ship. |
-| `systematic-debugging` driver | `opus` | Root-cause work. |
-| Implementer subagent (executes a written plan task) | `sonnet` | ~5× cheaper, adequate for "follow these steps + run these commands". |
-| Spec-compliance reviewer | `sonnet` | Mechanical diff vs. plan. |
-| Code-quality reviewer (between phases, not per task) | `opus` | The one place quality reviews actually pay off. |
-| `Explore` agent (greps, file lookups) | inherit (defaults to `sonnet`) | Fine. Don't override. |
-
-**Never default subagents to Opus.** That's the single biggest waste lever from the bouquet-image-upload burn (2× 5h Opus windows for one feature).
-
-### Review cadence: phase boundaries, not per task
-
-The default `subagent-driven-development` skill spec runs spec-reviewer + code-quality-reviewer **after every task**. For a 17-task plan that's ~34 review subagents, each re-reading CLAUDE.md + plan + spec.
-
-**Override:** group tasks into phases of 3–5. Run spec-compliance review **after each task** (cheap, Sonnet). Run code-quality review **only at phase boundaries** (Opus, expensive). Final code-reviewer pass over the whole branch diff before PR.
-
-**Exception — keep per-task code-quality review** when the task touches a Known Pitfall area from `CLAUDE.md`:
-- Status workflows (`backend/src/constants/statuses.js`, any `*Service.js` state machine)
-- Stock math (`packages/shared/utils/stockMath.js`, `StockItem.jsx`, `StockTab.jsx`)
-- Cancel-with-return (three lockstep files in CLAUDE.md Known Pitfalls #7)
-- Wix sync / webhook (`backend/src/services/wix*.js`, `backend/src/routes/wix*.js`)
-- Shadow-window writes (anything routed through `stockRepo` / `orderRepo` while a `*_BACKEND` flag is at `shadow`)
-
-### Pre-trim subagent prompts
-
-Don't paste the full plan into every executor subagent. The plan exists on disk under `docs/superpowers/plans/`. Each implementer gets:
-- The single task's section (verbatim, including its checklist)
-- The plan path so the subagent can read more if it needs to
-- The 3–5 file paths that task touches
-- The spec excerpt that constrains the task (1–2 paragraphs, not the whole spec)
-- Pointer to `CLAUDE.md` for repo conventions (subagent reads automatically)
-
-That's it. No prior tasks, no future tasks, no chat history.
-
-### Right-size plans
-
-Hard limits before starting `subagent-driven-development`:
-- ≤ 15 tasks
-- ≤ 1500 lines of plan markdown
-- Each task = one commit's worth (≤ ~300 LOC, ≤ 2 files in most cases)
-
-If `writing-plans` produces something larger, **split**: land an MVP first (≤ 8 tasks), file follow-up plans for the rest. The 2300-line bouquet-image-upload plan was a smell that cost a full Opus window.
-
-### Skip TDD red phase for low-signal task types
-
-TDD red/green stays mandatory for: new backend services, new shared utils, new shared hooks, new repos, anything in `Known Pitfalls`.
-
-**Skip the formal red phase** (write the test alongside or after instead) for:
-- Pure UI wiring (importing an existing shared component into a page)
-- CSS / Tailwind tweaks
-- Copy / translation changes (`packages/shared/translations.js`)
-- Doc-only edits
-- Simple route handlers that compose existing services with no new logic
-
-Verification via `superpowers:verification-before-completion` stays mandatory regardless.
-
-### Worktree mandatory
-
-If two Claude sessions might run in this repo, create a worktree under `.worktrees/<feature>/` via `superpowers:using-git-worktrees`. The cross-session git collisions of 2026-05-02 (stray commits, branch flips mid-task, mangled commit messages) were caused by skipping this.
-
-### Pre-PR verification gate
-
-Before announcing the PR is ready, run the check matrix from `CLAUDE.md` § "Pre-PR Verification". Specifically:
-1. Backend changes → `cd backend && npx vitest run` + `npm run harness &` then `npm run test:e2e`
-2. Shared changes → `cd packages/shared && ../../backend/node_modules/.bin/vitest run` AND build all three apps (`apps/florist`, `apps/dashboard`, `apps/delivery`)
-3. Single-app frontend changes → build that app, plus any other app touching files you changed in `packages/shared/`
-
-Quote the actual output. No "tests pass" claims without the green output in the conversation.
+Run for any change > one-line. Routes light work via bail-outs at bottom.
 
 ## Sequence
 
-0. **Branch hygiene gate** — before anything else, run `BRANCH_AUDIT_FRESH=1 bash .claude/hooks/branch-audit.sh` (or invoke `/branches` for an interactive audit). If the audit reports >2 stale branches >7d old without an open PR, OR any open PR by the current user that hasn't been touched in >5 days, **stop and resolve those first**. Land them, close them, or salvage to BACKLOG. The "pile new work onto whatever branch is checked out" trap that produced the May 2026 branch graveyard happens because new features get started while old ones are still half-shipped. Don't add to the pile.
-1. **`superpowers:brainstorming`** — explore intent + design. Skip if the user's prompt to `/feature` already pins scope down to file-level decisions.
-2. **`superpowers:writing-plans`** — write the plan to `docs/superpowers/plans/YYYY-MM-DD-<feature>.md`. Enforce the right-size limits above. If the plan exceeds them, propose an MVP split before continuing.
-3. **`superpowers:using-git-worktrees`** — `.worktrees/<feature>/` with branch `feat/<feature>` (or `fix/`, `chore/`, etc. per `CLAUDE.md`).
-4. **`superpowers:subagent-driven-development`** — execute with the model + review-cadence overrides above. Use phase-boundary reviews; per-task only for Known-Pitfall tasks.
-5. **`superpowers:verification-before-completion`** — run the check matrix, paste output.
-6. **`superpowers:finishing-a-development-branch`** — propose merge / PR / cleanup. PR description must name the verification path per `CLAUDE.md` § "Verification Gate".
+0. **Branch hygiene.** `BRANCH_AUDIT_FRESH=1 bash .claude/hooks/branch-audit.sh`. Resolve >2 stale branches, or any open PR by current user untouched >5d, before starting new work. Pile-new-onto-old caused the May 2026 branch graveyard.
 
-## When to bail to a lighter flow
+1. **`grill-with-docs`.** Stress-test design vs `CONTEXT.md` + `docs/adr/`. Update glossary inline as terms resolve. Output: locked scope. Skip only if user pre-grilled this turn.
 
-If after `brainstorming` it's clear the work is:
-- A single-file copy / Tailwind / translation change → drop the chain. Just edit + verify + commit.
-- A bug obvious from a stack trace → skip to `superpowers:systematic-debugging`, then edit + verify + commit. No plan, no worktree.
-- 1–3 file mechanical refactor → use `feature-dev:feature-dev` (single guided pass, no subagent fanout) instead of this command.
+2. **`to-prd`** — *mandatory* if feature touches ≥2 of {schema, API route, UI page, integration}. Publish PRD as GitHub Issue, label `needs-triage`. Threshold-below: skip.
 
-Tell the user explicitly: "This looks lighter than `/feature` warrants — proposing X instead."
+3. **`writing-plans`** with overrides. Plan saved to `docs/superpowers/plans/YYYY-MM-DD-<feature>.md`:
+   - **Vertical slices.** Each task = thin demoable path through all relevant layers (schema/API/UI/tests). Reject horizontal-only plans (Task 1 = all schema, Task 2 = all API…). Re-slice before continuing.
+   - **CONTEXT.md vocabulary.** Domain entities use exact glossary terms in task names + module boundaries. "Customer" not "client", "Demand Entry" not "placeholder", "Stock Item" not "product".
+   - **Deep modules.** For each new module: deletion test. If delete scatters complexity across N callers → keep (deep). If delete vanishes complexity → it's a shallow wrapper; merge inline.
+   - **Right-size.** ≤15 tasks, ≤1500 lines, ≤300 LOC + ≤2 files per task. Above → split MVP + follow-ups.
+
+4. **`to-issues`** — *mandatory* for ≥5-task plans. Break plan into AFK/HITL tracer-bullet GitHub Issues, label `needs-triage`. Issues track state; plan file = implementation reference.
+
+5. **`using-git-worktrees`.** `.worktrees/<feature>/` on `feat/<name>` (or `fix/`/`chore/` per CLAUDE.md prefixes). Never `claude/*`. Two simultaneous sessions in this repo → each in its own worktree. `git worktree list` before any branch op.
+
+6. **`subagent-driven-development`** with overrides:
+   - **Models:** implementer + spec-reviewer = `sonnet`. Code-quality reviewer + final reviewer = `opus`. Explore agent inherits (sonnet). **Never default subagents to opus.**
+   - **Review cadence:** spec-review per task (sonnet, cheap). Code-quality review **at phase boundaries only** (groups of 3–5 tasks, opus). Per-task code-quality only when task touches **Known Pitfalls**: statuses (`statuses.js`, `*Service.js` state machines), stock math (`stockMath.js`, `StockItem.jsx`, `StockTab.jsx`), cancel-with-return (3 lockstep files in CLAUDE.md Pitfall #7), Wix sync (`wix*.js`), shadow-window writes (anything via `stockRepo`/`orderRepo` while a `*_BACKEND` flag = `shadow`).
+   - **TDD vertical.** Implementer writes one test → one impl → commit. **Never bulk-write tests then bulk-implement.** Bulk tests test imagined behavior; they pass when behavior breaks and break when behavior is fine (Matt's `tdd` skill).
+   - **Skip TDD red phase** for: pure UI wiring, CSS/Tailwind, copy/translation, doc edits, route handlers composing existing services. **Mandatory red phase** for: new backend services, new shared utils/hooks, new repos, all Known Pitfall areas.
+   - **Tight prompts.** Implementer subagent gets: that task's section verbatim + plan path + ≤5 file paths + spec excerpt. **No prior tasks, no future tasks, no chat history.**
+
+7. **`verification-before-completion`.** Run Pre-PR matrix from `CLAUDE.md` § Pre-PR Verification (backend vitest + e2e if backend touched, shared vitest + build all 3 apps if shared touched, single app build for app-only changes, lab `lab:test:unit` + `lab:test:api` if backend/shared/lab touched). **Quote actual green output in chat.** Tracer-bullet tasks: also demo end-to-end (curl, screenshot, or Playwright run).
+
+8. **`finishing-a-development-branch`.** PR body names verification path per CLAUDE.md Verification Gate. List slice issues with `Closes #N` **on separate lines** — comma-separated only closes the first (burned PR #259).
+
+## Bail-outs
+
+Tell user explicitly: "Lighter than `/feature` warrants — proposing X."
+
+| Situation | Route |
+|---|---|
+| Bug touching prod data path | `diagnose` (Phase 0 prod sweep: Railway logs → PG → shadow-health, flower-studio-tuned). Fix → verify → PR. No plan, no worktree. |
+| Single-file CSS / Tailwind / copy / translation | Direct edit + verify + commit. |
+| 1–3 file mechanical refactor | `feature-dev:feature-dev` single guided pass. |
+| Architecture audit before redesign | `/audit <area>`. |
 
 ## Cost target
 
-A medium feature (5–15 files, no schema change, no shadow-window write) should fit in **one** 5h Opus window when this command's defaults are followed. If two windows look likely, the plan is too big — split it.
+Medium feature (5–15 files, no schema, no shadow writes) = **one** 5h Opus window when overrides above followed. Two windows likely → plan too big → split into MVP + follow-ups.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,60 +142,30 @@ When unsure which skill to invoke, consult this table. The right skill at the ri
 | Full feature from idea to PR | `/feature` | Bundles the full chain below |
 | Implement a feature or bugfix (with tests) | `tdd` or `superpowers:test-driven-development` | Red-green-refactor |
 | Bug, test failure, unexpected behavior | `diagnose` | Reproduce → minimise → hypothesise → fix loop |
-| Refactor or improve architecture | `improve-codebase-architecture` | Finds shallow services + deep module opportunities |
+| Architecture audit (pre-redesign / quarterly) | `/audit <area>` | Wraps `improve-codebase-architecture`. Surfaces deep modules + shallow wrappers. No code edits — produces refactor issues. |
 | Verify work before PR | `superpowers:verification-before-completion` | Evidence before assertions, always |
 | Branch cleanup | `/branches` | Prune gone branches |
 | Create or triage a GitHub issue | `triage` | Issue state machine |
 | New skill needed | `write-a-skill` | Proper structure + progressive disclosure |
 | Major UI overhaul / cross-cutting refactor / schema change | `lab/WORKFLOW.md` | Lab harness: scenario rehearsal + factory discipline + CI `lab-api` gate |
 
-**Canonical entry point: `/feature`.** The `.claude/commands/feature.md` command bundles the chain below with the cost-discipline overrides from this file (Sonnet executors, batched reviews, tight subagent prompts, MVP-sized plans, TDD red-phase exemptions). Use `/feature <one-line description>` instead of invoking the skills one-by-one — the command exists specifically so future sessions don't re-derive the discipline. The manual chain below is documented for cases where `/feature` is overkill or where you need to deviate.
+### Canonical entry: `/feature`
 
-**Branch hygiene gate.** The SessionStart hook at `.claude/hooks/branch-audit.sh` runs at every session start and surfaces local branches with `[gone]` upstream, finished worktrees, open PRs by the current user, and local branches >7d old without an upstream. If the hook flags issues, run `/branches` to clean up before starting new work — the May 2026 branch graveyard happened because new features were piled onto whatever branch was checked out instead of landing the prior work first. `/feature` enforces this gate at step 0; if you skip `/feature` for a quick fix, you can still hit it manually with `/branches`. The hook is read-only (never mutates); only `/branches` and `/feature` take destructive action, and only with the safety rails described in those commands.
+For any change > one-line, run `/feature <one-line description>`. Full sequence + cost-discipline overrides + bail-outs live in `.claude/commands/feature.md`. The chain threads Matt's design discipline (`grill-with-docs`, `to-prd`, `to-issues`, vertical slicing, deep modules, CONTEXT.md vocabulary) with superpowers' execution discipline (worktrees, subagent-driven dev, verification gate, branch finishing).
 
-For any feature/bugfix that takes more than a one-line change, this is the default sequence. Future Claude sessions in this repo should follow it without being asked:
+**Skip the chain only for:** typo fixes, one-line bugfixes obvious from a stack trace, dependency bumps, doc-only PRs.
 
-0. **`grill-with-docs`** (preferred when CONTEXT.md/ADRs in scope) or **`grill-me`** — stress-test the design against this project's domain language and prior architectural decisions BEFORE writing a spec. Skippable only if scope is already locked by the user.
-1. **`superpowers:brainstorming`** — explore intent + design BEFORE writing code. Invoked before any plan-mode entry. Skip only if the user has already locked in scope. For larger features, follow with **`to-prd`** to formalize requirements into a PRD, then **`to-issues`** to break them into tracer-bullet GitHub issues.
-2. **`superpowers:writing-plans`** — produce a phased implementation plan saved under `docs/superpowers/plans/YYYY-MM-DD-<feature>.md`. Plans use bite-sized checkbox steps with exact code + commands, no placeholders.
-3. **`superpowers:using-git-worktrees`** — create an isolated worktree under `.worktrees/<feature>/` so the session has its own checkout, branch, and index. **Never share the main repo's working tree across two Claude sessions** — the cross-session git collisions of 2026-05-02 (stray commits, branch flips mid-task, mangled commit messages) were caused by this. Main repo (top-level checkout) stays on `master` for general operations only.
-4. **`superpowers:subagent-driven-development`** — execute plan tasks via fresh subagents with two-stage review between tasks. Keeps the main context clean and parallelises independent work.
-5. **`tdd`** or **`superpowers:test-driven-development`** — write the failing test first, then the minimal implementation. Required for backend services + shared utils per the Testing Rules section above.
-6. **`superpowers:verification-before-completion`** — run the actual verification commands (tests, builds, smoke tests) and confirm their output BEFORE claiming the work is done. Evidence beats assertion. Especially load-bearing for prod cutovers and integration changes (also see "Verification Gate" below).
+### Hard rules `/feature` enforces (apply even when not running it)
 
-**Lab harness — see `lab/WORKFLOW.md` for the full guide.** Mandatory rules in summary:
-- Schema change (new column, new table, NOT NULL added) → update `lab/factories/<entity>.js` in the SAME PR. Otherwise the `lab-api` CI job fails on the PR with NOT NULL or unknown-column errors. The lab is the canonical place to keep "what does a row look like?" in sync with the schema.
-- Major UI overhaul (Stock redesign, CRM rework, etc.) → build a scenario under `lab/scenarios/<name>.js`, rebuild the template, drive the UI via Playwright + `lab/helpers/api.js` for rehearsal before merge.
-- Determinism tests must compare faker-derived stable fields only — never `created_at`/`updated_at` (Date instances drift on CI under load).
-- Pre-PR matrix MUST include `npm run lab:test:unit` + `npm run lab:test:api` whenever backend, packages/shared, or lab/ changes. The Pre-PR Verification section below has the full check list.
-
-**Bug workflow:** When a bug, test failure, or unexpected behavior appears — invoke **`diagnose`** FIRST. Do not propose hypotheses or fixes before completing the reproduce → minimise → instrument loop. This applies even when the cause looks obvious.
-
-Skip the chain only for: typo fixes, one-line bugfixes obvious from a stack trace, dependency bumps, or doc-only PRs.
-
-If two Claude sessions are active in this repo simultaneously, **each session must operate in its own worktree** under `.worktrees/`. Use `git worktree list` before any branch operation to see who's on what.
-
-### Cost discipline (added 2026-05-03 after 2× 5h Opus burn on bouquet-image-upload)
-
-The default chain above is non-negotiable for quality. These tunings cut token cost without weakening it.
-
-**Model selection per role.** Subagents inherit Opus unless overridden. Pass `model` explicitly when spawning agents via the `Agent` tool:
-- **Opus** — planning (`writing-plans`, `code-architect`), final review (`code-reviewer`, `requesting-code-review`), debugging (`systematic-debugging`), brainstorming. Reasoning-heavy steps.
-- **Sonnet** — execution subagents that follow a written plan task ("implement Task 7 exactly as specified"). Sonnet 4.6 is adequate for "follow these steps + run these commands" and ~5× cheaper. Use for: TDD red/green loops on backend services with a clear spec, UI wiring tasks, doc updates, mechanical refactors.
-- **Haiku** — never for code; OK for one-shot greps / file lookups via Explore agent if Sonnet feels overkill.
-
-**When to skip TDD** (still respect the Testing Rules section). TDD red/green is mandatory for: new backend services, new shared utils, new repos, new shared hooks. Skip the formal red phase for: pure UI wiring (importing an existing shared component into a page), CSS/Tailwind tweaks, copy/translation changes, doc-only edits, simple route handlers that compose existing services. For these, write the test alongside or after the implementation — verification still mandatory before commit.
-
-**Batched reviews, not per-task.** `subagent-driven-development` spec defaults to two reviewers (code-quality + spec-compliance) between every task. For a 17-task plan this spawns ~34 review subagents, each re-reading CLAUDE.md + plan + spec. Instead:
-- Run reviews **at phase boundaries** (groups of 3–5 related tasks), not after every task.
-- Final reviewer pass at the end, before the PR, covering the whole branch diff.
-- Keep per-task review only when a task touches a Known Pitfall area (status workflows, stock math, cancel-with-return, Wix sync, shadow-window writes).
-
-**Pre-trim subagent prompts.** Don't paste the full plan into every executor subagent. Paste only that task's section + relevant file paths + the spec excerpt that affects it. The plan exists on disk — the subagent can read the bits it needs.
-
-**Right-size plans.** A 2300-line plan for one feature is a smell. If a plan exceeds ~1500 lines or 15 tasks, split it: land an MVP first, file follow-ups for the rest. Each task should be one commit's worth (≤ ~300 LOC, ≤ 2 files in most cases).
-
-**Rough budget guide.** A 17-task feature like bouquet-image-upload should fit in **one** 5h Opus window when tuned per above (Sonnet for executors, batched reviews, tight subagent prompts). If two windows look likely, the plan is probably too big — split.
+- **Branch hygiene gate.** SessionStart hook (`.claude/hooks/branch-audit.sh`) flags `[gone]` upstreams, finished worktrees, open user PRs, and local branches >7d old without upstream. Run `/branches` before starting new work if flagged. May 2026 branch graveyard came from piling new features onto whatever branch was checked out instead of landing prior work first. The hook is read-only; only `/branches` and `/feature` take destructive action.
+- **Bug workflow.** Invoke `diagnose` FIRST (not `systematic-debugging`). Phase 0 prod-signal sweep (Railway logs → PG via `claude_ro` → shadow-health) is flower-studio-tuned. No hypotheses or fixes before reproduce → minimise → instrument, even when cause looks obvious.
+- **Architecture audit.** `/audit <area>` wraps `improve-codebase-architecture`. Use before major redesigns (Stock overhaul, CRM rework) or quarterly. Produces refactor issues, not edits.
+- **Worktree mandatory for parallel sessions.** Two Claude sessions in this repo simultaneously → each in its own `.worktrees/<feature>/`. Cross-session git collisions of 2026-05-02 (stray commits, branch flips, mangled commit messages) caused by skipping this. `git worktree list` before any branch op.
+- **Lab harness — see `lab/WORKFLOW.md`.** Mandatory rules:
+  - Schema change (new column, new table, NOT NULL added) → update `lab/factories/<entity>.js` in same PR. Otherwise CI `lab-api` fails on NOT NULL or unknown-column.
+  - Major UI overhaul → build scenario under `lab/scenarios/<name>.js`, rebuild template, Playwright rehearsal before merge.
+  - Determinism tests compare faker-derived stable fields only — never `created_at`/`updated_at` (drift on CI).
+  - Pre-PR matrix MUST include `npm run lab:test:unit` + `npm run lab:test:api` when backend, packages/shared, or lab/ changes.
 
 ## Workflow Rules
 - Update `CHANGELOG.md` for any schema, env, or deployment-affecting change


### PR DESCRIPTION
## Summary

- **`/feature.md` rewritten** (112→51 lines): full chain now threads Matt Pocock design discipline (`grill-with-docs` → `to-prd` → `writing-plans` with vertical-slice + CONTEXT.md + deep-module overrides → `to-issues`) into superpowers execution (worktrees → `subagent-driven-development` with anti-horizontal TDD + phase-boundary reviews → verification → finishing).
- **`/audit.md` new** (26 lines): wraps `improve-codebase-architecture`. Pre-redesign or quarterly. Read-only — surfaces deep modules + shallow wrappers, produces refactor issues, no code edits. First user: pre-Stock-overhaul audit.
- **`CLAUDE.md` compressed** (327→282 lines): "Default Workflow Skills" prose section trimmed from ~70 lines to 18. Quick-Reference table preserved (added `/audit` row). Cost-discipline section removed (lives only in `/feature.md` now — single source of truth).

## Why now

Two skill systems were used interchangeably without a coherent workflow gluing them. `/feature` was pure superpowers; Matt's `to-prd`, `to-issues`, vertical slicing, and deep-module discipline weren't enforced. Lab harness PR shipped with no PRD issue, no slice issues, plan-only state tracking.

Long instructions also get skimmed. Three-layer split now: CLAUDE.md (always-loaded scannable index + 5 gate rules), `/feature.md` (on-demand executable workflow, ~50 lines), skill files (on-invoke, unchanged).

## What's enforced now that wasn't

1. Vertical slices (reject horizontal Task1=schema/Task2=API/Task3=UI plans)
2. CONTEXT.md vocabulary in plans, tests, modules
3. Deep-module deletion test on every new module
4. Anti-horizontal TDD — implementer writes one test → one impl → commit, never bulk
5. PRD as GitHub Issue (mandatory ≥2-layer features)
6. Tracer-bullet slice issues (mandatory ≥5-task plans, gives owner AFK queue via triage labels)
7. Demoability check for tracer-bullet tasks
8. `diagnose` over `systematic-debugging` for prod bugs
9. `/audit` exists — pre-redesign architecture lever

## Test plan

- [x] Doc-only PR — no code paths exercised
- [x] CLAUDE.md syntax check (markdown structure preserved, table intact, headings correct)
- [x] `/feature.md` references valid skills (grill-with-docs, to-prd, writing-plans, to-issues, using-git-worktrees, subagent-driven-development, verification-before-completion, finishing-a-development-branch)
- [x] `/audit.md` references `improve-codebase-architecture` + `to-issues` (both exist in `.claude/skills/`)
- [x] Cross-references intact: CLAUDE.md → `.claude/commands/feature.md`, `.claude/hooks/branch-audit.sh`, `lab/WORKFLOW.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)