### PR TITLE
fix(wix-push): evict storefront cache + per-collection counts

### DIFF
--- a/backend/src/__tests__/publicRoutes.test.js
+++ b/backend/src/__tests__/publicRoutes.test.js
@@ -12,7 +12,7 @@ import request from 'supertest';
 vi.mock('../repos/productConfigRepo.js', () => ({
   list: vi.fn(),
 }));
-vi.mock('../services/airtable.js', () => ({
+vi.mock('../repos/stockRepo.js', () => ({
   list: vi.fn(),
 }));
 vi.mock('../services/configService.js', () => ({
@@ -20,12 +20,9 @@ vi.mock('../services/configService.js', () => ({
   getActiveSeasonalCategory: vi.fn(() => null),
   getActiveSeasonalSlots: vi.fn(() => []),
 }));
-vi.mock('../config/airtable.js', () => ({
-  TABLES: { STOCK: 'Stock' },
-}));
 
 const productConfigRepo = await import('../repos/productConfigRepo.js');
-const airtable          = await import('../services/airtable.js');
+const stockRepo         = await import('../repos/stockRepo.js');
 const configService     = await import('../services/configService.js');
 
 async function buildApp() {
@@ -77,7 +74,7 @@ describe('GET /api/public/categories', () => {
         'Active': true,
       },
     ]);
-    airtable.list.mockResolvedValue([]); // no stock rows needed — Min Stems=0 + no Key Flower → inStock via Infinity
+    stockRepo.list.mockResolvedValue([]); // no stock rows needed — Min Stems=0 + no Key Flower → inStock via Infinity
 
     const app = await buildApp();
     const res = await request(app).get('/api/public/categories');
@@ -88,6 +85,28 @@ describe('GET /api/public/categories', () => {
     expect(at.productCount).toBe(2);
     // Pre-fix this was `null`. Guarding against regression to null.
     expect(at.productCount).not.toBeNull();
+  });
+
+  it('invalidatePublicCache evicts entries so the next request rebuilds', async () => {
+    productConfigRepo.list.mockResolvedValue([]);
+    stockRepo.list.mockResolvedValue([]);
+
+    vi.resetModules();
+    const m = await import('../routes/public.js');
+    const app = express();
+    app.use('/api/public', m.default);
+
+    await request(app).get('/api/public/products');
+    expect(productConfigRepo.list).toHaveBeenCalledTimes(1);
+
+    // Cached on the next call — fetcher not invoked again.
+    await request(app).get('/api/public/products');
+    expect(productConfigRepo.list).toHaveBeenCalledTimes(1);
+
+    // Eviction forces a rebuild on the next request.
+    m.invalidatePublicCache('products');
+    await request(app).get('/api/public/products');
+    expect(productConfigRepo.list).toHaveBeenCalledTimes(2);
   });
 
   it('returns 0 (not null) when no qualifying products exist', async () => {
@@ -104,7 +123,7 @@ describe('GET /api/public/categories', () => {
         'Active': true,
       },
     ]);
-    airtable.list.mockResolvedValue([]);
+    stockRepo.list.mockResolvedValue([]);
 
     const app = await buildApp();
     const res = await request(app).get('/api/public/categories');

--- a/backend/src/__tests__/wixPushJob.test.js
+++ b/backend/src/__tests__/wixPushJob.test.js
@@ -12,7 +12,13 @@ vi.mock('../services/wixProductSync.js', () => ({
   runPush: (onProgress) => runPushMock(onProgress),
 }));
 
-// Imported AFTER the mock so the module sees our stub.
+const invalidatePublicCacheMock = vi.fn();
+vi.mock('../routes/public.js', () => ({
+  default: {},
+  invalidatePublicCache: (...args) => invalidatePublicCacheMock(...args),
+}));
+
+// Imported AFTER the mocks so the module sees our stubs.
 const { startPushJob, getJob, _resetForTests } = await import('../services/wixPushJob.js');
 
 function nextTick() {
@@ -23,6 +29,7 @@ describe('wixPushJob', () => {
   beforeEach(() => {
     _resetForTests();
     runPushMock.mockReset();
+    invalidatePublicCacheMock.mockReset();
   });
 
   afterEach(() => {
@@ -140,5 +147,42 @@ describe('wixPushJob', () => {
 
   it('returns null from getJob for an unknown id', () => {
     expect(getJob('00000000-0000-0000-0000-000000000000')).toBeNull();
+  });
+
+  it('invalidates the public storefront cache after a successful push', async () => {
+    runPushMock.mockResolvedValue({
+      pricesSynced: 1, stockSynced: 0, categoriesSynced: 1,
+      collectionCounts: { 'available-today': 4 }, errors: [],
+    });
+
+    startPushJob();
+    await nextTick();
+    await nextTick();
+
+    expect(invalidatePublicCacheMock).toHaveBeenCalledTimes(1);
+    expect(invalidatePublicCacheMock).toHaveBeenCalledWith('products', 'stock');
+  });
+
+  it('invalidates the public cache even when the push completes with non-fatal errors (partial)', async () => {
+    runPushMock.mockResolvedValue({
+      pricesSynced: 0, stockSynced: 0, categoriesSynced: 0,
+      errors: ['Description prod-1: timeout'],
+    });
+
+    startPushJob();
+    await nextTick();
+    await nextTick();
+
+    expect(invalidatePublicCacheMock).toHaveBeenCalledWith('products', 'stock');
+  });
+
+  it('does NOT invalidate the public cache when the push throws (failed)', async () => {
+    runPushMock.mockRejectedValue(new Error('Wix down'));
+
+    startPushJob();
+    await nextTick();
+    await nextTick();
+
+    expect(invalidatePublicCacheMock).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/routes/public.js
+++ b/backend/src/routes/public.js
@@ -26,6 +26,19 @@ async function getCachedOrBuild(key, fetcher) {
   return data;
 }
 
+// Eviction hook for callers that just mutated the underlying data
+// (e.g. wixPushJob after a successful push). Without this the storefront
+// would serve stale `/products` + `/categories` for up to 60s after the
+// owner clicks Push, on top of any browser/CDN cache. Pass no keys to
+// flush all entries.
+export function invalidatePublicCache(...keys) {
+  if (keys.length === 0) {
+    for (const k of Object.keys(cache)) delete cache[k];
+    return;
+  }
+  for (const k of keys) delete cache[k];
+}
+
 function cached(key, fetcher) {
   return async (_req, res, next) => {
     try {

--- a/backend/src/services/wixProductSync.js
+++ b/backend/src/services/wixProductSync.js
@@ -862,7 +862,18 @@ export async function runPull() {
  *                    direct callers (e.g. the legacy `runSync`) can omit it.
  */
 export async function runPush(onProgress = NO_PROGRESS) {
-  const stats = { pricesSynced: 0, stockSynced: 0, categoriesSynced: 0, descriptionsSynced: 0, translationsSynced: 0, errors: [], warnings: [] };
+  const stats = {
+    pricesSynced: 0,
+    stockSynced: 0,
+    categoriesSynced: 0,
+    descriptionsSynced: 0,
+    translationsSynced: 0,
+    // Per-collection product counts so post-push debugging doesn't require a
+    // round-trip to the Wix API (`Doступно сегодня: 4`, `Peonies: 12`, …).
+    collectionCounts: {},
+    errors: [],
+    warnings: [],
+  };
   const log = (kind, message, level = 'info') => {
     try { onProgress({ kind, message, level }); } catch { /* never fail push because of a progress hook */ }
   };
@@ -1005,6 +1016,7 @@ export async function runPush(onProgress = NO_PROGRESS) {
           try {
             await setWixCategoryProducts(wixCatId, productIds);
             stats.categoriesSynced++;
+            stats.collectionCounts[slug] = productIds.length;
             log('item', `Категория «${catName}»: ${productIds.length} товаров`);
           } catch (err) {
             stats.errors.push(`Category ${catName}: ${err.message}`);
@@ -1048,8 +1060,10 @@ export async function runPush(onProgress = NO_PROGRESS) {
                 }
               }
               stats.categoriesSynced++;
+              stats.collectionCounts[category.slug || `slot-${slot.id}`] = slotProductIds.length;
               log('item', `Слот ${slot.id} («${category.name}»): ${slotProductIds.length} товаров`);
             } else {
+              stats.collectionCounts[`slot-${slot.id}`] = 0;
               log('item', `Слот ${slot.id}: нет активной категории → коллекция очищена`);
             }
           } catch (err) {
@@ -1110,6 +1124,7 @@ export async function runPush(onProgress = NO_PROGRESS) {
           try {
             await setWixCategoryProducts(availTodayId, availProductIds);
             stats.categoriesSynced++;
+            stats.collectionCounts['available-today'] = availProductIds.length;
             log('item', `Доступно сегодня: ${availProductIds.length} товаров`);
           } catch (err) {
             stats.errors.push(`Available Today: ${err.message}`);

--- a/backend/src/services/wixPushJob.js
+++ b/backend/src/services/wixPushJob.js
@@ -18,6 +18,7 @@
 
 import { randomUUID } from 'crypto';
 import { runPush } from './wixProductSync.js';
+import { invalidatePublicCache } from '../routes/public.js';
 
 const JOB_TTL_MS = 60 * 60 * 1000;   // keep finished jobs queryable for 1h
 const MAX_LOG_ENTRIES = 500;          // cap per-job log to avoid runaway memory
@@ -74,6 +75,10 @@ export function startPushJob() {
       job.status = stats.errors?.length ? 'partial' : 'done';
       job.finishedAt = Date.now();
       job.result = stats;
+      // Evict the storefront cache so /api/public/products and /categories
+      // serve the just-pushed state on the next request instead of waiting
+      // up to 60s for the TTL to expire.
+      invalidatePublicCache('products', 'stock');
     })
     .catch(err => {
       job.status = 'failed';


### PR DESCRIPTION
## Summary
Two prevention fixes after the Available Today cold-cache + stale-cache incident.

**1. Cache invalidation on push.** The 60s in-memory cache in `/api/public/*` meant a successful Wix push left the storefront serving stale product/stock state for up to a minute, on top of any browser cache. New `invalidatePublicCache()` exported from `public.js`; `wixPushJob` calls it after a successful push so the next `/products` + `/categories` request rebuilds from PG.

**2. Per-collection counts in push stats.** Adds `stats.collectionCounts` (per-slug map) so `[PUSH] Complete` logs report e.g. `{"available-today":4,"peonies":12,...}` instead of just the aggregate `categoriesSynced`. Future "did push update X?" debugging no longer needs a Wix Stores API round-trip.

## Verification
- `cd backend && npx vitest run` — 354/354 pass (36 files).
- New tests: cache-eviction round-trip + 3 push-job hooks (success / partial / failed paths).

## Test plan
- [ ] CI green
- [ ] After merge + Railway deploy, click Push in dashboard → confirm `[PUSH] Complete:` log includes `collectionCounts` map
- [ ] Hit `/api/public/products` immediately after push completes → reflects new state without 60s wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)