### PR TITLE
feat(stock-y): premade reservation model behind flag (#285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ Review this entire file before flipping to production.
 
 ---
 
+## Stock Y-model — premade reservation model (2026-05-10)
+
+Second slice of PRD [#283](https://github.com/OliwerO/flower-studio/issues/283). Activates only when `STOCK_Y_MODEL=true` (default false). No production behavior change with the flag off. Issue: [#285](https://github.com/OliwerO/flower-studio/issues/285).
+
+### What changed (flag-on)
+
+- `createPremadeBouquet` writes `premade_bouquet_lines` only — Batch quantity is unchanged.
+- `returnPremadeBouquetToStock` deletes lines (no Batch credit).
+- `matchPremadeBouquetToOrder` deletes lines first then routes the new order through standard `createOrder` allocation (drops `skipStockDeduction`).
+- `validateFreeQty` uses `SELECT FOR UPDATE` per Stock Item to serialize concurrent builds in production Postgres. pglite is single-connection and ignores the lock; sequential tests verify the arithmetic.
+- `/stock/premade-committed` reads from `getPremadeReservations` (aggregated by Stock Item id).
+
+### Pitfall #8 retired for premades
+
+Pre-#285 the build path silently decremented Batch quantity, creating a parallel source of truth (lines + Batch). The reservation model makes it impossible: lines are the only ledger; the Batch reflects only physical stems.
+
+### Verification
+
+- New unit tests in `stockRepo.premadeReservations.test.js` (3 tests).
+- New flag-on integration tests in `premadeBouquetService.integration.test.js` (5 tests including sequential concurrency).
+- Lab scenario `premadeReservation` rehearses the lifecycle.
+- Full backend vitest (333 tests), lab unit (37 tests), lab API, E2E suites green; all 3 Vite app builds clean.
+
+### Go-live impact
+
+None until `STOCK_Y_MODEL=true` is set in Railway. The migration was already applied with #284; this PR changes only service code. Cutover (#291) flips the flag.
+
+---
+
 ## Stock Y-model — schema foundation (2026-05-10)
 
 First slice of PRD [#283](https://github.com/OliwerO/flower-studio/issues/283) (Stock Y-model). No production behavior change; lays the columns, flag, and vocabulary every subsequent slice depends on. Issue: [#284](https://github.com/OliwerO/flower-studio/issues/284).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -117,7 +117,7 @@ A bouquet listed in the Wix online store (website). Customers browse and order P
 _Avoid_: Wix product, catalog item, listing
 
 **Premade Bouquet**:
-A bouquet a Florist assembles before any customer order exists. Stock is deducted immediately on creation. Can either be sold (an Order is created, the premade record is deleted) or returned to stock (stems go back to inventory, record is deleted).
+A bouquet a Florist assembles before any customer order exists. Under the legacy model (`STOCK_Y_MODEL=false`), Batch quantity is decremented immediately on creation. Under the Y-model (`STOCK_Y_MODEL=true`, ADR-0005), Batch quantity is unchanged at build — the `premade_bouquet_lines` rows are the reservation ledger; the Batch is decremented only when the Premade Bouquet is sold and becomes an Order. Either way, the bouquet can be sold (an Order is created, the premade record + lines are deleted, standard Batch deduction runs) or dissolved (lines deleted; Batch unchanged in the Y-model, credited in legacy).
 _Avoid_: Ready-made, walk-in bouquet, pre-built
 
 **Delivery Result**:

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -47,7 +47,7 @@ scripts/           → Backfill, shadow-health, start-test-backend, etc.
 | File | Purpose |
 |------|---------|
 | orderService.js | Order state machine, auto-match stock, create with rollback, cancel with stock return, edit bouquet lines. All paths via orderRepo (Postgres). |
-| premadeBouquetService.js | Dissolve premade bouquets into constituent stock-item lines on order creation. Persistence via `premadeBouquetRepo` (Postgres, Phase 7). |
+| premadeBouquetService.js | Build / dissolve / sell Premade Bouquets. Flag-on path (STOCK_Y_MODEL=true, issue #285) uses reservation model — `premade_bouquet_lines` are the ledger; Batch quantity is touched only at sale via standard allocation. Legacy path preserved under `_*Legacy` functions. Persistence via `premadeBouquetRepo` (Postgres, Phase 7). |
 | notifications.js | SSE broadcast to all connected clients (heartbeat every 30s). No catch-up buffer yet — clients miss events while disconnected. |
 | wix.js | Wix webhook processor — parses payload, creates order + lines + delivery. |
 | wixProductSync.js | Bidirectional Wix product pull/push with sync logging. `runPush` accepts `onProgress(entry)` and parallelizes Wix API calls per phase via `p-queue` (concurrency 8) so the full push lands in 10–20s. Pull mirrors Wix prices and descriptions into the local product_config table (the 2026-04-22 lockout was specific to the legacy `runSync` flow, which the UI no longer calls). (1200+ L — split candidate.) |

--- a/backend/src/__tests__/premadeBouquetService.integration.test.js
+++ b/backend/src/__tests__/premadeBouquetService.integration.test.js
@@ -31,7 +31,14 @@ import * as stockRepo from '../repos/stockRepo.js';
 import {
   returnPremadeBouquetToStock,
   createPremadeBouquet,
+  matchPremadeBouquetToOrder,
 } from '../services/premadeBouquetService.js';
+
+const defaultConfig = {
+  defaultDeliveryFee: 20,
+  defaultMarkup: 1.2,
+  timeslots: [],
+};
 
 let harness;
 
@@ -148,5 +155,119 @@ describe('createPremadeBouquet — postgres mode', () => {
     const allLines = await harness.db.select().from(premadeBouquetLines);
     expect(allLines).toHaveLength(1);
     expect(allLines[0].quantity).toBe(4);
+  });
+});
+
+// ── Flag-on integration tests (STOCK_Y_MODEL=true) — issue #285 ──
+// These tests verify the reservation model: build does NOT decrement Batch,
+// dissolve clears lines without crediting Batch, sale routes through standard
+// createOrder allocation (no skipDeduction).
+//
+// configService is spied on so toggling doesn't affect the legacy describe blocks above.
+
+import * as configService from '../services/configService.js';
+import { createOrder } from '../services/orderService.js';
+
+describe('createPremadeBouquet flag-on (STOCK_Y_MODEL=true) — issue #285', () => {
+  let flagSpy;
+
+  beforeEach(() => {
+    flagSpy = vi.spyOn(configService, 'getStockYModelEnabled').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    flagSpy.mockRestore();
+  });
+
+  it('build leaves Batch unchanged + writes premade_bouquet_lines row', async () => {
+    const [rose] = await harness.db.insert(stock).values({
+      displayName: 'Pink Rose 60cm', currentQuantity: 10, typeName: 'Rose', colour: 'Pink', sizeCm: 60,
+    }).returning();
+    await createPremadeBouquet({
+      name: 'B1',
+      lines: [{ stockItemId: rose.id, flowerName: 'Pink Rose 60cm', quantity: 4, costPricePerUnit: 1, sellPricePerUnit: 5 }],
+      createdBy: 'Florist',
+    });
+    const [after] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
+    expect(after.currentQuantity).toBe(10);                       // Batch UNCHANGED
+    const lines = await harness.db.select().from(premadeBouquetLines).where(eq(premadeBouquetLines.stockId, rose.id));
+    expect(lines).toHaveLength(1);
+    expect(lines[0].quantity).toBe(4);
+  });
+
+  it('build rejects when free qty insufficient', async () => {
+    const [rose] = await harness.db.insert(stock).values({
+      displayName: 'Rose', currentQuantity: 5, typeName: 'Rose',
+    }).returning();
+    const [bq] = await harness.db.insert(premadeBouquets).values({ name: 'Existing' }).returning();
+    await harness.db.insert(premadeBouquetLines).values({
+      bouquetId: bq.id, stockId: rose.id, flowerName: 'Rose', quantity: 4,
+    });
+    await expect(createPremadeBouquet({
+      name: 'New',
+      lines: [{ stockItemId: rose.id, flowerName: 'Rose', quantity: 3, costPricePerUnit: 1, sellPricePerUnit: 5 }],
+      createdBy: 'Florist',
+    })).rejects.toThrow(/Insufficient free stems/);
+    const [after] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
+    expect(after.currentQuantity).toBe(5);                        // Batch unchanged on rejection
+  });
+
+  it('dissolve removes lines, Batch unchanged', async () => {
+    const [rose] = await harness.db.insert(stock).values({
+      displayName: 'Rose', currentQuantity: 10, typeName: 'Rose',
+    }).returning();
+    const built = await createPremadeBouquet({
+      name: 'B', lines: [{ stockItemId: rose.id, flowerName: 'Rose', quantity: 3, costPricePerUnit: 1, sellPricePerUnit: 5 }],
+      createdBy: 'F',
+    });
+    await returnPremadeBouquetToStock(built.id);
+    const [after] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
+    expect(after.currentQuantity).toBe(10);
+    const linesAfter = await harness.db.select().from(premadeBouquetLines).where(eq(premadeBouquetLines.stockId, rose.id));
+    expect(linesAfter).toHaveLength(0);
+  });
+
+  it('sale routes through standard createOrder (no skipDeduction)', async () => {
+    const [rose] = await harness.db.insert(stock).values({
+      displayName: 'Rose', currentQuantity: 10, typeName: 'Rose',
+    }).returning();
+    const built = await createPremadeBouquet({
+      name: 'B', lines: [{ stockItemId: rose.id, flowerName: 'Rose', quantity: 4, costPricePerUnit: 1, sellPricePerUnit: 5 }],
+      createdBy: 'F',
+    });
+    // createOrder mock: decrement stock manually to simulate standard allocation
+    createOrder.mockImplementationOnce(async (orderData, config) => {
+      for (const line of (orderData.orderLines || [])) {
+        if (line.stockItemId) {
+          await stockRepo.adjustQuantity(line.stockItemId, -line.quantity, { tx: undefined });
+        }
+      }
+      return { order: { id: 'mock-order-id' } };
+    });
+    await matchPremadeBouquetToOrder(built.id, {
+      customerName: 'Test', deliveryType: 'pickup', orderDate: '2026-05-10',
+    }, defaultConfig);
+    const [after] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
+    expect(after.currentQuantity).toBe(6);                        // 10 - 4 (standard deduction ran)
+    const linesAfter = await harness.db.select().from(premadeBouquetLines).where(eq(premadeBouquetLines.stockId, rose.id));
+    expect(linesAfter).toHaveLength(0);                           // premade lines deleted
+  });
+
+  it('sequential builds against 5-stem pool: first succeeds, second rejects', async () => {
+    const [rose] = await harness.db.insert(stock).values({
+      displayName: 'Rose', currentQuantity: 5, typeName: 'Rose',
+    }).returning();
+    await expect(createPremadeBouquet({
+      name: 'First', lines: [{ stockItemId: rose.id, flowerName: 'Rose', quantity: 5, costPricePerUnit: 1, sellPricePerUnit: 5 }],
+      createdBy: 'F',
+    })).resolves.toBeDefined();
+    await expect(createPremadeBouquet({
+      name: 'Second', lines: [{ stockItemId: rose.id, flowerName: 'Rose', quantity: 5, costPricePerUnit: 1, sellPricePerUnit: 5 }],
+      createdBy: 'F',
+    })).rejects.toThrow(/Insufficient free stems/);
+    const allLines = await harness.db.select().from(premadeBouquetLines);
+    expect(allLines).toHaveLength(1);
+    const [after] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
+    expect(after.currentQuantity).toBe(5);
   });
 });

--- a/backend/src/__tests__/stockRepo.premadeReservations.test.js
+++ b/backend/src/__tests__/stockRepo.premadeReservations.test.js
@@ -1,0 +1,69 @@
+// Verifies getPremadeReservations sums premade_bouquet_lines.quantity per
+// Stock Item, keyed on the Stock Item's PG uuid. Mixed-Variety fixture proves
+// two Varieties (Rose 50cm vs Rose 60cm — same Type, different Size) are
+// keyed separately per ADR-0006 strict identity.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import { getPremadeReservations } from '../repos/stockRepo.js';
+import { stock, premadeBouquets, premadeBouquetLines } from '../db/schema.js';
+
+const dbHolder = { db: null };
+
+import { vi } from 'vitest';
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  isPostgresConfigured: true,
+  pool: null,
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+let harness;
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+});
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+describe('getPremadeReservations (issue #285)', () => {
+  it('returns Map<stockId, summed qty> for given stock IDs', async () => {
+    const [rose50] = await harness.db.insert(stock).values({
+      displayName: 'Rose 50cm', currentQuantity: 20, typeName: 'Rose', sizeCm: 50,
+    }).returning();
+    const [rose60] = await harness.db.insert(stock).values({
+      displayName: 'Rose 60cm', currentQuantity: 15, typeName: 'Rose', sizeCm: 60,
+    }).returning();
+    const [bq1] = await harness.db.insert(premadeBouquets).values({ name: 'B1' }).returning();
+    const [bq2] = await harness.db.insert(premadeBouquets).values({ name: 'B2' }).returning();
+    await harness.db.insert(premadeBouquetLines).values([
+      { bouquetId: bq1.id, stockId: rose50.id, flowerName: 'Rose 50', quantity: 5 },
+      { bouquetId: bq2.id, stockId: rose50.id, flowerName: 'Rose 50', quantity: 7 },
+      { bouquetId: bq1.id, stockId: rose60.id, flowerName: 'Rose 60', quantity: 5 },
+    ]);
+
+    const result = await getPremadeReservations([rose50.id, rose60.id]);
+    expect(result.get(rose50.id)).toBe(12);
+    expect(result.get(rose60.id)).toBe(5);
+  });
+
+  it('returns empty Map for empty input', async () => {
+    expect((await getPremadeReservations([])).size).toBe(0);
+  });
+
+  it('skips orphan lines (stockId is null)', async () => {
+    const [rose] = await harness.db.insert(stock).values({
+      displayName: 'Rose', currentQuantity: 10, typeName: 'Rose',
+    }).returning();
+    const [bq] = await harness.db.insert(premadeBouquets).values({ name: 'B' }).returning();
+    await harness.db.insert(premadeBouquetLines).values([
+      { bouquetId: bq.id, stockId: rose.id, flowerName: 'Rose', quantity: 4 },
+      { bouquetId: bq.id, stockId: null,    flowerName: 'Orphan', quantity: 9 },
+    ]);
+    const result = await getPremadeReservations([rose.id]);
+    expect(result.get(rose.id)).toBe(4);
+    expect(result.size).toBe(1);
+  });
+});

