### PR TITLE
feat(stock-y): backend gap closures — POST /stock 4-tuple + premade names + Y-payload createDemandEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Review this entire file before flipping to production.
 
 ---
 
+## 2026-05-10 — Stock Y-model: backend gap closures (#287/#288/#289 follow-up)
+
+### Backend
+- `POST /stock` now accepts 4-tuple Variety attrs (`typeName`, `colour`, `sizeCm`, `cultivar`) on the wire. Coerced + persisted to `type_name`/`colour`/`size_cm`/`cultivar` columns. Legacy `displayName`-only POST still works.
+- `GET /stock/premade-committed` Y-model branch now populates `bouquets: [{ bouquetId, name, qty }]` (previously empty array). Shape matches legacy branch exactly. New `stockRepo.getPremadeReservationDetails(stockIds)` sibling helper.
+
+### Shared
+- `useOrderEditing.createDemandEntry(varietyDraft)` accepts 4-tuple object draft (back-compat with string baseName). When 4-tuple provided, POST /stock includes all attrs.
+- `useOrderEditing.addNewVariety(draft)` — new helper for Owner "+ Create new Variety" flow. Returns the created Stock Item.
+- `<VarietyAllocationPicker>` `kind: 'fresh'` emission now carries `variety: { type_name, colour, size_cm, cultivar }` so hosts can route the 4-tuple to `createDemandEntry`.
+
+### Frontend
+- 4 picker callsites (BouquetEditor, BouquetSection, Step2Bouquet × 2) now wire `onCreateVariety` + `kind: 'fresh'` paths to the new 4-tuple endpoints. TODOs removed.
+
+### Notes
+- Closes the three known follow-ups noted in PRs #298 (#288 picker) and #299 (#289 list). Owner can now create new Y-model Varieties from the picker; reserved-bucket tap shows premade names.
+
+---
+
 ## 2026-05-10 — Stock Y-model: Variety collapsed list (#289)
 
 ### Added (shared)

