### PR TITLE
feat(bouquet-photo): add photo upload to florist OrderCard + clipboard paste button

### DIFF
--- a/apps/florist/src/components/OrderCard.jsx
+++ b/apps/florist/src/components/OrderCard.jsx
@@ -11,7 +11,7 @@ import t from '../translations.js';
 import fmtDate from '../utils/formatDate.js';
 import DatePicker from './DatePicker.jsx';
 import useConfigLists from '../hooks/useConfigLists.js';
-import { DissolvePremadesDialog, computePremadeShortfalls } from '@flower-studio/shared';
+import { DissolvePremadesDialog, computePremadeShortfalls, BouquetImageEditor } from '@flower-studio/shared';
 import ExpandableTextarea from './ExpandableTextarea.jsx';
 
 const STATUS_STYLES = {
@@ -1191,6 +1191,19 @@ function OrderCard({
                   {detail['Notes Original'] && <Row label={t.customerNote} value={detail['Notes Original']} />}
                 </div>
               )}
+
+              {/* ── Bouquet photo — florist+owner upload, owner removes ── */}
+              <div>
+                <p className="text-[10px] font-bold uppercase tracking-wide text-pink-700 dark:text-pink-400 mb-1">
+                  📸 {t.bouquetPhotoLabel || 'Фото букета'}
+                </p>
+                <BouquetImageEditor
+                  orderId={order.id}
+                  currentUrl={detail['Image URL'] || detail.bouquetImageUrl || ''}
+                  canRemove={isOwner}
+                  onChange={(url) => setDetail(prev => prev ? { ...prev, 'Image URL': url, bouquetImageUrl: url } : prev)}
+                />
+              </div>
 
               {/* ── Owner-authored notes (editable at any stage) ── */}
               <div className="space-y-2">

--- a/packages/shared/components/BouquetImageEditor.jsx
+++ b/packages/shared/components/BouquetImageEditor.jsx
@@ -9,15 +9,19 @@ import { useToast } from '../context/ToastContext.jsx';
 //   - wixProductId → POST/DELETE /products/:wixProductId/image
 //   - orderId      → POST/DELETE /orders/:orderId/image
 //
-// Two input methods:
+// Three input methods:
 //   1. Click → opens native file picker (camera+library on phones)
-//   2. Paste while focused → reads image from clipboard (desktop)
+//   2. Paste while focused → reads image from clipboard (desktop Ctrl/Cmd+V)
+//   3. "Paste from clipboard" button → navigator.clipboard.read() (mobile-friendly)
 //
 // Single-image semantic: upload replaces the existing image. Remove is
 // owner-only (controlled via `canRemove`). The component shows an
 // optimistic preview during upload and reverts on error.
 
 const PASTE_LABEL_RU = 'Вставьте или выберите фото';
+const CLIPBOARD_LABEL_RU = '📋 Вставить из буфера';
+const CLIPBOARD_NO_IMAGE_RU = 'В буфере нет изображения';
+const CLIPBOARD_DENIED_RU = 'Нет доступа к буферу обмена';
 const REMOVE_LABEL_RU = 'Удалить';
 const REMOVE_CONFIRM_RU = 'Удалить это фото?';
 
@@ -83,6 +87,26 @@ export default function BouquetImageEditor({
     }
   }, [handleFile, uploading]);
 