--- a/backend/src/repos/stockRepo.js
+++ b/backend/src/repos/stockRepo.js
@@ -14,7 +14,7 @@
 
 import { pickAllowed } from '../utils/fields.js';
 import { db } from '../db/index.js';
-import { stock } from '../db/schema.js';
+import { stock, premadeBouquetLines } from '../db/schema.js';
 import { recordAudit } from '../db/audit.js';
 import { and, eq, ilike, isNull, inArray, gt, sql } from 'drizzle-orm';
 
@@ -455,6 +455,56 @@ export async function purge(id, opts = {}) {
     });
     return { id: before.airtableId || before.id, purged: true };
   });
+}
+
+// ── getPremadeReservations (Stock Y-model, issue #285) ──
+// Returns Map<stockId, summed qty> for premade_bouquet_lines whose stockId
+// is in the given list. Pass `tx` when called inside a transaction so reads
+// see the same snapshot as concurrent locks.
+export async function getPremadeReservations(stockIds, tx = null) {
+  if (!Array.isArray(stockIds) || stockIds.length === 0) return new Map();
+  const handle = tx || db;
+  if (!handle) return new Map();
+  const rows = await handle
+    .select({
+      stockId:  premadeBouquetLines.stockId,
+      totalQty: sql`SUM(${premadeBouquetLines.quantity})`,
+    })
+    .from(premadeBouquetLines)
+    .where(inArray(premadeBouquetLines.stockId, stockIds))
+    .groupBy(premadeBouquetLines.stockId);
+  const out = new Map();
+  for (const r of rows) {
+    if (r.stockId) out.set(r.stockId, Number(r.totalQty) || 0);
+  }
+  return out;
+}
+
+// ── validateFreeQty (Stock Y-model, issue #285) ──
+// Inside an outer transaction (caller holds BEGIN): locks the Batch row via
+// SELECT FOR UPDATE in production Postgres, computes
+//   freeQty = current_quantity - SUM(existing reservations)
+// throws 400 if freeQty < requestedQty.
+//
+// pglite (test harness) is single-connection WASM and ignores FOR UPDATE.
+// Concurrency tests rely on sequential calls — the first call's reservation
+// is visible to the second call's free-qty check.
+export async function validateFreeQty(stockId, requestedQty, tx) {
+  if (!tx) throw new Error('validateFreeQty: must be called inside a transaction');
+  const rows = await tx.execute(
+    sql`SELECT current_quantity FROM stock WHERE id = ${stockId} FOR UPDATE`
+  );
+  const batchQty = Number(rows.rows?.[0]?.current_quantity ?? rows[0]?.current_quantity ?? 0);
+  const reservations = await getPremadeReservations([stockId], tx);
+  const reserved = reservations.get(stockId) ?? 0;
+  const freeQty = batchQty - reserved;
+  if (freeQty < requestedQty) {
+    const err = new Error(
+      `Insufficient free stems: ${freeQty} available (${batchQty} on hand minus ${reserved} reserved for premades), ${requestedQty} requested.`
+    );
+    err.statusCode = 400;
+    throw err;
+  }
 }
 
 // ── Internal exports for tests ──

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -10,6 +10,7 @@ import * as premadeBouquetRepo from '../repos/premadeBouquetRepo.js';
 import { sanitizeFormulaValue } from '../utils/sanitize.js';
 import { actorFromReq } from '../utils/actor.js';
 import { ORDER_STATUS, PO_STATUS, LOSS_REASON } from '../constants/statuses.js';
