### PR TITLE
fix(config): restore all config lost during Phase 7 cutover (timeslots + 7 other fields)

### DIFF
--- a/backend/src/__tests__/configService.test.js
+++ b/backend/src/__tests__/configService.test.js
@@ -70,6 +70,95 @@ describe('deliveryTimeSlots defaults and migration', () => {
   afterEach(() => { vi.resetModules(); });
 });
 
+describe('migrateRestoreAirtableConfig (Phase 7 cutover regression)', () => {
+  // Simulates Postgres being seeded from DEFAULTS — the regression state.
+  async function loadWithDefaults(overrides = {}) {
+    vi.resetModules();
+    vi.doMock('../repos/appConfigRepo.js', () => ({
+      get: vi.fn().mockResolvedValue({
+        defaultDeliveryFee: 35,
+        targetMarkup: 2.2,
+        suppliers: ['Stojek', '4f', 'Stefan', 'Mateusz', 'Other'],
+        stockCategories: ['Roses', 'Tulips', 'Seasonal', 'Greenery', 'Accessories', 'Other'],
+        paymentMethods: ['Cash', 'Card', 'Mbank', 'Monobank', 'Revolut', 'PayPal', 'Wix Online'],
+        orderSources: ['In-store', 'Instagram', 'WhatsApp', 'Telegram', 'Wix', 'Flowwow', 'Other'],
+        floristNames: ['Anya', 'Daria'],
+        floristRates: {},
+        freeDeliveryThreshold: 300,
+        expressSurcharge: 20,
+        deliveryTimeSlots: ['10:00-12:00', '12:00-14:00', '14:00-16:00', '16:00-18:00'],
+        ...overrides,
+      }),
+      set: vi.fn().mockResolvedValue(undefined),
+      nextOrderId: vi.fn().mockResolvedValue('202605-001'),
+    }));
+    vi.doMock('../repos/productConfigRepo.js', () => ({ list: vi.fn().mockResolvedValue([]) }));
+    vi.doMock('../services/telegram.js', () => ({ sendAlert: vi.fn() }));
+    vi.doMock('../db/index.js', () => ({ db: {} }));
+    vi.doMock('../db/audit.js', () => ({ recordAudit: vi.fn() }));
+    const { getConfig: gc } = await import('../services/configService.js');
+    await new Promise(r => setTimeout(r, 50));
+    return gc;
+  }
+
+  afterEach(() => { vi.resetModules(); });
+
+  it('restores freeDeliveryThreshold from 300 → 600', async () => {
+    const gc = await loadWithDefaults();
+    expect(gc('freeDeliveryThreshold')).toBe(600);
+  });
+
+  it('restores targetMarkup from 2.2 → 2.5', async () => {
+    const gc = await loadWithDefaults();
+    expect(gc('targetMarkup')).toBe(2.5);
+  });
+
+  it('restores suppliers — adds Arek, OZ, Pani Marysia, Bisping', async () => {
+    const gc = await loadWithDefaults();
+    const s = gc('suppliers');
+    expect(s).toContain('Arek');
+    expect(s).toContain('OZ');
+    expect(s).toContain('Pani Marysia');
+    expect(s).toContain('Bisping');
+  });
+
+  it('restores stockCategories — adds 8 flower types', async () => {
+    const gc = await loadWithDefaults();
+    const cats = gc('stockCategories');
+    expect(cats).toContain('Ranunculus');
+    expect(cats).toContain('Dahlias');
+    expect(cats).toContain('Hydrangeas');
+    expect(cats.length).toBe(14);
+  });
+
+  it('restores paymentMethods — Stripe, RUB, TwojStartUp', async () => {
+    const gc = await loadWithDefaults();
+    const pm = gc('paymentMethods');
+    expect(pm).toContain('Stripe');
+    expect(pm).toContain('RUB');
+    expect(pm).toContain('TwojStartUp');
+  });
+
+  it('restores orderSources — adds Facebook, Phone', async () => {
+    const gc = await loadWithDefaults();
+    const os = gc('orderSources');
+    expect(os).toContain('Facebook');
+    expect(os).toContain('Phone');
+  });
+
+  it('restores floristNames → [Sasha] and floristRates', async () => {
+    const gc = await loadWithDefaults();
+    expect(gc('floristNames')).toEqual(['Sasha']);
+    expect(gc('floristRates')).toEqual({ Sasha: { Standard: 33 } });
+  });
+
+  it('skips restore when value already differs from DEFAULTS (manual edit preserved)', async () => {
+    const gc = await loadWithDefaults({ freeDeliveryThreshold: 450 });
+    // 450 is neither DEFAULTS (300) nor backup (600) — a manual edit → preserved
+    expect(gc('freeDeliveryThreshold')).toBe(450);
+  });
+});
+
 describe('getActiveSeasonalSlots', () => {
   it('returns two entries, one per slot', () => {
     const result = getActiveSeasonalSlots();

--- a/backend/src/__tests__/configService.test.js
+++ b/backend/src/__tests__/configService.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('../repos/appConfigRepo.js', () => ({
   get: vi.fn().mockResolvedValue(null),
@@ -33,6 +33,41 @@ function setSlots(slot1Overrides = {}, slot2Overrides = {}) {
 beforeEach(() => {
   vi.useRealTimers();
   setSlots();
+});
+
+describe('deliveryTimeSlots defaults and migration', () => {
+  it('DEFAULTS include 08:00-10:00 and 18:00-20:00', () => {
+    // The module boots with appConfigRepo.get=null, so config is seeded from DEFAULTS.
+    const slots = getConfig('deliveryTimeSlots');
+    expect(slots).toContain('08:00-10:00');
+    expect(slots).toContain('18:00-20:00');
+  });
+
+  it('migrateDeliveryTimeSlots restores missing slots when stored config only has 4', async () => {
+    vi.resetModules();
+    vi.doMock('../repos/appConfigRepo.js', () => ({
+      get: vi.fn().mockResolvedValue({
+        deliveryTimeSlots: ['10:00-12:00', '12:00-14:00', '14:00-16:00', '16:00-18:00'],
+      }),
+      set: vi.fn().mockResolvedValue(undefined),
+      nextOrderId: vi.fn().mockResolvedValue('202605-001'),
+    }));
+    vi.doMock('../repos/productConfigRepo.js', () => ({ list: vi.fn().mockResolvedValue([]) }));
+    vi.doMock('../services/telegram.js', () => ({ sendAlert: vi.fn() }));
+    vi.doMock('../db/index.js', () => ({ db: {} }));
+    vi.doMock('../db/audit.js', () => ({ recordAudit: vi.fn() }));
+
+    const { getConfig: getConfigFresh } = await import('../services/configService.js');
+    // loadConfig is async; give it one tick to complete
+    await new Promise(r => setTimeout(r, 50));
+
+    const slots = getConfigFresh('deliveryTimeSlots');
+    expect(slots).toContain('08:00-10:00');
+    expect(slots).toContain('18:00-20:00');
+    expect(slots.length).toBeGreaterThanOrEqual(6);
+  });
+
+  afterEach(() => { vi.resetModules(); });
 });
 
 describe('getActiveSeasonalSlots', () => {

--- a/backend/src/services/configService.js
+++ b/backend/src/services/configService.js
@@ -228,6 +228,57 @@ function migrateDeliveryTimeSlots() {
   saveConfig().catch(err => console.error('[SETTINGS] Timeslot migration save failed:', err.message));
 }
 
+// Restores values lost when Postgres was seeded from DEFAULTS instead of
+// the live Airtable config during the Phase 7 cutover (2026-05-08).
+// Each field only restores if it still exactly matches the DEFAULT value —
+// meaning the owner hasn't touched it since the reset.
+// Source of truth: backups/2026-05-02/App_Config.json.
+function migrateRestoreAirtableConfig() {
+  // Sorted stringification for array equality checks
+  const sortedStr = arr => JSON.stringify([...arr].sort());
+
+  const patches = {};
+
+  if (config.targetMarkup === 2.2)
+    patches.targetMarkup = 2.5;
+
+  if (config.freeDeliveryThreshold === 300)
+    patches.freeDeliveryThreshold = 600;
+
+  const defaultSuppliers = ['Stojek', '4f', 'Stefan', 'Mateusz', 'Other'];
+  if (sortedStr(config.suppliers || []) === sortedStr(defaultSuppliers))
+    patches.suppliers = ['4f', 'Arek', 'Bisping', 'Mateusz', 'Other', 'OZ', 'Pani Marysia', 'Stefan', 'Stojek'];
+
+  const defaultCategories = ['Roses', 'Tulips', 'Seasonal', 'Greenery', 'Accessories', 'Other'];
+  if (sortedStr(config.stockCategories || []) === sortedStr(defaultCategories))
+    patches.stockCategories = [
+      'Accessories', 'Dahlias', 'Dianthus', 'Freesias', 'Greenery',
+      'Hydrangeas', 'Lisianthus', 'Other', 'Oxypetalum', 'Ranunculus',
+      'Red Roses', 'Roses', 'Seasonal', 'Tulips',
+    ];
+
+  const defaultPayment = ['Cash', 'Card', 'Mbank', 'Monobank', 'Revolut', 'PayPal', 'Wix Online'];
+  if (sortedStr(config.paymentMethods || []) === sortedStr(defaultPayment))
+    patches.paymentMethods = ['Cash', 'Mbank', 'Monobank', 'PayPal', 'Revolut', 'RUB', 'Stripe', 'TwojStartUp'];
+
+  const defaultSources = ['In-store', 'Instagram', 'WhatsApp', 'Telegram', 'Wix', 'Flowwow', 'Other'];
+  if (sortedStr(config.orderSources || []) === sortedStr(defaultSources))
+    patches.orderSources = ['Facebook', 'Flowwow', 'In-store', 'Instagram', 'Other', 'Phone', 'Telegram', 'WhatsApp', 'Wix'];
+
+  const defaultFlorists = ['Anya', 'Daria'];
+  if (sortedStr(config.floristNames || []) === sortedStr(defaultFlorists)) {
+    patches.floristNames = ['Sasha'];
+    // Only restore rates if floristNames was also reset — avoid stomping manual edits
+    if (Object.keys(config.floristRates || {}).length === 0)
+      patches.floristRates = { Sasha: { Standard: 33 } };
+  }
+
+  if (Object.keys(patches).length === 0) return;
+  console.log('[SETTINGS] Restoring Airtable config lost during Phase 7 cutover:', Object.keys(patches).join(', '));
+  Object.assign(config, patches);
+  saveConfig().catch(err => console.error('[SETTINGS] Airtable config restore failed:', err.message));
+}
+
 async function saveConfig(before) {
   try {
     await appConfigRepo.set('config', config);
@@ -258,6 +309,7 @@ async function loadConfig() {
       migrateFloristRates();
       migrateSeasonalSlots();
       migrateDeliveryTimeSlots();
+      migrateRestoreAirtableConfig();
       console.log('[SETTINGS] Config loaded from Postgres');
     } else {
       await appConfigRepo.set('config', DEFAULTS);

--- a/backend/src/services/configService.js
+++ b/backend/src/services/configService.js
@@ -61,7 +61,7 @@ const DEFAULTS = {
   ],
   freeDeliveryThreshold: 300,
   expressSurcharge: 20,
-  deliveryTimeSlots: ['10:00-12:00', '12:00-14:00', '14:00-16:00', '16:00-18:00'],
+  deliveryTimeSlots: ['08:00-10:00', '10:00-12:00', '12:00-14:00', '14:00-16:00', '16:00-18:00', '18:00-20:00'],
   availableTodayCutoff: '18:00',
   availableTodayTimezone: 'Europe/Warsaw',
   cutoffReminderLastDate: null,
@@ -218,6 +218,16 @@ function migrateSeasonalSlots() {
   saveConfig().catch(err => console.error('[SETTINGS] Slot migration save failed:', err.message));
 }
 
+function migrateDeliveryTimeSlots() {
+  const required = ['08:00-10:00', '18:00-20:00'];
+  const stored = config.deliveryTimeSlots || [];
+  const missing = required.filter(s => !stored.includes(s));
+  if (missing.length === 0) return;
+  console.log(`[SETTINGS] Restoring missing timeslots: ${missing.join(', ')}`);
+  config.deliveryTimeSlots = [...stored, ...missing].sort();
+  saveConfig().catch(err => console.error('[SETTINGS] Timeslot migration save failed:', err.message));
+}
+
 async function saveConfig(before) {
   try {
     await appConfigRepo.set('config', config);
@@ -247,6 +257,7 @@ async function loadConfig() {
       migrateAutoCategoryTranslations();
       migrateFloristRates();
       migrateSeasonalSlots();
+      migrateDeliveryTimeSlots();
       console.log('[SETTINGS] Config loaded from Postgres');
     } else {
       await appConfigRepo.set('config', DEFAULTS);


### PR DESCRIPTION
## Root cause

Postgres `app_config` was seeded from code `DEFAULTS` instead of the live Airtable config during Phase 7 cutover (2026-05-08). `deepMerge` replaces arrays wholesale, so all customised values were silently overwritten.

Confirmed via `backups/2026-05-02/App_Config.json` diff + live `/api/public/delivery-pricing` (showed `freeDeliveryThreshold: 300`, `timeSlots: 4 slots`).

## Fields restored

| Field | Was (DEFAULTS) | Restored to |
|---|---|---|
| `freeDeliveryThreshold` | 300 | **600** — critical, wrong free-delivery cutoff |
| `targetMarkup` | 2.2 | **2.5** |
| `deliveryTimeSlots` | 4 slots | **6 slots** (08:00-10:00, 18:00-20:00 added) |
| `suppliers` | 5 entries | **9 entries** (Arek, OZ, Pani Marysia, Bisping) |
| `stockCategories` | 6 entries | **14 entries** (Ranunculus, Dahlias, Hydrangeas, …) |
| `paymentMethods` | defaults set | **backup set** (Stripe, RUB, TwojStartUp) |
| `orderSources` | 7 entries | **9 entries** (Facebook, Phone) |
| `floristNames` | ['Anya', 'Daria'] | **['Sasha']** |
| `floristRates` | {} | **{Sasha: {Standard: 33}}** |

`storefrontCategories` was intact (nested object — deepMerge preserved it correctly).

## How it works

Each `migrateXxx()` function fires on startup and only patches a field when it still exactly matches DEFAULTS — so any manual correction the owner made after the reset is preserved. After the first successful restart, Postgres is updated and the migration becomes a no-op.

## Verification

- Backend vitest: **364/364 passed** (10 new regression tests)
- 8 per-field restore assertions + 1 manual-edit-preserved guard
- No schema/API changes

Closes #273