+  const onClipboardRead = useCallback(async () => {
+    if (uploading) return;
+    try {
+      const items = await navigator.clipboard.read();
+      let found = false;
+      for (const item of items) {
+        const imageType = item.types.find(t => t.startsWith('image/'));
+        if (imageType) {
+          const blob = await item.getType(imageType);
+          handleFile(new File([blob], 'clipboard.png', { type: imageType }));
+          found = true;
+          break;
+        }
+      }
+      if (!found) toast(CLIPBOARD_NO_IMAGE_RU, 'error');
+    } catch (err) {
+      toast(err.name === 'NotAllowedError' ? CLIPBOARD_DENIED_RU : (err.message || CLIPBOARD_DENIED_RU), 'error');
+    }
+  }, [uploading, handleFile, toast]);
+
   useEffect(() => {
     const node = containerRef.current;
     if (!node) return;
@@ -111,56 +135,72 @@ export default function BouquetImageEditor({
     }
   };
 
+  const supportsClipboardRead = Boolean(navigator.clipboard?.read);
+
   return (
-    <div
-      ref={containerRef}
-      tabIndex={0}
-      className="relative rounded-xl border border-gray-200 overflow-hidden focus:outline-none focus:ring-2 focus:ring-brand-400"
-      onClick={() => !uploading && fileInputRef.current?.click()}
-    >
-      {/*
-        No `capture` attr — owner needs the full picker (camera + photo
-        library + Files / iCloud Drive). With `capture="environment"`
-        mobile browsers jump straight to the camera and never offer the
-        library, which is the wrong default for bouquet photos that are
-        usually taken in advance and stored on the phone.
-        Clipboard paste is wired separately on the container (see onPaste).
-      */}
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/jpeg,image/png,image/webp"
-        className="hidden"
-        data-testid="bouquet-image-file-input"
-        onChange={(e) => {
-          const file = e.target.files?.[0];
-          if (file) handleFile(file);
-          e.target.value = '';
-        }}
-      />
-      {previewUrl ? (
-        <img
-          src={previewUrl}
-          alt="Bouquet"
-          className="block w-full h-40 object-cover"
+    <div>
+      <div
+        ref={containerRef}
+        tabIndex={0}
+        className="relative rounded-xl border border-gray-200 overflow-hidden focus:outline-none focus:ring-2 focus:ring-brand-400"
+        onClick={() => !uploading && fileInputRef.current?.click()}
+      >
+        {/*
+          No `capture` attr — owner needs the full picker (camera + photo
+          library + Files / iCloud Drive). With `capture="environment"`
+          mobile browsers jump straight to the camera and never offer the
+          library, which is the wrong default for bouquet photos that are
+          usually taken in advance and stored on the phone.
+          Clipboard paste is wired separately: Ctrl/Cmd+V on the focused
+          container (see onPaste), or the button below (onClipboardRead).
+        */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          className="hidden"
+          data-testid="bouquet-image-file-input"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) handleFile(file);
+            e.target.value = '';
+          }}
         />
-      ) : (
-        <div className="h-40 flex items-center justify-center bg-gray-50 text-gray-400 text-sm">
-          {PASTE_LABEL_RU}
-        </div>
-      )}
-      {uploading && (
-        <div className="absolute inset-0 bg-black/40 flex items-center justify-center text-white text-sm">
-          {progress}%
-        </div>
-      )}
-      {canRemove && previewUrl && !uploading && (
+        {previewUrl ? (
+          <img
+            src={previewUrl}
+            alt="Bouquet"
+            className="block w-full h-40 object-cover"
+          />
+        ) : (
+          <div className="h-40 flex items-center justify-center bg-gray-50 text-gray-400 text-sm">
+            {PASTE_LABEL_RU}
+          </div>
+        )}
+        {uploading && (
+          <div className="absolute inset-0 bg-black/40 flex items-center justify-center text-white text-sm">
+            {progress}%
+          </div>
+        )}
+        {canRemove && previewUrl && !uploading && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); onRemove(); }}
+            className="absolute top-2 right-2 px-2 py-1 rounded-full bg-white/90 text-red-600 text-xs font-semibold shadow"
+          >
+            {REMOVE_LABEL_RU}
+          </button>
+        )}
+      </div>
+      {supportsClipboardRead && (
         <button
           type="button"
-          onClick={(e) => { e.stopPropagation(); onRemove(); }}
-          className="absolute top-2 right-2 px-2 py-1 rounded-full bg-white/90 text-red-600 text-xs font-semibold shadow"
+          data-testid="clipboard-paste-btn"
+          onClick={onClipboardRead}
+          disabled={uploading}
+          className="mt-1.5 w-full text-center text-xs text-gray-400 hover:text-brand-600 py-0.5 disabled:opacity-40 transition-colors"
         >
-          {REMOVE_LABEL_RU}
+          {CLIPBOARD_LABEL_RU}
         </button>
       )}
     </div>

--- a/packages/shared/test/BouquetImageEditor.test.jsx
+++ b/packages/shared/test/BouquetImageEditor.test.jsx
@@ -2,13 +2,43 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, fireEvent, screen, waitFor, cleanup } from '@testing-library/react';
 
+const mockShowToast = vi.fn();
+vi.mock('../context/ToastContext.jsx', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
 vi.mock('../api/uploadImage.js', () => ({
   uploadBouquetImage: vi.fn().mockResolvedValue({ imageUrl: 'https://static/new.jpg' }),
   removeBouquetImage: vi.fn().mockResolvedValue({ ok: true }),
+  uploadOrderImage: vi.fn().mockResolvedValue({ imageUrl: 'https://static/new.jpg' }),
+  removeOrderImage: vi.fn().mockResolvedValue({ ok: true }),
 }));
 
 import BouquetImageEditor from '../components/BouquetImageEditor.jsx';
 import { uploadBouquetImage, removeBouquetImage } from '../api/uploadImage.js';
+
+function stubClipboard(imageBlob = null) {
+  const mockRead = imageBlob
+    ? vi.fn().mockResolvedValue([{
+        types: [imageBlob.type],
+        getType: vi.fn().mockResolvedValue(imageBlob),
+      }])
+    : vi.fn().mockResolvedValue([{ types: ['text/plain'], getType: vi.fn() }]);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { read: mockRead },
+    writable: true,
+    configurable: true,
+  });
+  return mockRead;
+}
+
+function removeClipboard() {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  });
+}
 
 beforeEach(() => { vi.clearAllMocks(); });
 // Vitest doesn't auto-cleanup testing-library renders unless `globals: true`,
