### PR TITLE
fix(dashboard): premade bouquet modal no longer closes on background poll

### DIFF
--- a/apps/dashboard/src/components/PremadeBouquetList.jsx
+++ b/apps/dashboard/src/components/PremadeBouquetList.jsx
@@ -27,21 +27,20 @@ function timeAgo(iso) {
 
 export default function PremadeBouquetList({ onMatchClicked }) {
   const { showToast } = useToast();
-  const [bouquets, setBouquets] = useState([]);
-  const [loading, setLoading] = useState(true);
+  // null = not yet loaded (show spinner); [] or [...] = loaded (render list).
+  // Background polls only call setBouquets — they never touch a loading flag,
+  // so the create modal is never unmounted mid-composition.
+  const [bouquets, setBouquets] = useState(null);
   const [expandedId, setExpanded] = useState(null);
   const [showCreateModal, setShowCreateModal] = useState(false);
 
   const fetchBouquets = useCallback(async () => {
-    setLoading(true);
     try {
       const res = await client.get('/premade-bouquets');
       setBouquets(res.data || []);
     } catch (err) {
       console.error('Failed to fetch premade bouquets:', err);
       showToast(err.response?.data?.error || t.error, 'error');
-    } finally {
-      setLoading(false);
     }
   }, [showToast]);
 
@@ -65,7 +64,7 @@ export default function PremadeBouquetList({ onMatchClicked }) {
     }
   }
 
-  if (loading) {
+  if (bouquets === null) {
     return (
       <div className="text-center py-12 text-ios-tertiary">{t.loading || 'Loading...'}</div>
     );


### PR DESCRIPTION
## Root cause

`PremadeBouquetList` set `loading = true` on every `fetchBouquets()` call, including the 30-second background poll interval. When `loading === true`, the component returned early with a spinner — which unmounted the `PremadeBouquetCreateModal` from the DOM. Every 30 seconds the owner's in-progress bouquet composition was silently wiped.

The florist app uses a dedicated `/bouquets/new` page route so it has no polling loop interfering with the creation UI.

## Fix

Replace `const [loading, setLoading] = useState(true)` with `const [bouquets, setBouquets] = useState(null)`.

- `null` → not yet fetched → show spinner (first render only)
- `[]` or `[...]` → loaded → render list

Background polls call only `setBouquets` — no loading flag, no early return, no modal unmount.

## Test plan

- [ ] Open Orders tab → Premade section → click "+ Create premade bouquet"
- [ ] Fill in name and add a flower
- [ ] Wait >30 seconds — modal should stay open and intact
- [ ] Save — bouquet appears in the list
- [ ] Verify the list background-refreshes silently (no spinner flicker after first load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)