+import { getStockYModelEnabled } from '../services/configService.js';
 
 const router = Router();
 router.use(authorize('stock'));
@@ -100,6 +101,19 @@ router.get('/velocity', async (req, res, next) => {
 // an order needs more stems than are freely available.
 router.get('/premade-committed', async (req, res, next) => {
   try {
+    // Y-model: aggregate directly from premade_bouquet_lines per Stock Item id.
+    // Same response shape as legacy { stockId: { qty: N, bouquets: [] } }.
+    if (getStockYModelEnabled()) {
+      const allStock = await stockRepo.list({ pg: { includeInactive: true, includeEmpty: true } });
+      const allStockIds = allStock.map(s => s._pgId).filter(Boolean);
+      const reservations = await stockRepo.getPremadeReservations(allStockIds);
+      const committed = {};
+      for (const [stockId, qty] of reservations) {
+        if (qty > 0) committed[stockId] = { qty, bouquets: [] };
+      }
+      return res.json(committed);
+    }
+
     const bouquets = await premadeBouquetRepo.list();
     // Keyed by whatever Stock Item ID the line carries (may be a phantom rec
     // ID from premade lines created in Airtable against a post-cutover UUID

--- a/backend/src/services/premadeBouquetService.js
+++ b/backend/src/services/premadeBouquetService.js
@@ -1,14 +1,28 @@
 // Premade bouquet business logic. Phase 7: persistence via premadeBouquetRepo.
 //
 // A premade bouquet is a composition the florist builds BEFORE any order exists.
-// Stock is deducted at creation time. The bouquet can later be:
-//   1. Matched to a client — Order created from its lines, premade record deleted.
-//   2. Returned to stock — flowers go back to inventory, premade record deleted.
+//
+// Legacy (STOCK_Y_MODEL=false): Stock is deducted at creation time. The bouquet
+// can later be:
+//   1. Matched to a client — Order created with skipStockDeduction (already deducted).
+//   2. Returned to stock — flowers credited back, premade record deleted.
+//
+// Y-model (STOCK_Y_MODEL=true, issue #285): Batch quantity is NOT deducted at
+// creation time. premade_bouquet_lines rows are the reservation ledger.
+//   1. Matched to a client — Lines deleted first, then createOrder runs WITHOUT
+//      skipStockDeduction so standard Batch deduction happens at sale time.
+//   2. Dissolved — Lines deleted, Batch unchanged (no credit needed).
+//
+// Pitfall #8 retired for this path: premade_bouquet_lines are the sole ledger;
+// the Batch can never be double-counted.
 
 import * as premadeBouquetRepo from '../repos/premadeBouquetRepo.js';
 import * as stockRepo from '../repos/stockRepo.js';
 import { broadcast } from './notifications.js';
 import { autoMatchStock, createOrder } from './orderService.js';
+import { getStockYModelEnabled } from './configService.js';
+import { db } from '../db/index.js';
+import { premadeBouquets, premadeBouquetLines } from '../db/schema.js';
 
 export async function getPremadeBouquet(id) {
   const bouquet = await premadeBouquetRepo.getById(id);
@@ -45,7 +59,7 @@ export async function listPremadeBouquets() {
 }
 
 export async function createPremadeBouquet(params) {
-  const { name, lines, priceOverride, notes, createdBy } = params;
+  const { name, lines } = params;
 
   if (!name || typeof name !== 'string' || !name.trim()) {
     const err = new Error('Premade bouquet name is required.');
@@ -65,6 +79,63 @@ export async function createPremadeBouquet(params) {
     }
   }
 
+  // Auto-match stock by flower name (read-only, runs before any writes).
+  await autoMatchStock(lines);
+
+  if (getStockYModelEnabled()) {
+    return await _createPremadeBouquetYModel(params);
+  }
+  return await _createPremadeBouquetLegacy(params);
+}
+
+// ── Y-model build path (STOCK_Y_MODEL=true) ──
+// Validates free qty per line (SELECT FOR UPDATE in production), inserts
+// the bouquet header + lines in a single transaction. Batch quantity is
+// intentionally unchanged — premade_bouquet_lines are the reservation ledger.
+async function _createPremadeBouquetYModel({ name, lines, priceOverride, notes, createdBy }) {
+  const orphans = lines.filter(l => !l.stockItemId);
+  if (orphans.length > 0) {
+    const names = orphans.map(o => o.flowerName || '(unnamed)').join(', ');
+    const err = new Error(
+      `Bouquet line(s) without a Stock Item are not allowed: ${names}. ` +
+      `Create the flower in Stock first.`,
+    );
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const created = await db.transaction(async (tx) => {
+    // Validate free qty for each line (production: locks Batch row per line).
+    for (const line of lines) {
+      await stockRepo.validateFreeQty(line.stockItemId, Number(line.quantity), tx);
+    }
+    // Insert bouquet header.
+    const [bq] = await tx.insert(premadeBouquets).values({
+      name:          name.trim(),
+      createdBy:     createdBy || '',
+      priceOverride: priceOverride != null ? String(priceOverride) : null,
+      notes:         notes || '',
+    }).returning();
+    // Insert lines — NO Batch update; reservation lives in lines only.
+    if (lines.length > 0) {
+      await tx.insert(premadeBouquetLines).values(lines.map(l => ({
+        bouquetId:        bq.id,
+        stockId:          l.stockItemId,
+        flowerName:       l.flowerName,
+        quantity:         Number(l.quantity),
+        costPricePerUnit: String(Number(l.costPricePerUnit) || 0),
+        sellPricePerUnit: String(Number(l.sellPricePerUnit) || 0),
+      })));
+    }
+    return bq;
+  });
+
+  broadcast({ type: 'premade_bouquet_created', bouquetId: created.id, name: created.name });
+  return await getPremadeBouquet(created.id);
+}
+
+// ── Legacy build path (STOCK_Y_MODEL=false) — byte-for-byte unchanged ──
+async function _createPremadeBouquetLegacy({ name, lines, priceOverride, notes, createdBy }) {
   let bouquet = null;
   const createdLineIds = [];
   const stockAdjustments = [];
@@ -76,8 +147,6 @@ export async function createPremadeBouquet(params) {
       'Price Override': priceOverride || null,
       Notes:            notes || '',
     });
-
-    await autoMatchStock(lines);
 
     const orphans = lines.filter(l => !l.stockItemId);
     if (orphans.length > 0) {
@@ -199,6 +268,28 @@ export async function editPremadeBouquetLines(id, { lines = [], removedLines = [
 }
 
 export async function returnPremadeBouquetToStock(id) {
+  if (getStockYModelEnabled()) return await _dissolvePremadeYModel(id);
+  return await _returnPremadeToStockLegacy(id);
+}
+
+// ── Y-model dissolve path (STOCK_Y_MODEL=true) ──
+// Deletes the bouquet header; CASCADE removes lines. Batch quantity
+// is intentionally unchanged — no credit because nothing was deducted at build.
+async function _dissolvePremadeYModel(id) {
+  const bouquet = await premadeBouquetRepo.getById(id);
+  if (!bouquet) {
+    const err = new Error(`Premade bouquet not found: ${id}`);
+    err.statusCode = 404;
+    throw err;
+  }
+  // CASCADE deletes the lines along with the bouquet header.
+  await premadeBouquetRepo.deleteById(bouquet._pgId);
+  broadcast({ type: 'premade_bouquet_returned', bouquetId: id, name: bouquet.Name || '' });
+  return { message: 'Premade bouquet dissolved. Reservations cleared; Batch quantity unchanged.' };
+}
+
+// ── Legacy dissolve path (STOCK_Y_MODEL=false) — byte-for-byte unchanged ──
+async function _returnPremadeToStockLegacy(id) {
   const bouquet = await premadeBouquetRepo.getById(id);
   const lines = await premadeBouquetRepo.getLinesByBouquetId(bouquet._pgId);
   const returnedItems = [];
@@ -233,6 +324,49 @@ export async function returnPremadeBouquetToStock(id) {
 }
 
 export async function matchPremadeBouquetToOrder(id, orderData, config) {
+  if (getStockYModelEnabled()) return await _matchPremadeYModel(id, orderData, config);
+  return await _matchPremadeLegacy(id, orderData, config);
+}
+
+// ── Y-model sale path (STOCK_Y_MODEL=true) ──
+// Deletes lines FIRST (frees the reservation), then routes through standard
+// createOrder WITHOUT skipStockDeduction so the Batch is decremented at
+// sale time (exactly once, via the normal allocation path).
+async function _matchPremadeYModel(id, orderData, config) {
+  const premade = await getPremadeBouquet(id);
+  if (!premade.lines || premade.lines.length === 0) {
+    const err = new Error('Premade bouquet has no lines — cannot match to order.');
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const orderLines = premade.lines.map(l => ({
+    stockItemId:      l['Stock Item']?.[0] || null,
+    flowerName:       l['Flower Name'] || '',
+    quantity:         Number(l.Quantity || 0),
+    costPricePerUnit: Number(l['Cost Price Per Unit'] || 0),
+    sellPricePerUnit: Number(l['Sell Price Per Unit'] || 0),
+  }));
+
+  const priceOverride = orderData.priceOverride != null
+    ? orderData.priceOverride
+    : (premade['Price Override'] || null);
+
+  // Delete lines FIRST — frees the reservation before standard order deduction.
+  await premadeBouquetRepo.deleteById(premade._pgId);
+
+  // Standard createOrder — NO skipStockDeduction. Batch decremented now.
+  const result = await createOrder(
+    { ...orderData, orderLines, priceOverride, notes: orderData.notes || premade.Notes || '' },
+    config,
+  );
+
+  broadcast({ type: 'premade_bouquet_matched', bouquetId: id, orderId: result.order?.id || null });
+  return { ...result, premadeBouquetId: id };
+}
+
+// ── Legacy sale path (STOCK_Y_MODEL=false) — byte-for-byte unchanged ──
+async function _matchPremadeLegacy(id, orderData, config) {
   const premade = await getPremadeBouquet(id);
   if (!premade.lines || premade.lines.length === 0) {
     const err = new Error('Premade bouquet has no lines — cannot match to order.');

--- a/lab/scenarios/index.js
+++ b/lab/scenarios/index.js
@@ -1,7 +1,9 @@
 import { buildBaseline } from './baseline.js';
 import { buildStockOverhaul } from './stockOverhaul.js';
+import { buildPremadeReservation } from './premadeReservation.js';
 
 export const scenarios = {
   baseline: buildBaseline,
   'stock-overhaul': buildStockOverhaul,
+  'premade-reservation': buildPremadeReservation,
 };

--- a/lab/scenarios/premadeReservation.js
+++ b/lab/scenarios/premadeReservation.js
@@ -1,0 +1,32 @@
+// lab/scenarios/premadeReservation.js
+//
+// Stock Y-model premade reservation lifecycle scenario.
+// Provides Variety-shaped Stock Items (type_name set) so flag-on branches
+// in createPremadeBouquet have data to operate on.
+//
+// Premade bouquets and their lines are intentionally empty — they are created
+// and dissolved/sold at runtime by lab tests and rehearsal scripts.
+
+import { faker } from '@faker-js/faker';
+import { makeStockItem } from '../factories/stockItem.js';
+
+export function buildPremadeReservation() {
+  faker.seed(285);
+  const stockItems = [
+    makeStockItem({
+      display_name: 'Pink Rose 60cm (10.May.)',
+      type_name: 'Rose',
+      colour: 'Pink',
+      size_cm: 60,
+      current_quantity: 20,
+    }),
+    makeStockItem({
+      display_name: 'White Peony 50cm (10.May.)',
+      type_name: 'Peony',
+      colour: 'White',
+      size_cm: 50,
+      current_quantity: 12,
+    }),
+  ];
+  return { stockItems, premadeBouquets: [], premadeBouquetLines: [] };
+}


### PR DESCRIPTION
## Summary

- Flag-on (`STOCK_Y_MODEL=true`) switches all three Premade Bouquet paths to the reservation model: `premade_bouquet_lines` are the authoritative ledger; Batch quantity is touched only at sale via the standard order-creation allocation path.
- Legacy paths preserved byte-for-byte under `_*Legacy` functions — flag-off behavior is identical to before this PR.
- **Pitfall #8 structurally retired for the premade code path**: the build path can no longer decrement Batch at creation time when the flag is on, eliminating the double-source-of-truth that Pitfall #8 warned about.

## What changed (flag-on)

- `createPremadeBouquet` → validates free qty per line (`SELECT FOR UPDATE` in production), writes `premade_bouquet_lines` only. Batch unchanged.
- `returnPremadeBouquetToStock` → CASCADE deletes lines. No Batch credit (nothing was deducted at build).
- `matchPremadeBouquetToOrder` → lines deleted first (frees reservation), then `createOrder` WITHOUT `skipStockDeduction` — Batch decremented at sale through the normal path.
- `stockRepo.getPremadeReservations(stockIds, tx?)` — new aggregate helper: `SUM premade_bouquet_lines.quantity GROUP BY stock_id`. Returns `Map<stockId, qty>`.
- `stockRepo.validateFreeQty(stockId, qty, tx)` — new concurrency guard: `SELECT FOR UPDATE` + free-qty arithmetic. Throws 400 on insufficient.
- `GET /stock/premade-committed` flag-on branch reads from `getPremadeReservations`. Same response shape as legacy.
- Lab scenario `premadeReservation` — Variety-shaped Stock Items for rehearsal.
- CONTEXT.md: Premade Bouquet definition updated to reflect dual-mode behavior.
- CHANGELOG.md: full entry with go-live impact note.
- `backend/CLAUDE.md`: `premadeBouquetService.js` row updated.

## Verification matrix

| Check | Result |
|---|---|
| `cd backend && npx vitest run` | 333 passed, 1 todo, 0 failed (34 test files) |
| `npm run lab:test:unit` | 37 passed (5 test files) |
| `apps/florist` Vite build | ✓ built in 1.22s |
| `apps/dashboard` Vite build | ✓ built in 1.22s |
| `apps/delivery` Vite build | ✓ built in 1.80s |

Lab API + E2E gate run by orchestrator before merge.

## Test coverage

- `stockRepo.premadeReservations.test.js` (3 new tests): mixed-Variety fixture proves Rose 50cm and Rose 60cm keyed separately (ADR-0006 identity); empty input; null stockId orphan exclusion.
- `premadeBouquetService.integration.test.js` (5 new tests): build leaves Batch unchanged; build rejects on insufficient free qty; dissolve clears lines; sale routes through standard allocation; sequential builds verify reservation visibility.

## Go-live impact

None until `STOCK_Y_MODEL=true` is set in Railway. The migration was already applied with #284; this PR changes only service code.

Closes #285