@@ -50,5 +80,49 @@ describe('BouquetImageEditor', () => {
     fireEvent.click(btn);
     await waitFor(() => expect(removeBouquetImage).toHaveBeenCalledWith('p1'));
     await waitFor(() => expect(onChange).toHaveBeenCalledWith(''));
+  });
+
+  describe('clipboard paste button', () => {
+    afterEach(() => { removeClipboard(); });
+
+    it('shows clipboard button when navigator.clipboard.read is available', () => {
+      stubClipboard();
+      render(<BouquetImageEditor wixProductId="p1" currentUrl="" canRemove={false} onChange={() => {}} />);
+      expect(screen.getByTestId('clipboard-paste-btn')).toBeTruthy();
+    });
+
+    it('hides clipboard button when navigator.clipboard is unavailable', () => {
+      removeClipboard();
+      render(<BouquetImageEditor wixProductId="p1" currentUrl="" canRemove={false} onChange={() => {}} />);
+      expect(screen.queryByTestId('clipboard-paste-btn')).toBeNull();
+    });
+
+    it('reads image from clipboard and uploads on button click', async () => {
+      const onChange = vi.fn();
+      const blob = new Blob([new Uint8Array([1])], { type: 'image/png' });
+      stubClipboard(blob);
+      render(<BouquetImageEditor wixProductId="p1" currentUrl="" canRemove={false} onChange={onChange} />);
+      fireEvent.click(screen.getByTestId('clipboard-paste-btn'));
+      await waitFor(() => expect(uploadBouquetImage).toHaveBeenCalled());
+      await waitFor(() => expect(onChange).toHaveBeenCalledWith('https://static/new.jpg'));
+    });
+
+    it('shows error toast when clipboard has no image', async () => {
+      stubClipboard(null);
+      render(<BouquetImageEditor wixProductId="p1" currentUrl="" canRemove={false} onChange={() => {}} />);
+      fireEvent.click(screen.getByTestId('clipboard-paste-btn'));
+      await waitFor(() => expect(mockShowToast).toHaveBeenCalledWith(expect.stringMatching(/буфере нет/i), 'error'));
+    });
+
+    it('shows permission denied toast on NotAllowedError', async () => {
+      const err = Object.assign(new Error('denied'), { name: 'NotAllowedError' });
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { read: vi.fn().mockRejectedValue(err) },
+        writable: true, configurable: true,
+      });
+      render(<BouquetImageEditor wixProductId="p1" currentUrl="" canRemove={false} onChange={() => {}} />);
+      fireEvent.click(screen.getByTestId('clipboard-paste-btn'));
+      await waitFor(() => expect(mockShowToast).toHaveBeenCalledWith(expect.stringMatching(/доступа/i), 'error'));
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **Florist app — OrderCard**: adds the bouquet photo section (📸) between the order-date row and the florist-note textarea. Florists can now upload a photo directly from the expanded card without navigating to the full detail page. Owner gets the Remove button; florists get upload-only.
- **Shared — BouquetImageEditor**: adds a \"📋 Вставить из буфера\" button using `navigator.clipboard.read()`. Works on mobile without a keyboard (no need to focus → Ctrl+V). Hidden gracefully when the Clipboard API isn't available. Existing Ctrl+V paste-on-focus still works.
- Dashboard `OrderDetailPanel` gets the clipboard button automatically — it uses the same shared component.

## Verification

- `packages/shared` vitest: **135/135 passed** (+5 new clipboard tests)
- All three apps built clean: florist ✓, dashboard ✓, delivery ✓
- No backend or schema changes.

## Test plan

- [ ] Open an order card in the florist app → expand → scroll past delivery/driver section → bouquet photo section appears
- [ ] Tap the image area → native file picker opens
- [ ] On desktop: copy an image to clipboard, tap "📋 Вставить из буфера" → upload starts
- [ ] On iOS tablet: copy photo from Photos app, tap clipboard button → browser asks permission once → uploads
- [ ] Owner role: Remove button appears on photos; florist role: no Remove button
- [ ] Dashboard OrderDetailPanel: clipboard button also visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)