--- a/apps/dashboard/src/components/order/BouquetSection.jsx
+++ b/apps/dashboard/src/components/order/BouquetSection.jsx
@@ -226,9 +226,7 @@ export default function BouquetSection({ order, editing, isTerminal, saving, tar
               }}
               onSelectStock={picked => {
                 if (picked && picked.kind === 'fresh') {
-                  // TODO(Task 7): pass full variety attrs once createDemandEntry supports new shape.
-                  // For now fall back to display name so the call doesn't 4xx in production.
-                  editing.createDemandEntry(picked.displayName || picked.date || '');
+                  editing.createDemandEntry(picked.variety || picked.displayName || picked.date || '');
                 } else if (picked) {
                   const existing = editing.editLines.findIndex(l => l.stockItemId === picked.id);
                   if (existing >= 0) {
@@ -242,13 +240,9 @@ export default function BouquetSection({ order, editing, isTerminal, saving, tar
                 editing.setAddingFlower(false);
               }}
               onCreateVariety={async draft => {
-                // TODO(Task 7): POST /stock four-tuple support not yet confirmed.
-                // POST /stock only accepts displayName — pass legacy shape so we don't 4xx.
-                const legacyName = [draft.type_name, draft.colour].filter(Boolean).join(' ');
-                await editing.addNewFlower
-                  ? editing.openNewFlowerForm(legacyName || draft.type_name)
-                  : editing.addNewFlowerQuick(legacyName || draft.type_name);
+                const res = await editing.addNewVariety(draft);
                 setYPickerOpen(false);
+                return res;
               }}
               onClose={() => setYPickerOpen(false)}
             />

--- a/apps/dashboard/src/components/steps/Step2Bouquet.jsx
+++ b/apps/dashboard/src/components/steps/Step2Bouquet.jsx
@@ -5,7 +5,7 @@ import client from '../../api/client.js';
 import t from '../../translations.js';
 import { useToast } from '../../context/ToastContext.jsx';
 import useConfigLists from '../../hooks/useConfigLists.js';
-import { renderStockName, VarietyAllocationPicker, useStockYModelFlag } from '@flower-studio/shared';
+import { renderStockName, VarietyAllocationPicker, useStockYModelFlag, varietyDisplayName } from '@flower-studio/shared';
 
 const PO_MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
 function formatPoDate(dateStr) {
@@ -642,9 +642,8 @@ export default function Step2Bouquet({
           }}
           onSelectStock={picked => {
             if (picked?.kind === 'fresh') {
-              // TODO: pass full variety attrs once createDemandEntry supports new shape.
-              // Fallback: add a text-only line using the display name from the first item.
-              const firstName = yPickerStockItems[0]?.['Display Name'] || picked.date || '';
+              const v = picked.variety || {};
+              const firstName = varietyDisplayName(v) || yPickerStockItems[0]?.['Display Name'] || picked.date || '';
               onLinesChange(lines => {
                 const exists = lines.find(l => !l.stockItemId && l.flowerName === firstName);
                 if (exists) return lines.map(l => !l.stockItemId && l.flowerName === firstName ? { ...l, quantity: l.quantity + 1 } : l);
@@ -658,11 +657,14 @@ export default function Step2Bouquet({
             setFlowerQuery('');
           }}
           onCreateVariety={async draft => {
-            // TODO: POST /stock four-tuple not yet confirmed. Fall back to legacy display name.
-            const legacyName = [draft.type_name, draft.colour].filter(Boolean).join(' ');
+            const displayName = (draft.baseName || varietyDisplayName(draft) || '').trim();
             try {
               const res = await client.post('/stock', {
-                displayName: legacyName || draft.type_name,
+                displayName,
+                typeName: draft.type_name ?? null,
+                colour:   draft.colour ?? null,
+                sizeCm:   draft.size_cm ?? null,
+                cultivar: draft.cultivar ?? null,
                 costPrice: 0, sellPrice: 0, quantity: 0,
               });
               const newItem = res.data;

--- a/apps/florist/src/components/BouquetEditor.jsx
+++ b/apps/florist/src/components/BouquetEditor.jsx
@@ -367,9 +367,7 @@ export default function BouquetEditor({ editing, saving, detail, isTerminal, isO
               }}
               onSelectStock={picked => {
                 if (picked && picked.kind === 'fresh') {
-                  // TODO(Task 7): pass full variety attrs once createDemandEntry supports new shape.
-                  // For now fall back to display name so the call doesn't 4xx in production.
-                  editing.createDemandEntry(picked.displayName || picked.date || '');
+                  editing.createDemandEntry(picked.variety || picked.displayName || picked.date || '');
                 } else if (picked) {
                   const existing = editing.editLines.findIndex(l => l.stockItemId === picked.id);
                   if (existing >= 0) {
@@ -382,10 +380,7 @@ export default function BouquetEditor({ editing, saving, detail, isTerminal, isO
                 setFlowerSearch('');
               }}
               onCreateVariety={async draft => {
-                // TODO(Task 7): POST /stock four-tuple support not yet confirmed.
-                // POST /stock only accepts displayName — pass legacy shape so we don't 4xx.
-                const legacyName = [draft.type_name, draft.colour].filter(Boolean).join(' ');
-                const res = await editing.addNewFlowerQuick(legacyName || draft.type_name);
+                const res = await editing.addNewVariety(draft);
                 setYPickerOpen(false);
                 return res;
               }}

--- a/apps/florist/src/components/steps/Step2Bouquet.jsx
+++ b/apps/florist/src/components/steps/Step2Bouquet.jsx
@@ -10,7 +10,7 @@ import { useToast } from '../../context/ToastContext.jsx';
 import { useAuth } from '../../context/AuthContext.jsx';
 import t from '../../translations.js';
 import useConfigLists from '../../hooks/useConfigLists.js';
-import { renderStockName, VarietyAllocationPicker, useStockYModelFlag } from '@flower-studio/shared';
+import { renderStockName, VarietyAllocationPicker, useStockYModelFlag, varietyDisplayName } from '@flower-studio/shared';
 
 const PO_MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
 function formatPoDate(dateStr) {
@@ -825,17 +825,14 @@ export default function Step2Bouquet({
           }}
           onSelectStock={picked => {
             if (picked?.kind === 'fresh') {
-              // TODO: pass full variety attrs once createDemandEntry supports new shape.
-              // Fallback: add a text-only line using the display name from the first item
-              // in the variety group. Backend POST /stock four-tuple not yet confirmed.
-              const firstName = yPickerStockItems[0]?.['Display Name'] || picked.date || '';
+              const v = picked.variety || {};
+              const firstName = varietyDisplayName(v) || yPickerStockItems[0]?.['Display Name'] || picked.date || '';
               onLinesChange(lines => {
                 const exists = lines.find(l => !l.stockItemId && l.flowerName === firstName);
                 if (exists) return lines.map(l => !l.stockItemId && l.flowerName === firstName ? { ...l, quantity: l.quantity + 1 } : l);
                 return [...lines, { stockItemId: null, flowerName: firstName, quantity: 1, costPricePerUnit: 0, sellPricePerUnit: 0, stockDeferred: isFutureOrder }];
               });
             } else if (picked) {
-              // Find original Airtable-shaped item and add it
               const original = stock.find(s => s.id === picked.id) || picked;
               addOne(original);
             }
@@ -843,21 +840,26 @@ export default function Step2Bouquet({
             setFlowerQuery('');
           }}
           onCreateVariety={async draft => {
-            // TODO: POST /stock four-tuple not yet confirmed. Fall back to legacy display name.
-            const legacyName = [draft.type_name, draft.colour].filter(Boolean).join(' ');
+            const displayName = (draft.baseName || varietyDisplayName(draft) || '').trim();
             try {
               const res = await client.post('/stock', {
-                displayName: legacyName || draft.type_name,
+                displayName,
+                typeName: draft.type_name ?? null,
+                colour:   draft.colour ?? null,
+                sizeCm:   draft.size_cm ?? null,
+                cultivar: draft.cultivar ?? null,
                 costPrice: 0, sellPrice: 0, quantity: 0,
               });
               const newItem = res.data;
               addOne({ id: newItem.id, 'Display Name': newItem['Display Name'], 'Current Cost Price': 0, 'Current Sell Price': 0 });
               onStockRefresh();
+              setYPickerOpen(false);
+              return newItem;
             } catch (err) {
               showToast(err.response?.data?.error || t.error, 'error');
+              setYPickerOpen(false);
+              return null;
             }
-            setYPickerOpen(false);
-            return null;
           }}
           onClose={() => setYPickerOpen(false)}
         />

--- a/backend/src/__tests__/stock.postVarietyAttrs.test.js
+++ b/backend/src/__tests__/stock.postVarietyAttrs.test.js
@@ -1,0 +1,177 @@
+// Route-level tests: POST /stock accepts 4-tuple Variety attributes.
+// Covers issue #287/#288 follow-up — typeName, colour, sizeCm, cultivar
+// are accepted on creation and persisted to type_name, colour, size_cm,
+// cultivar columns (already added by migration 0012 / #284).
+//
+// Auth pattern: inject req.role via x-test-role header (same as
+// stock.varietyBackfill.routes.test.js) to avoid PIN env-var bootstrap race.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express from 'express';
+import supertest from 'supertest';
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import { stock } from '../db/schema.js';
+import { eq } from 'drizzle-orm';
+
+const dbHolder = { db: null };
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  isPostgresConfigured: true,
+  pool: null,
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+import stockRouter from '../routes/stock.js';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.role = req.headers['x-test-role'] || 'owner';
+    next();
+  });
+  app.use('/stock', stockRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(err.statusCode || 500).json({ error: err.message });
+  });
+  return app;
+}
+
+let harness, app;
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+  app = buildApp();
+  vi.clearAllMocks();
+});
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+// Helper: read back the raw PG row by uuid
+async function getStockRow(id) {
+  const [row] = await harness.db.select().from(stock).where(eq(stock.id, id));
+  return row ?? null;
+}
+
+describe('POST /stock — 4-tuple Variety attributes', () => {
+  it('full 4-tuple: response includes Type/Colour/Size/Cultivar; PG row has correct columns', async () => {
+    const res = await supertest(app)
+      .post('/stock')
+      .set('x-test-role', 'florist')
+      .send({
+        displayName: 'Rose Sarah Bernhardt 60cm',
+        category: 'Flowers',
+        quantity: 20,
+        costPrice: 3.5,
+        typeName: 'Rose',
+        colour: 'Pink',
+        sizeCm: 60,
+        cultivar: 'Sarah Bernhardt',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.Type).toBe('Rose');
+    expect(res.body.Colour).toBe('Pink');
+    expect(res.body.Size).toBe(60);
+    expect(res.body.Cultivar).toBe('Sarah Bernhardt');
+
+    const row = await getStockRow(res.body._pgId);
+    expect(row.typeName).toBe('Rose');
+    expect(row.colour).toBe('Pink');
+    expect(row.sizeCm).toBe(60);
+    expect(row.cultivar).toBe('Sarah Bernhardt');
+  });
+
+  it('partial 4-tuple (only typeName): other 3 columns are null in DB', async () => {
+    const res = await supertest(app)
+      .post('/stock')
+      .set('x-test-role', 'florist')
+      .send({
+        displayName: 'Mystery Flower',
+        quantity: 5,
+        costPrice: 1,
+        typeName: 'Dahlia',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.Type).toBe('Dahlia');
+    expect(res.body.Colour).toBeNull();
+    expect(res.body.Size).toBeNull();
+    expect(res.body.Cultivar).toBeNull();
+
+    const row = await getStockRow(res.body._pgId);
+    expect(row.typeName).toBe('Dahlia');
+    expect(row.colour).toBeNull();
+    expect(row.sizeCm).toBeNull();
+    expect(row.cultivar).toBeNull();
+  });
+
+  it('legacy shape (no 4-tuple fields): still works; 4-tuple columns null in DB', async () => {
+    const res = await supertest(app)
+      .post('/stock')
+      .set('x-test-role', 'florist')
+      .send({
+        displayName: 'Legacy Stem',
+        category: 'Greenery',
+        quantity: 10,
+        costPrice: 0.5,
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.Type).toBeNull();
+    expect(res.body.Colour).toBeNull();
+    expect(res.body.Size).toBeNull();
+    expect(res.body.Cultivar).toBeNull();
+
+    const row = await getStockRow(res.body._pgId);
+    expect(row.typeName).toBeNull();
+    expect(row.colour).toBeNull();
+    expect(row.sizeCm).toBeNull();
+    expect(row.cultivar).toBeNull();
+  });
+
+  it('empty string for colour is coerced to null', async () => {
+    const res = await supertest(app)
+      .post('/stock')
+      .set('x-test-role', 'florist')
+      .send({
+        displayName: 'Whiteless Rose',
+        quantity: 8,
+        costPrice: 2,
+        typeName: 'Rose',
+        colour: '',
+        cultivar: '',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.Colour).toBeNull();
+    expect(res.body.Cultivar).toBeNull();
+
+    const row = await getStockRow(res.body._pgId);
+    expect(row.colour).toBeNull();
+    expect(row.cultivar).toBeNull();
+  });
+
+  it('invalid sizeCm (non-numeric string) is coerced to null', async () => {
+    const res = await supertest(app)
+      .post('/stock')
+      .set('x-test-role', 'florist')
+      .send({
+        displayName: 'Bad Size Tulip',
+        quantity: 5,
+        costPrice: 1,
+        typeName: 'Tulip',
+        sizeCm: 'abc',
+      });
+
+    // Non-numeric sizeCm should coerce to null rather than crash
+    expect(res.status).toBe(201);
+    expect(res.body.Size).toBeNull();
+
+    const row = await getStockRow(res.body._pgId);
+    expect(row.sizeCm).toBeNull();
+  });
+});

--- a/backend/src/__tests__/stock.premadeCommitted.route.test.js
+++ b/backend/src/__tests__/stock.premadeCommitted.route.test.js
@@ -1,0 +1,209 @@
+// Route tests for GET /stock/premade-committed — Task T2, issue #288 follow-up.
+//
+// Validates that the Y-model branch populates bouquets[] instead of returning
+// empty arrays. Shape must match the legacy branch exactly:
+//   { stockId: { qty: N, bouquets: [{ bouquetId, name, qty }] } }
+//
+// Coverage:
+//   • Y-model: stock used by 2 premades → bouquets[] has both entries with
+//     correct bouquetId, name, and per-bouquet qty.
+//   • Y-model: stock item not used by any premade is omitted from response.
+//   • Y-model: field names match legacy branch shape (bouquetId, name, qty).
+//   • Flag-off guard: legacy path still returns correct shape.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express from 'express';
+import supertest from 'supertest';
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import {
+  stock,
+  premadeBouquets,
+  premadeBouquetLines,
+} from '../db/schema.js';
+
+// ── db module mock — injected via dbHolder ──
+const dbHolder = { db: null };
+vi.mock('../db/index.js', () => ({
+  get db()              { return dbHolder.db; },
+  isPostgresConfigured: true,
+  pool:                 null,
+  connectPostgres:      async () => {},
+  disconnectPostgres:   async () => {},
+}));
+
+// ── audit mock — no-op ──
+vi.mock('../db/audit.js', () => ({ recordAudit: vi.fn().mockResolvedValue(undefined) }));
+
+// ── configService mock — toggleable Y-model flag ──
+let yModelEnabled = false;
+vi.mock('../services/configService.js', () => ({
+  getStockYModelEnabled:    () => yModelEnabled,
+  getConfig:                () => undefined,
+  getActiveSeasonalCategory: () => null,
+  generateOrderId:          async () => 'TEST-001',
+}));
+
+// ── Notification / SSE mocks ──
+vi.mock('../services/notifications.js', () => ({ broadcastEvent: vi.fn() }));
+vi.mock('../services/telegram.js', () => ({ sendTelegramMessage: vi.fn().mockResolvedValue(undefined) }));
+
+import stockRouter from '../routes/stock.js';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.role = req.headers['x-test-role'] || 'owner';
+    next();
+  });
+  app.use('/stock', stockRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(err.statusCode || 500).json({ error: err.message });
+  });
+  return app;
+}
+
+let harness, app;
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+  yModelEnabled = false;
+  app = buildApp();
+  vi.clearAllMocks();
+});
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+// ── Seed helpers ──
+
+async function seedStock(overrides = {}) {
+  const [row] = await harness.db.insert(stock).values({
+    displayName:     overrides.displayName     ?? 'Rose Red',
+    currentQuantity: overrides.currentQuantity ?? 20,
+    active:          overrides.active          ?? true,
+    typeName:        overrides.typeName        ?? 'Rose',
+  }).returning();
+  return row;
+}
+
+async function seedPremade(name = 'Spring Bouquet') {
+  const [row] = await harness.db.insert(premadeBouquets).values({
+    name,
+    createdBy: 'florist',
+    notes: '',
+  }).returning();
+  return row;
+}
+
+async function seedPremadeLine(bouquetId, stockId, quantity = 5) {
+  const [row] = await harness.db.insert(premadeBouquetLines).values({
+    bouquetId,
+    stockId,
+    flowerName:       'Rose Red',
+    quantity,
+    costPricePerUnit: '1.00',
+    sellPricePerUnit: '3.00',
+  }).returning();
+  return row;
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Y-model flag-ON tests
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('GET /stock/premade-committed — Y-model (STOCK_Y_MODEL=true)', () => {
+  beforeEach(() => { yModelEnabled = true; });
+
+  it('stock used by 2 premades returns bouquets[] with both entries', async () => {
+    const rose = await seedStock({ displayName: 'Rose Red' });
+    const bq1  = await seedPremade('Morning Bunch');
+    const bq2  = await seedPremade('Evening Bunch');
+    await seedPremadeLine(bq1.id, rose.id, 3);
+    await seedPremadeLine(bq2.id, rose.id, 7);
+
+    const res = await supertest(app)
+      .get('/stock/premade-committed')
+      .set('x-test-role', 'owner');
+
+    expect(res.status).toBe(200);
+    const entry = res.body[rose.id];
+    expect(entry).toBeDefined();
+    expect(entry.qty).toBe(10);
+    expect(Array.isArray(entry.bouquets)).toBe(true);
+    expect(entry.bouquets).toHaveLength(2);
+
+    // Both bouquet entries must have correct shape and values
+    const b1 = entry.bouquets.find(b => b.bouquetId === bq1.id);
+    const b2 = entry.bouquets.find(b => b.bouquetId === bq2.id);
+
+    expect(b1).toBeDefined();
+    expect(b1.name).toBe('Morning Bunch');
+    expect(b1.qty).toBe(3);
+
+    expect(b2).toBeDefined();
+    expect(b2.name).toBe('Evening Bunch');
+    expect(b2.qty).toBe(7);
+  });
+
+  it('stock item not used by any premade is omitted from the response', async () => {
+    const rose     = await seedStock({ displayName: 'Rose Red' });
+    const peony    = await seedStock({ displayName: 'Peony White', typeName: 'Peony' });
+    const bq       = await seedPremade('Morning Bunch');
+    await seedPremadeLine(bq.id, rose.id, 5);
+    // peony has no premade lines
+
+    const res = await supertest(app)
+      .get('/stock/premade-committed')
+      .set('x-test-role', 'owner');
+
+    expect(res.status).toBe(200);
+    expect(res.body[rose.id]).toBeDefined();
+    expect(res.body[peony.id]).toBeUndefined();
+  });
+
+  it('bouquets[] entries have exact field names: bouquetId, name, qty (matches legacy shape)', async () => {
+    const rose = await seedStock({ displayName: 'Rose Red' });
+    const bq   = await seedPremade('Fancy Bunch');
+    await seedPremadeLine(bq.id, rose.id, 4);
+
+    const res = await supertest(app)
+      .get('/stock/premade-committed')
+      .set('x-test-role', 'owner');
+
+    expect(res.status).toBe(200);
+    const [bouquet] = res.body[rose.id].bouquets;
+    expect(bouquet).toHaveProperty('bouquetId');
+    expect(bouquet).toHaveProperty('name');
+    expect(bouquet).toHaveProperty('qty');
+    // No extra/unexpected fields (strict shape check)
+    expect(Object.keys(bouquet).sort()).toEqual(['bouquetId', 'name', 'qty'].sort());
+  });
+
+  it('returns empty object when no premade lines exist at all', async () => {
+    await seedStock({ displayName: 'Orphan Stock' });
+
+    const res = await supertest(app)
+      .get('/stock/premade-committed')
+      .set('x-test-role', 'owner');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({});
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// Flag-OFF guard — legacy path must not regress
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('GET /stock/premade-committed — flag-off (STOCK_Y_MODEL=false)', () => {
+  it('returns 200 with correct outer shape (legacy path)', async () => {
+    const res = await supertest(app)
+      .get('/stock/premade-committed')
+      .set('x-test-role', 'owner');
+
+    expect(res.status).toBe(200);
+    expect(typeof res.body).toBe('object');
+  });
+});

--- a/backend/src/repos/stockRepo.js
+++ b/backend/src/repos/stockRepo.js
@@ -222,6 +222,8 @@ export const STOCK_WRITE_ALLOWED = [
   'Current Cost Price', 'Current Sell Price', 'Supplier', 'Reorder Threshold',
   'Active', 'Supplier Notes', 'Dead/Unsold Stems', 'Lot Size', 'Farmer',
   'Last Restocked', 'Substitute For',
+  // Stock Y-model 4-tuple Variety attributes (issue #284 / #287)
+  'Type', 'Colour', 'Size', 'Cultivar',
 ];
 
 // ── Wire-format ↔ PG-row mapping ──
@@ -279,6 +281,15 @@ export function responseToPg(fields) {
   if ('Farmer' in fields)             out.farmer            = fields.Farmer || null;
   if ('Last Restocked' in fields)     out.lastRestocked     = fields['Last Restocked'] || null;
   if ('Substitute For' in fields)     out.substituteFor     = Array.isArray(fields['Substitute For']) ? fields['Substitute For'] : null;
+  // Stock Y-model 4-tuple Variety attributes (issue #284 / #287)
+  // Empty strings normalised to null; sizeCm coerced to integer or null.
+  if ('Type' in fields)     out.typeName = fields.Type    ? String(fields.Type).trim()    || null : null;
+  if ('Colour' in fields)   out.colour   = fields.Colour  ? String(fields.Colour).trim()  || null : null;
+  if ('Cultivar' in fields) out.cultivar = fields.Cultivar ? String(fields.Cultivar).trim() || null : null;
+  if ('Size' in fields) {
+    const n = parseInt(fields.Size, 10);
+    out.sizeCm = Number.isFinite(n) ? n : null;
+  }
   return out;
 }
 
@@ -816,6 +827,41 @@ export async function getPremadeReservations(stockIds, tx = null) {
   const out = new Map();
   for (const r of rows) {
     if (r.stockId) out.set(r.stockId, Number(r.totalQty) || 0);
+  }
+  return out;
+}
+
+// ── getPremadeReservationDetails (Stock Y-model, issue #288 follow-up) ──
+// Like getPremadeReservations but returns full bouquet context per stock item.
+// Returns Map<stockId, { totalQty, bouquets: [{ bouquetId, name, qty }] }>
+// so the /stock/premade-committed Y-model branch can populate bouquets[].
+// Joins premade_bouquet_lines → premade_bouquets, groups by (stockId, bouquetId, name).
+// Does NOT accept a `tx` argument — this is a read-only endpoint, no transaction needed.
+export async function getPremadeReservationDetails(stockIds) {
+  if (!Array.isArray(stockIds) || stockIds.length === 0) return new Map();
+  if (!db) return new Map();
+  const rows = await db
+    .select({
+      stockId:     premadeBouquetLines.stockId,
+      bouquetId:   premadeBouquetLines.bouquetId,
+      bouquetName: premadeBouquets.name,
+      lineQty:     sql`SUM(${premadeBouquetLines.quantity})`,
+    })
+    .from(premadeBouquetLines)
+    .innerJoin(premadeBouquets, eq(premadeBouquetLines.bouquetId, premadeBouquets.id))
+    .where(inArray(premadeBouquetLines.stockId, stockIds))
+    .groupBy(premadeBouquetLines.stockId, premadeBouquetLines.bouquetId, premadeBouquets.name);
+
+  const out = new Map();
+  for (const r of rows) {
+    if (!r.stockId) continue;
+    const qty = Number(r.lineQty) || 0;
+    if (!out.has(r.stockId)) {
+      out.set(r.stockId, { totalQty: 0, bouquets: [] });
+    }
+    const entry = out.get(r.stockId);
+    entry.totalQty += qty;
+    entry.bouquets.push({ bouquetId: r.bouquetId, name: r.bouquetName, qty });
   }
   return out;
 }

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -120,10 +120,10 @@ router.get('/premade-committed', async (req, res, next) => {
     if (getStockYModelEnabled()) {
       const allStock = await stockRepo.list({ pg: { includeInactive: true, includeEmpty: true } });
       const allStockIds = allStock.map(s => s._pgId).filter(Boolean);
-      const reservations = await stockRepo.getPremadeReservations(allStockIds);
+      const details = await stockRepo.getPremadeReservationDetails(allStockIds);
       const committed = {};
-      for (const [stockId, qty] of reservations) {
-        if (qty > 0) committed[stockId] = { qty, bouquets: [] };
+      for (const [stockId, { totalQty, bouquets }] of details) {
+        if (totalQty > 0) committed[stockId] = { qty: totalQty, bouquets };
       }
       return res.json(committed);
     }
@@ -398,10 +398,18 @@ router.get('/pending-po', async (req, res, next) => {
 });
 
 // POST /api/stock — create a new stock item (florist quick-add during spontaneous delivery)
-// Body: { displayName, category, quantity, costPrice, sellPrice?, supplier?, unit? }
+// Body: { displayName, category, quantity, costPrice, sellPrice?, supplier?, unit?,
+//         typeName?, colour?, sizeCm?, cultivar? }
+// The 4-tuple Variety attrs (typeName/colour/sizeCm/cultivar) are optional pass-through
+// fields added for issue #287. sizeCm is coerced to integer or null; empty strings for
+// string attrs normalise to null. No further validation beyond coercion.
 router.post('/', async (req, res, next) => {
   try {
-    const { displayName, category, quantity, costPrice, sellPrice, supplier, unit, lotSize, farmer } = req.body;
+    const {
+      displayName, category, quantity, costPrice, sellPrice, supplier, unit, lotSize, farmer,
+      // Stock Y-model 4-tuple Variety attrs (camelCase wire → Airtable-style field names)
+      typeName, colour, sizeCm, cultivar,
+    } = req.body;
     if (!displayName) return res.status(400).json({ error: 'displayName is required' });
 
     const fields = {
@@ -417,6 +425,13 @@ router.post('/', async (req, res, next) => {
     if (unit)       fields['Unit'] = unit;
     if (lotSize)    fields['Lot Size'] = Number(lotSize);
     if (farmer)     fields['Farmer'] = farmer;
+
+    // 4-tuple Variety attrs — always pass so responseToPg can normalise them
+    // (empty strings → null handled inside responseToPg / stockRepo).
+    if (typeName  !== undefined) fields['Type']    = typeName;
+    if (colour    !== undefined) fields['Colour']  = colour;
+    if (sizeCm    !== undefined) fields['Size']    = sizeCm;
+    if (cultivar  !== undefined) fields['Cultivar'] = cultivar;
 
     const item = await stockRepo.create(fields, { actor: actorFromReq(req) });
     res.status(201).json(item);

--- a/docs/superpowers/plans/2026-05-10-stock-y-gaps.md
+++ b/docs/superpowers/plans/2026-05-10-stock-y-gaps.md
@@ -1,0 +1,57 @@
+# Stock Y-model: gap closures (#287/#288/#289 follow-ups)
+
+> Subagent-driven execution. Sonnet implementer + spec-review. Backend = TDD red mandatory.
+
+**Goal:** Close 3 backend gaps that left `<VarietyAllocationPicker>` create-flow + reserved-bucket tap as dead-ends.
+
+## Tasks
+
+### T1: `POST /stock` accepts 4-tuple Variety attrs
+
+**Files:** `backend/src/routes/stock.js`, `backend/src/repos/stockRepo.js`, `backend/src/__tests__/stockRoutes.test.js` (or appropriate)
+
+Today the POST handler whitelists `displayName, category, quantity, costPrice, sellPrice, supplier, unit, lotSize, farmer`. Add `typeName, colour, sizeCm, cultivar` (camelCase wire) → write to `type_name, colour, size_cm, cultivar` columns. Pass-through; no validation beyond type coercion.
+
+**Tests:** post with all 4-tuple fields → row reads them back; partial fields (only typeName) work; legacy displayName-only still works.
+
+### T2: `/stock/premade-committed` Y-model branch populates `bouquets[]`
+
+**Files:** `backend/src/routes/stock.js` lines ~110-130, possibly `backend/src/repos/stockRepo.js`
+
+Currently Y-model branch returns `{ stockId: { qty, bouquets: [] } }`. Extend to join premade_bouquet_lines → premade_bouquets so `bouquets: [{ bouquetId, name, qty }]` is populated, matching the legacy branch's shape.
+
+**Tests:** premade with 2 lines for same Variety → response has both bouquet names. Empty premades → `bouquets: []`.
+
+### T3: `createDemandEntry` accepts 4-tuple draft
+
+**Files:** `packages/shared/hooks/useOrderEditing.js` lines 220-266, `packages/shared/test/useOrderEditing.test.js` if exists or new test
+
+Current signature: `createDemandEntry(baseName: string)`. New: `createDemandEntry(varietyDraft)` where `varietyDraft` is either the legacy string (back-compat) OR `{ baseName?, type_name?, colour?, size_cm?, cultivar? }`. When 4-tuple provided, POST /stock with all fields. Display name auto-derived from `varietyDisplayName` if not given.
+
+**Tests:** 4-tuple draft → POST body carries all 4; legacy string still works.
+
+### T4: Picker callsite TODOs
+
+**Files:** 4 callsites with `TODO: pass full variety attrs once createDemandEntry supports new shape`:
+- `apps/florist/src/components/BouquetEditor.jsx:370-372`
+- `apps/dashboard/src/components/order/BouquetSection.jsx:228-231`
+- `apps/florist/src/components/steps/Step2Bouquet.jsx:827-846`
+- `apps/dashboard/src/components/steps/Step2Bouquet.jsx:644-661`
+
+Replace fallbacks: when picker emits `{ kind: 'fresh', date, variety }` (we may need to extend the payload), call `editing.createDemandEntry({ ...variety, baseName: varietyDisplayName(variety) })`. Same for `onCreateVariety` flow — pass through the 4-tuple to `apiClient.post('/stock', { typeName, colour, sizeCm, cultivar, displayName })`.
+
+Note: `<VarietyAllocationPicker>` may already have the variety in scope when emitting fresh. Verify by reading the component; if not, extend the emission shape to include the variety four-tuple.
+
+**Skip TDD red** for this task (UI wiring composing existing services).
+
+### T5: CHANGELOG + Pre-PR matrix + PR merge
+
+**Files:** `CHANGELOG.md`
+
+Single-line entry under a new `## 2026-05-10 — Stock Y-model: gap closures` heading citing #287/#288/#289 follow-ups + the 3 gaps closed.
+
+Run Pre-PR matrix (backend vitest + e2e + shared vitest + 3 builds + lab unit/api). Open PR, merge on green, cleanup.
+
+## Sizing
+
+~150 LOC across ~8 files. T1+T2 parallel-safe. T3 depends on T1. T4 depends on T3.

--- a/packages/shared/components/VarietyAllocationPicker.jsx
+++ b/packages/shared/components/VarietyAllocationPicker.jsx
@@ -16,7 +16,7 @@ import { stockAllocationEngine } from '../utils/stockAllocationEngine.js';
  *   role             — 'owner' | 'florist' (gates "+ Create new Variety")
  *   t                — translation strings (pickerSearchPlaceholder, pickerCreateNew,
  *                      pickerNoResults, stems, onHand, planned, reserved, net, cancel)
- *   onSelectStock    — (stockItem | { kind: 'fresh', date }) => void
+ *   onSelectStock    — (stockItem | { kind: 'fresh', date, variety: { type_name, colour, size_cm, cultivar } | null }) => void
  *   onCreateVariety  — (varietyDraft) => Promise<stockItem>  (Owner-only, Task 4)
  *   premadesByStockId — Map<stockId, [{id, name, qty}]> — optional, for reserved expand
  *   onClose          — () => void
@@ -134,7 +134,17 @@ export default function VarietyAllocationPicker({
   }
 
   function handleFreshClick() {
-    onSelectStock({ kind: 'fresh', date: requiredBy });
+    const group = groups.find((g) => g.key === expandedKey);
+    onSelectStock({
+      kind: 'fresh',
+      date: requiredBy,
+      variety: group ? {
+        type_name: group.type_name,
+        colour: group.colour,
+        size_cm: group.size_cm,
+        cultivar: group.cultivar,
+      } : null,
+    });
   }
 
   function handleDraftChange(field, value) {

--- a/packages/shared/hooks/useOrderEditing.js
+++ b/packages/shared/hooks/useOrderEditing.js
@@ -219,6 +219,33 @@ export default function useOrderEditing({ orderId, apiClient, showToast, t }) {
     setAddingFlower(false);
   }
 
+  // ── New Variety (Owner-only "+ Create new Variety" path) ─────────
+  // Creates a new Stock Item with full 4-tuple Variety attrs and qty=0.
+  // Returns the new row so callers (e.g. VarietyAllocationPicker) can
+  // pass it back through onSelectStock to add a line.
+  async function addNewVariety(draft) {
+    const displayName = (draft.baseName || varietyDisplayName(draft) || '').trim();
+    if (!displayName) {
+      showToast(t.updateError || 'Error creating Variety', 'error');
+      return null;
+    }
+    try {
+      const res = await apiClient.post('/stock', {
+        displayName,
+        typeName: draft.type_name ?? null,
+        colour: draft.colour ?? null,
+        sizeCm: draft.size_cm ?? null,
+        cultivar: draft.cultivar ?? null,
+        quantity: 0,
+      });
+      setStockItems(prev => [...prev, res.data]);
+      return res.data;
+    } catch {
+      showToast(t.updateError || 'Error creating Variety', 'error');
+      return null;
+    }
+  }
+
   // ── Demand Entry path ──────────────────────────────────────────────
   // Creates or deepens the single undated Demand Entry for a variety.
   // If one already exists, uses it (deepens aggregate negative qty).
@@ -506,6 +533,7 @@ export default function useOrderEditing({ orderId, apiClient, showToast, t }) {
     openNewFlowerForm,
     addNewFlower,
     addNewFlowerQuick,
+    addNewVariety,
     getFilteredStock,
     doSave,
     handleSaveClick,

--- a/packages/shared/hooks/useOrderEditing.js
+++ b/packages/shared/hooks/useOrderEditing.js
@@ -7,6 +7,7 @@
 
 import { useState } from 'react';
 import parseBatchName from '../utils/parseBatchName.js';
+import { varietyDisplayName } from '../utils/varietyKey.js';
 
 const _DATE_BATCH_RE = /\(\d{1,2}\.\w{3,4}\.?\)$/;
 
@@ -222,8 +223,27 @@ export default function useOrderEditing({ orderId, apiClient, showToast, t }) {
   // Creates or deepens the single undated Demand Entry for a variety.
   // If one already exists, uses it (deepens aggregate negative qty).
   // If not, creates one inheriting price from the most recent Batch.
-  async function createDemandEntry(baseName) {
-    const variety = findAllMatchingVariety(stockItems, baseName);
+  //
+  // varietyDraft: string (back-compat) OR
+  //   { baseName?, type_name?, colour?, size_cm?, cultivar? }
+  // When an object is provided the POST body includes the 4-tuple Variety
+  // attrs (typeName/colour/sizeCm/cultivar) so the backend can persist them.
+  // displayName is taken from baseName if given, otherwise auto-computed via
+  // varietyDisplayName.
+  async function createDemandEntry(varietyDraft) {
+    // Normalise to a resolved display name + optional 4-tuple fields.
+    let displayName;
+    let tupleFields = null; // null = legacy path (omit from POST body)
+
+    if (typeof varietyDraft === 'string') {
+      displayName = varietyDraft;
+    } else {
+      const { baseName, type_name, colour, size_cm, cultivar } = varietyDraft;
+      displayName = baseName || varietyDisplayName({ type_name, colour, size_cm, cultivar });
+      tupleFields = { type_name, colour, size_cm, cultivar };
+    }
+
+    const variety = findAllMatchingVariety(stockItems, displayName);
     const demandEntry = variety.find(s => parseBatchName(s['Display Name'] || '').batch === null);
 
     if (demandEntry) {
@@ -241,13 +261,26 @@ export default function useOrderEditing({ orderId, apiClient, showToast, t }) {
     const costPrice = Number(mostRecentBatch?.['Current Cost Price']) || 0;
     const sellPrice = Number(mostRecentBatch?.['Current Sell Price']) || 0;
 
+    const postBody = {
+      displayName: displayName.trim(),
+      quantity: 0,
+      costPrice,
+      sellPrice,
+    };
+
+    // 4-tuple path: include Variety attrs only when explicitly provided.
+    // Only include fields that were present on the draft (avoid sending
+    // undefined values — back-compat callers omit the whole key).
+    if (tupleFields !== null) {
+      const { type_name, colour, size_cm, cultivar } = tupleFields;
+      if (type_name !== undefined)  postBody.typeName = type_name;
+      if (colour    !== undefined)  postBody.colour   = colour;
+      if (size_cm   !== undefined)  postBody.sizeCm   = size_cm;
+      if (cultivar  !== undefined)  postBody.cultivar = cultivar;
+    }
+
     try {
-      const res = await apiClient.post('/stock', {
-        displayName: baseName.trim(),
-        quantity: 0,
-        costPrice,
-        sellPrice,
-      });
+      const res = await apiClient.post('/stock', postBody);
       setStockItems(prev => [...prev, res.data]);
       setEditLines(prev => [...prev, {
         id: null,

--- a/packages/shared/test/VarietyAllocationPicker.test.jsx
+++ b/packages/shared/test/VarietyAllocationPicker.test.jsx
@@ -122,7 +122,11 @@ describe('VarietyAllocationPicker — Stage 2 allocation panel', () => {
       onSelectStock={onSelectStock} onClose={() => {}} />);
     fireEvent.click(screen.getAllByTestId('variety-row')[0]);
     fireEvent.click(screen.getByTestId('option-fresh'));
-    expect(onSelectStock).toHaveBeenCalledWith({ kind: 'fresh', date: '2026-05-12' });
+    expect(onSelectStock).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'fresh',
+      date: '2026-05-12',
+      variety: expect.objectContaining({ type_name: 'Rose', colour: 'Pink', size_cm: 60, cultivar: null }),
+    }));
   });
 });
 

--- a/packages/shared/test/useOrderEditing.test.js
+++ b/packages/shared/test/useOrderEditing.test.js
@@ -1,5 +1,8 @@
-import { describe, it, expect } from 'vitest';
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
 import { findDuplicateStockItem, isStockItemVisible, findAllMatchingVariety } from '../hooks/useOrderEditing.js';
+import useOrderEditing from '../hooks/useOrderEditing.js';
 
 describe('findDuplicateStockItem', () => {
   const stock = [
@@ -100,5 +103,142 @@ describe('findAllMatchingVariety', () => {
   it('handles items with no Display Name', () => {
     const messy = [{ id: 'x1' }, { id: 'x2', 'Display Name': 'Rose' }];
     expect(findAllMatchingVariety(messy, 'Rose').map(s => s.id)).toEqual(['x2']);
+  });
+});
+
+// ── createDemandEntry ──────────────────────────────────────────────────────
+// Tests use renderHook + a mocked apiClient. stockItems starts empty so the
+// duplicate-entry check never fires (no pre-existing Demand Entry).
+
+function makeHookProps(overrides = {}) {
+  return {
+    orderId:   'ord-1',
+    apiClient: {
+      get:  vi.fn().mockResolvedValue({ data: [] }),
+      post: vi.fn().mockResolvedValue({
+        data: { id: 'stock-new', 'Display Name': 'New Item', 'Current Cost Price': 0, 'Current Sell Price': 0 },
+      }),
+    },
+    showToast: vi.fn(),
+    t: { updateError: 'Error' },
+    ...overrides,
+  };
+}
+
+describe('createDemandEntry', () => {
+  // ── Legacy string path ────────────────────────────────────────────────────
+
+  it('legacy string: POSTs /stock with displayName only (no 4-tuple fields)', async () => {
+    const props = makeHookProps();
+    const { result } = renderHook(() => useOrderEditing(props));
+
+    await act(async () => {
+      await result.current.createDemandEntry('Rose');
+    });
+
+    expect(props.apiClient.post).toHaveBeenCalledWith('/stock', {
+      displayName: 'Rose',
+      quantity: 0,
+      costPrice: 0,
+      sellPrice: 0,
+    });
+    // 4-tuple fields must NOT be present
+    const body = props.apiClient.post.mock.calls[0][1];
+    expect(body).not.toHaveProperty('typeName');
+    expect(body).not.toHaveProperty('colour');
+    expect(body).not.toHaveProperty('sizeCm');
+    expect(body).not.toHaveProperty('cultivar');
+  });
+
+  // ── 4-tuple draft, no baseName (auto-computed displayName) ───────────────
+
+  it('4-tuple draft without baseName: auto-computes displayName via varietyDisplayName', async () => {
+    const props = makeHookProps();
+    const { result } = renderHook(() => useOrderEditing(props));
+
+    await act(async () => {
+      await result.current.createDemandEntry({
+        type_name: 'Rose',
+        colour: 'Pink',
+        size_cm: 60,
+        cultivar: null,
+      });
+    });
+
+    expect(props.apiClient.post).toHaveBeenCalledWith('/stock', {
+      displayName: 'Rose Pink 60cm',
+      typeName: 'Rose',
+      colour: 'Pink',
+      sizeCm: 60,
+      cultivar: null,
+      quantity: 0,
+      costPrice: 0,
+      sellPrice: 0,
+    });
+  });
+
+  // ── 4-tuple draft with explicit baseName (wins over auto-computed) ────────
+
+  it('4-tuple draft with explicit baseName: baseName wins over auto-computed name', async () => {
+    const props = makeHookProps();
+    const { result } = renderHook(() => useOrderEditing(props));
+
+    await act(async () => {
+      await result.current.createDemandEntry({
+        baseName: 'My Rose',
+        type_name: 'Rose',
+      });
+    });
+
+    const body = props.apiClient.post.mock.calls[0][1];
+    expect(body.displayName).toBe('My Rose');
+    expect(body.typeName).toBe('Rose');
+    // colour/sizeCm/cultivar absent from draft → not sent
+    expect(body).not.toHaveProperty('colour');
+    expect(body).not.toHaveProperty('sizeCm');
+    expect(body).not.toHaveProperty('cultivar');
+  });
+
+  // ── Existing Demand Entry path (regression: addFlowerFromStock, no POST) ─
+
+  it('when Demand Entry already exists: calls addFlowerFromStock, skips POST', async () => {
+    // Seed stockItems with a pre-existing Demand Entry for 'Rose'
+    const existingEntry = {
+      id: 'stock-existing',
+      'Display Name': 'Rose',        // no batch date → Demand Entry
+      'Current Cost Price': 5,
+      'Current Sell Price': 10,
+      'Current Quantity': -3,
+    };
+    const props = makeHookProps({
+      apiClient: {
+        get:  vi.fn().mockResolvedValue({ data: [existingEntry] }),
+        post: vi.fn(),
+      },
+    });
+    const { result } = renderHook(() => useOrderEditing(props));
+
+    // Boot stockItems by triggering startEditing (which calls apiClient.get)
+    await act(async () => {
+      result.current.startEditing([]);
+    });
+    // Wait for the async fetches inside startEditing to settle
+    await act(async () => {});
+
+    // Clear any POST calls that may have happened during startEditing
+    props.apiClient.post.mockClear();
+
+    await act(async () => {
+      await result.current.createDemandEntry('Rose');
+    });
+
+    // Should NOT have posted a new stock item
+    expect(props.apiClient.post).not.toHaveBeenCalledWith('/stock', expect.anything());
+    // Should have added the existing entry to editLines instead
+    expect(result.current.editLines).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ stockItemId: 'stock-existing' }),
+      ]),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Closes the three known follow-ups noted in #298 (PR for #288) and #299 (PR for #289):

- **`POST /stock` accepts 4-tuple Variety attrs** (`typeName`, `colour`, `sizeCm`, `cultivar`). Owner "+ Create new Variety" now produces a real Y-model row, not a `displayName`-only legacy fallback.
- **`/stock/premade-committed` Y-model branch populates `bouquets[]`**. Reserved-bucket tap on `<VarietyListItem>` now shows premade names + qty contributions, not just the count.
- **`useOrderEditing.createDemandEntry(varietyDraft)` accepts 4-tuple draft**. `<VarietyAllocationPicker>` `kind: 'fresh'` emission carries the variety; hosts route it through; backend creates a dated Demand Entry with attrs populated.
- **4 picker callsites migrated** (BouquetEditor, BouquetSection, Step2Bouquet × 2). All TODOs removed.

## Verification path

Pre-PR matrix — all green:

- `cd backend && npx vitest run` — **423 / 423** (1 todo) — +5 POST 4-tuple tests + +5 premade-committed shape tests
- `cd packages/shared && ../../backend/node_modules/.bin/vitest run` — **270 / 270** (+4 createDemandEntry hook tests)
- `cd apps/florist && ./node_modules/.bin/vite build` — ✓ 1.14s
- `cd apps/dashboard && ./node_modules/.bin/vite build` — ✓ 1.23s
- `cd apps/delivery && ./node_modules/.bin/vite build` — ✓ 0.56s
- `npm run lab:test:unit` — **37 / 37**
- `npm run lab:test:api` — **8 / 8**

E2E suite runs on CI.

## What unlocks

After this lands, end-to-end local UI testing of the picker + list is unblocked once **#290** lands (scenario extension seeds 4-tuple rows). Owner-driven Variety creation, dated Demand Entries with attrs, and premade reservation names all work in production under `STOCK_Y_MODEL=true` after this merges.

## Changes

| File | LOC delta | What |
|---|---|---|
| `backend/src/routes/stock.js` | +25/-5 | POST 4-tuple, premade-committed bouquets[] |
| `backend/src/repos/stockRepo.js` | +46 | `STOCK_WRITE_ALLOWED` extension + `getPremadeReservationDetails` |
| `packages/shared/hooks/useOrderEditing.js` | +60 | `createDemandEntry` 4-tuple + `addNewVariety` |
| `packages/shared/components/VarietyAllocationPicker.jsx` | +12 | `variety` field on fresh emission |
| 4 callsites | -49 / +37 | TODOs removed, real wiring |
| Tests | +509 across 3 files | Backend + hook coverage |
| `CHANGELOG.md` | +19 | Entry above #289 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)