### PR TITLE
feat(stock-y): migration script + lab regression gate (#290)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ Review this entire file before flipping to production.
 
 ---
 
+## 2026-05-11 — Stock Y-model: migration script + lab regression gate (#290)
+
+### Backend
+- **NEW DESTRUCTIVE script** `backend/scripts/migrate-stock-y-model.js` — converts legacy aggregate Demand Entry rows to Y-model (dated DEs + premade reservation back-add).
+  - Single transaction; `APPROVE=yes` gate; `--dry-run` rolls back without writing.
+  - Pre-condition: aborts if any `stock.type_name IS NULL` (run #292 Owner backfill UI first).
+  - Top-of-script idempotency guard: skips all phases if `stock.date` is already NOT NULL (re-running after a successful migration = no-op exit 0).
+- **Five phases:**
+  1. **Phase 1 — split aggregates by Required By.** For each aggregate DE with `qty < 0, date IS NULL` and active linked order_lines, group lines by `o.required_by → o.order_date → CURRENT_DATE`, create one dated DE per date with summed qty, repoint `order_lines.stock_item_id`, delete the aggregate. Filter: `o.status NOT IN ('Cancelled', 'Delivered', 'Picked Up') AND o.deleted_at IS NULL AND ol.deleted_at IS NULL` — only active demand flows into dated DEs; terminated lines are dropped.
+  2. **Phase 2 — orphan negative → today-dated DE.** Aggregates whose only linked lines are terminated/deleted (or that have no linked lines at all) become today-dated for owner review. Variety attrs preserved.
+  3. **Phase 3 — positive-qty undated → dated Batch.** Bulk UPDATE: every `qty >= 0, date IS NULL` row gets `date = today`. Covers legacy Batches and positive-qty manual edits identically.
+  4. **Phase 4 — premade reservation back-add.** SUM `premade_bouquet_lines.quantity` per `stock_id`, ADD to that Stock row's `current_quantity`. Per Pitfall #8: post-migration, `current_quantity` once again means physical on-hand, and reservations live in a separate informational bucket served by `/stock/premade-committed`.
+  5. **Phase 5 — apply NOT NULL.** `ALTER COLUMN date / type_name SET NOT NULL` once all rows have values. Phase 5 inside the migration transaction; rolls back cleanly on dry-run or failure.
+
+### Lab harness
+- **NEW scenario** `lab/scenarios/stockYMigration.js` — extends `stockOverhaul` with prod-shaped fixtures: a multi-order aggregate DE (2 dates), an orphan negative DE, a positive-qty manual edit, a premade bouquet with active lines, and an aggregate linked to one `New` + one `Cancelled` order (Phase 1 filter regression). Every stock row has `type_name` set (post-#292 state).
+- **NEW lab API test** `lab/tests/api/migrate-stock-y-model.test.js` — 9 tests covering pre-condition, all 5 phases, idempotency, and the Phase 1 filter. Self-bootstraps the template in `beforeAll` and restores `baseline` in `afterAll`, so it slots cleanly into the existing CI `lab-api` job.
+- **Schema-aware seed:** `lab/helpers/seed.js` now inserts `premade_bouquets` + `premade_bouquet_lines` (FK-safe order).
+
+### Notes
+- **NOT in scope this PR:** prod cutover, `STOCK_Y_MODEL=true` flag flip (both #291), Variety attribute backfill UI (#292).
+- **Cutover order reminder:** #284 (schema/flag) → #292 (Owner attribute backfill) → #285/#286/#287/#288/#289 (Y-model code paths) → #290 (this script, run with `APPROVE=yes`) → #291 (flag flip + retire flag-off branches).
+- **Operator note:** the Phase 1 active-order filter means the magnitude of the resulting dated DEs may be smaller than the aggregate's pre-migration `current_quantity` if any linked orders were cancelled-with-return or already delivered. The aggregate is deleted, so the residual is dropped intentionally — dated DEs represent **future** unfulfilled demand only.
+
+---
+
 ## 2026-05-10 — Stock Y-model: backend gap closures (#287/#288/#289 follow-up)
 
 ### Backend

--- a/backend/scripts/migrate-stock-y-model.js
+++ b/backend/scripts/migrate-stock-y-model.js
@@ -132,6 +132,24 @@ async function phase3PositiveUndated(client, today) {
   console.log(`[phase3] Dated ${rowCount} positive-qty undated row(s) → ${today}.`);
 }
 
+async function phase4PremadeBackAdd(client) {
+  const { rows: sums } = await client.query(`
+    SELECT stock_id, SUM(quantity)::int AS reserved
+    FROM premade_bouquet_lines
+    WHERE stock_id IS NOT NULL
+    GROUP BY stock_id
+  `);
+  for (const { stock_id, reserved } of sums) {
+    if (reserved > 0) {
+      await client.query(
+        `UPDATE stock SET current_quantity = current_quantity + $1, updated_at = NOW() WHERE id = $2`,
+        [reserved, stock_id]
+      );
+    }
+  }
+  console.log(`[phase4] Back-added premade reservations to ${sums.length} Batch(es).`);
+}
+
 async function run() {
   const client = await pool.connect();
   try {
@@ -140,8 +158,9 @@ async function run() {
     await phase1Split(client);
     await phase2OrphanNegative(client, today);
     await phase3PositiveUndated(client, today);
+    await phase4PremadeBackAdd(client);
 
-    // Phases 4-5 added in subsequent tasks.
+    // Phase 5 added in subsequent tasks.
 
     if (DRY_RUN) {
       console.log('[migrate] DRY RUN — rolling back transaction.');

--- a/backend/scripts/migrate-stock-y-model.js
+++ b/backend/scripts/migrate-stock-y-model.js
@@ -49,13 +49,75 @@ async function preCondition(client) {
   }
 }
 
+async function phase1Split(client) {
+  // Find aggregate DEs: negative qty, no date, linked to at least one order_line.
+  const { rows: aggregates } = await client.query(`
+    SELECT s.id, s.display_name, s.type_name, s.colour, s.size_cm, s.cultivar,
+           s.current_quantity, s.current_cost_price, s.current_sell_price,
+           s.supplier, s.unit, s.category
+    FROM stock s
+    WHERE s.current_quantity < 0
+      AND s.date IS NULL
+      AND s.deleted_at IS NULL
+      AND EXISTS (SELECT 1 FROM order_lines ol WHERE ol.stock_item_id = s.id::text)
+  `);
+
+  for (const agg of aggregates) {
+    // Group linked order_lines by Required By fallback chain.
+    const { rows: lines } = await client.query(`
+      SELECT ol.id AS line_id, ol.quantity,
+             COALESCE(o.required_by::text, o.order_date::text, CURRENT_DATE::text) AS due_date
+      FROM order_lines ol
+      JOIN orders o ON o.id = ol.order_id
+      WHERE ol.stock_item_id = $1::text
+    `, [agg.id]);
+
+    // Group by due_date, summing quantities.
+    const byDate = new Map();
+    for (const l of lines) {
+      const cur = byDate.get(l.due_date) ?? { qty: 0, lineIds: [] };
+      cur.qty += l.quantity;
+      cur.lineIds.push(l.line_id);
+      byDate.set(l.due_date, cur);
+    }
+
+    // Create one dated DE per distinct date, repoint order_lines.
+    for (const [date, group] of byDate.entries()) {
+      const { rows: [newRow] } = await client.query(`
+        INSERT INTO stock (
+          display_name, purchase_name, category, current_quantity, unit,
+          current_cost_price, current_sell_price, supplier,
+          type_name, colour, size_cm, cultivar, date, active
+        ) VALUES ($1, NULL, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, true)
+        RETURNING id
+      `, [
+        agg.display_name, agg.category, -group.qty, agg.unit,
+        agg.current_cost_price, agg.current_sell_price, agg.supplier,
+        agg.type_name, agg.colour, agg.size_cm, agg.cultivar, date,
+      ]);
+      // Repoint order_lines to the new dated DE.
+      await client.query(
+        `UPDATE order_lines SET stock_item_id = $1 WHERE id = ANY($2::uuid[])`,
+        [newRow.id, group.lineIds]
+      );
+      console.log(`[phase1] split ${agg.id} → ${newRow.id} (date=${date}, qty=${-group.qty}, lines=${group.lineIds.length})`);
+    }
+
+    // Delete the original aggregate DE.
+    await client.query(`DELETE FROM stock WHERE id = $1`, [agg.id]);
+  }
+
+  console.log(`[phase1] Split ${aggregates.length} aggregate DE(s).`);
+}
+
 async function run() {
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
     await preCondition(client);
+    await phase1Split(client);
 
-    // Phases 1-5 added in subsequent tasks.
+    // Phases 2-5 added in subsequent tasks.
 
     if (DRY_RUN) {
       console.log('[migrate] DRY RUN — rolling back transaction.');

--- a/backend/scripts/migrate-stock-y-model.js
+++ b/backend/scripts/migrate-stock-y-model.js
@@ -157,6 +157,12 @@ async function phase3PositiveUndated(client, today) {
   console.log(`[phase3] Dated ${rowCount} positive-qty undated row(s) → ${today}.`);
 }
 
+async function phase5SetNotNull(client) {
+  await client.query(`ALTER TABLE stock ALTER COLUMN date SET NOT NULL`);
+  await client.query(`ALTER TABLE stock ALTER COLUMN type_name SET NOT NULL`);
+  console.log('[phase5] Applied NOT NULL on stock.date and stock.type_name.');
+}
+
 async function phase4PremadeBackAdd(client) {
   const { rows: sums } = await client.query(`
     SELECT stock_id, SUM(quantity)::int AS reserved
@@ -199,8 +205,7 @@ async function run() {
     await phase2OrphanNegative(client, today);
     await phase3PositiveUndated(client, today);
     await phase4PremadeBackAdd(client);
-
-    // Phase 5 added in subsequent tasks.
+    await phase5SetNotNull(client);
 
     if (DRY_RUN) {
       console.log('[migrate] DRY RUN — rolling back transaction.');

--- a/backend/scripts/migrate-stock-y-model.js
+++ b/backend/scripts/migrate-stock-y-model.js
@@ -14,7 +14,9 @@
 //   4. Premade reservation back-add to matching Batch on-hand.
 //   5. ALTER COLUMN date / type_name SET NOT NULL.
 //
-// Idempotent: re-running after Phase 5 is a no-op.
+// Idempotent: re-running after Phase 5 (NOT NULL applied) is a no-op
+// via the early-exit guard `alreadyMigrated()`. Phases 1-3 also become
+// no-ops because their predicates require `date IS NULL`.
 //
 // Usage:
 //   APPROVE=yes node backend/scripts/migrate-stock-y-model.js --dry-run
@@ -50,7 +52,11 @@ async function preCondition(client) {
 }
 
 async function phase1Split(client) {
-  // Find aggregate DEs: negative qty, no date, linked to at least one order_line.
+  // Find aggregate DEs: negative qty, no date, linked to at least one active order_line.
+  // Phase 1 sums only **active, non-deleted** order_lines (status NOT IN
+  //   Cancelled/Delivered/Picked Up). If an aggregate's only linked lines
+  //   are terminated, it routes to Phase 2 (orphan path) instead and is
+  //   today-dated for operator review.
   const { rows: aggregates } = await client.query(`
     SELECT s.id, s.display_name, s.type_name, s.colour, s.size_cm, s.cultivar,
            s.current_quantity, s.current_cost_price, s.current_sell_price,
@@ -59,17 +65,29 @@ async function phase1Split(client) {
     WHERE s.current_quantity < 0
       AND s.date IS NULL
       AND s.deleted_at IS NULL
-      AND EXISTS (SELECT 1 FROM order_lines ol WHERE ol.stock_item_id = s.id::text)
+      AND EXISTS (
+        SELECT 1 FROM order_lines ol
+        JOIN orders o ON o.id = ol.order_id
+        WHERE ol.stock_item_id = s.id::text
+          AND o.status NOT IN ('Cancelled', 'Delivered', 'Picked Up')
+          AND o.deleted_at IS NULL
+          AND ol.deleted_at IS NULL
+      )
   `);
 
   for (const agg of aggregates) {
     // Group linked order_lines by Required By fallback chain.
+    // Only active, non-deleted orders/lines — terminated lines persist in
+    // production after cancel-with-return/delivery/pickup and must not be counted.
     const { rows: lines } = await client.query(`
       SELECT ol.id AS line_id, ol.quantity,
              COALESCE(o.required_by::text, o.order_date::text, CURRENT_DATE::text) AS due_date
       FROM order_lines ol
       JOIN orders o ON o.id = ol.order_id
       WHERE ol.stock_item_id = $1::text
+        AND o.status NOT IN ('Cancelled', 'Delivered', 'Picked Up')
+        AND o.deleted_at IS NULL
+        AND ol.deleted_at IS NULL
     `, [agg.id]);
 
     // Group by due_date, summing quantities.
@@ -116,7 +134,14 @@ async function phase2OrphanNegative(client, today) {
     WHERE s.current_quantity < 0
       AND s.date IS NULL
       AND s.deleted_at IS NULL
-      AND NOT EXISTS (SELECT 1 FROM order_lines ol WHERE ol.stock_item_id = s.id::text)
+      AND NOT EXISTS (
+        SELECT 1 FROM order_lines ol
+        JOIN orders o ON o.id = ol.order_id
+        WHERE ol.stock_item_id = s.id::text
+          AND o.status NOT IN ('Cancelled', 'Delivered', 'Picked Up')
+          AND o.deleted_at IS NULL
+          AND ol.deleted_at IS NULL
+      )
   `);
   for (const o of orphans) {
     await client.query(`UPDATE stock SET date = $1, updated_at = NOW() WHERE id = $2`, [today, o.id]);
@@ -150,11 +175,26 @@ async function phase4PremadeBackAdd(client) {
   console.log(`[phase4] Back-added premade reservations to ${sums.length} Batch(es).`);
 }
 
+async function alreadyMigrated(client) {
+  const { rows } = await client.query(`
+    SELECT is_nullable FROM information_schema.columns
+    WHERE table_name = 'stock' AND column_name = 'date'
+  `);
+  return rows[0]?.is_nullable === 'NO';
+}
+
 async function run() {
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
     await preCondition(client);
+
+    if (await alreadyMigrated(client)) {
+      console.log('[migrate] Stock.date already NOT NULL — migration already complete. No-op.');
+      await client.query('ROLLBACK');
+      return;
+    }
+
     await phase1Split(client);
     await phase2OrphanNegative(client, today);
     await phase3PositiveUndated(client, today);

--- a/backend/scripts/migrate-stock-y-model.js
+++ b/backend/scripts/migrate-stock-y-model.js
@@ -124,6 +124,14 @@ async function phase2OrphanNegative(client, today) {
   console.log(`[phase2] Dated ${orphans.length} orphan aggregate DE(s) → ${today}.`);
 }
 
+async function phase3PositiveUndated(client, today) {
+  const { rowCount } = await client.query(`
+    UPDATE stock SET date = $1, updated_at = NOW()
+    WHERE current_quantity >= 0 AND date IS NULL AND deleted_at IS NULL
+  `, [today]);
+  console.log(`[phase3] Dated ${rowCount} positive-qty undated row(s) → ${today}.`);
+}
+
 async function run() {
   const client = await pool.connect();
   try {
@@ -131,8 +139,9 @@ async function run() {
     await preCondition(client);
     await phase1Split(client);
     await phase2OrphanNegative(client, today);
+    await phase3PositiveUndated(client, today);
 
-    // Phases 3-5 added in subsequent tasks.
+    // Phases 4-5 added in subsequent tasks.
 
     if (DRY_RUN) {
       console.log('[migrate] DRY RUN — rolling back transaction.');

--- a/backend/scripts/migrate-stock-y-model.js
+++ b/backend/scripts/migrate-stock-y-model.js
@@ -1,0 +1,77 @@
+// backend/scripts/migrate-stock-y-model.js
+// Category: DESTRUCTIVE
+//
+// Migrates production Stock data from legacy aggregate Demand Entry model
+// to Y-model (dated Demand Entries + premade back-add).
+//
+// Pre-condition: All stock rows must have `type_name` set (run Owner
+// backfill UI from issue #292 first).
+//
+// Phases (single transaction):
+//   1. Split aggregate Demand Entries by linked order Required By.
+//   2. Orphan negative aggregates → today-dated Demand Entry.
+//   3. Positive-qty undated rows → synthetic Batch dated migration day.
+//   4. Premade reservation back-add to matching Batch on-hand.
+//   5. ALTER COLUMN date / type_name SET NOT NULL.
+//
+// Idempotent: re-running after Phase 5 is a no-op.
+//
+// Usage:
+//   APPROVE=yes node backend/scripts/migrate-stock-y-model.js --dry-run
+//   APPROVE=yes node backend/scripts/migrate-stock-y-model.js
+
+import 'dotenv/config';
+import pg from 'pg';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+if (process.env.APPROVE !== 'yes') {
+  console.error('Set APPROVE=yes to confirm you want to run the Y-model migration.');
+  process.exit(1);
+}
+if (!process.env.DATABASE_URL) {
+  console.error('DATABASE_URL not set. Aborting.');
+  process.exit(1);
+}
+
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+const today = new Date().toISOString().slice(0, 10);
+
+async function preCondition(client) {
+  const { rows } = await client.query(
+    `SELECT count(*)::int AS missing FROM stock WHERE type_name IS NULL AND deleted_at IS NULL`
+  );
+  if (rows[0].missing > 0) {
+    throw new Error(
+      `Pre-condition failed: ${rows[0].missing} stock row(s) have type_name IS NULL. ` +
+      `Run the Owner-driven Variety attribute backfill (issue #292) first.`
+    );
+  }
+}
+
+async function run() {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await preCondition(client);
+
+    // Phases 1-5 added in subsequent tasks.
+
+    if (DRY_RUN) {
+      console.log('[migrate] DRY RUN — rolling back transaction.');
+      await client.query('ROLLBACK');
+    } else {
+      await client.query('COMMIT');
+      console.log('[migrate] Done.');
+    }
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('[migrate] FAILED:', err.message);
+    process.exitCode = 1;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+run();

--- a/backend/scripts/migrate-stock-y-model.js
+++ b/backend/scripts/migrate-stock-y-model.js
@@ -110,14 +110,29 @@ async function phase1Split(client) {
   console.log(`[phase1] Split ${aggregates.length} aggregate DE(s).`);
 }
 
+async function phase2OrphanNegative(client, today) {
+  const { rows: orphans } = await client.query(`
+    SELECT s.id FROM stock s
+    WHERE s.current_quantity < 0
+      AND s.date IS NULL
+      AND s.deleted_at IS NULL
+      AND NOT EXISTS (SELECT 1 FROM order_lines ol WHERE ol.stock_item_id = s.id::text)
+  `);
+  for (const o of orphans) {
+    await client.query(`UPDATE stock SET date = $1, updated_at = NOW() WHERE id = $2`, [today, o.id]);
+  }
+  console.log(`[phase2] Dated ${orphans.length} orphan aggregate DE(s) → ${today}.`);
+}
+
 async function run() {
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
     await preCondition(client);
     await phase1Split(client);
+    await phase2OrphanNegative(client, today);
 
-    // Phases 2-5 added in subsequent tasks.
+    // Phases 3-5 added in subsequent tasks.
 
     if (DRY_RUN) {
       console.log('[migrate] DRY RUN — rolling back transaction.');

--- a/docs/superpowers/plans/2026-05-11-stock-y-migration.md
+++ b/docs/superpowers/plans/2026-05-11-stock-y-migration.md
@@ -1,0 +1,971 @@
+# Stock Y-model migration script Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the idempotent `backend/scripts/migrate-stock-y-model.js` script with `--dry-run` mode that converts production Stock data from the legacy aggregate Demand Entry model to the Y-model (dated Demand Entries + premade back-add), gated behind owner-driven Variety attribute backfill (#292).
+
+**Architecture:** One destructive script in `backend/scripts/`, five phases applied inside a single Postgres transaction. Lab regression: dedicated scenario `stockYMigration` (a minimal extension of `stockOverhaul` with prod-shaped fixtures) + API tests in `lab/tests/api/migrate-stock-y-model.test.js` that boot a real lab Postgres template, run the script, and assert post-state per phase.
+
+**Tech Stack:** Node ES modules, Drizzle ORM, pg, vitest (lab integration), Docker lab Postgres.
+
+---
+
+## Scope notes
+
+Per #290:
+- **Pre-condition:** abort if any `stock.type_name IS NULL`. Owner runs #292 backfill UI first.
+- **NOT in scope:** Variety attribute backfill (moved to #292 UI), prod cutover (that's #291), `STOCK_Y_MODEL=true` flag flip (#291).
+- **Five phases** in order: (1) aggregate DE → dated DEs split by Required By, (2) orphan negative aggregate → today-dated DE, (3) positive-qty undated row → synthetic Batch dated migration day, (4) premade reservation back-add to matching Batch, (5) `ALTER TABLE ... SET NOT NULL` on `date` and `type_name`.
+- **Idempotency:** re-running after a clean Phase 5 = no-op (all candidate queries return zero rows).
+
+## Identifying legacy rows (post-#284, pre-cutover)
+
+`stock` schema after #284:
+- `date` nullable, `type_name` nullable, `colour`/`size_cm`/`cultivar` nullable forever.
+
+| Phase | SQL predicate |
+|---|---|
+| Phase 1 | `current_quantity < 0 AND date IS NULL AND EXISTS (...stock_item_id = stock.id)` |
+| Phase 2 | `current_quantity < 0 AND date IS NULL AND NOT EXISTS (...stock_item_id = stock.id)` |
+| Phase 3 | `current_quantity >= 0 AND date IS NULL` |
+| Phase 4 | SUM `premade_bouquet_lines.quantity` per `stock_id` → ADD to that Stock row's `current_quantity` |
+| Phase 5 | `ALTER TABLE stock ALTER COLUMN date SET NOT NULL; ALTER TABLE stock ALTER COLUMN type_name SET NOT NULL;` |
+
+Note: `order_lines.stock_item_id` is TEXT (legacy Airtable rec ID or stringified UUID). Repointing = string replace.
+
+## Required By fallback chain (Phase 1)
+
+For each order_line linked to an aggregate DE, derive its target dated DE date as: `order.required_by ?? order.order_date ?? CURRENT_DATE`.
+
+## File Structure
+
+- **Create:** `backend/scripts/migrate-stock-y-model.js` — the script (DESTRUCTIVE header, `APPROVE=yes` gate, `--dry-run` flag).
+- **Create:** `lab/scenarios/stockYMigration.js` — extends `stockOverhaul` with the four prod-shaped fixtures. Every row has `type_name` set (simulates post-#292 state).
+- **Modify:** `lab/scenarios/index.js` — register new scenario as `stock-y-migration`.
+- **Create:** `lab/tests/api/migrate-stock-y-model.test.js` — integration tests per phase.
+- **Modify:** `CHANGELOG.md` — entry above #300.
+
+---
+
+## Task 1: Script scaffold + dry-run + pre-condition + scenario
+
+**Files:**
+- Create: `backend/scripts/migrate-stock-y-model.js`
+- Create: `lab/scenarios/stockYMigration.js`
+- Modify: `lab/scenarios/index.js`
+- Create: `lab/tests/api/migrate-stock-y-model.test.js`
+
+**Skip TDD red phase rationale:** Script scaffold is mechanical — header, arg parsing, pre-condition guard. The pre-condition test (file 4) IS the red phase for this task.
+
+**Spec excerpt:**
+> Script header tags it `DESTRUCTIVE`. Pre-condition check: aborts with a clear message if any `stock.type_name IS NULL`. `--dry-run` produces a reviewable diff and does not write. Re-running the script after a successful run is a no-op.
+
+- [ ] **Step 1: Create `backend/scripts/migrate-stock-y-model.js` scaffold**
+
+```js
+// backend/scripts/migrate-stock-y-model.js
+// Category: DESTRUCTIVE
+//
+// Migrates production Stock data from legacy aggregate Demand Entry model
+// to Y-model (dated Demand Entries + premade back-add).
+//
+// Pre-condition: All stock rows must have `type_name` set (run Owner
+// backfill UI from issue #292 first).
+//
+// Phases (single transaction):
+//   1. Split aggregate Demand Entries by linked order Required By.
+//   2. Orphan negative aggregates → today-dated Demand Entry.
+//   3. Positive-qty undated rows → synthetic Batch dated migration day.
+//   4. Premade reservation back-add to matching Batch on-hand.
+//   5. ALTER COLUMN date / type_name SET NOT NULL.
+//
+// Idempotent: re-running after Phase 5 is a no-op.
+//
+// Usage:
+//   APPROVE=yes node backend/scripts/migrate-stock-y-model.js --dry-run
+//   APPROVE=yes node backend/scripts/migrate-stock-y-model.js
+
+import 'dotenv/config';
+import pg from 'pg';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+if (process.env.APPROVE !== 'yes') {
+  console.error('Set APPROVE=yes to confirm you want to run the Y-model migration.');
+  process.exit(1);
+}
+if (!process.env.DATABASE_URL) {
+  console.error('DATABASE_URL not set. Aborting.');
+  process.exit(1);
+}
+
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+const today = new Date().toISOString().slice(0, 10);
+
+async function preCondition(client) {
+  const { rows } = await client.query(
+    `SELECT count(*)::int AS missing FROM stock WHERE type_name IS NULL AND deleted_at IS NULL`
+  );
+  if (rows[0].missing > 0) {
+    throw new Error(
+      `Pre-condition failed: ${rows[0].missing} stock row(s) have type_name IS NULL. ` +
+      `Run the Owner-driven Variety attribute backfill (issue #292) first.`
+    );
+  }
+}
+
+async function run() {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await preCondition(client);
+
+    // Phases 1-5 added in subsequent tasks.
+
+    if (DRY_RUN) {
+      console.log('[migrate] DRY RUN — rolling back transaction.');
+      await client.query('ROLLBACK');
+    } else {
+      await client.query('COMMIT');
+      console.log('[migrate] Done.');
+    }
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('[migrate] FAILED:', err.message);
+    process.exitCode = 1;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+run();
+```
+
+- [ ] **Step 2: Create `lab/scenarios/stockYMigration.js`**
+
+```js
+// lab/scenarios/stockYMigration.js
+//
+// Fixture for the Stock Y-model migration script regression gate
+// (issue #290). Extends stockOverhaul with prod-shaped fixtures and
+// guarantees every stock row has `type_name` set (post-#292 state).
+
+import { faker } from '@faker-js/faker';
+import { buildStockOverhaul } from './stockOverhaul.js';
+
+export function buildStockYMigration() {
+  faker.seed(290);
+  const base = buildStockOverhaul();
+
+  // Simulate post-#292 backfill: every stock row gets a type_name if missing.
+  const stockItems = base.stockItems.map(s => ({
+    ...s,
+    type_name: s.type_name ?? (s.display_name.split(' ')[0] || 'Unknown'),
+  }));
+
+  return {
+    customers:  base.customers,
+    stockItems,
+    orders:     base.orders,
+    orderLines: base.orderLines,
+    deliveries: base.deliveries,
+  };
+}
+```
+
+- [ ] **Step 3: Register scenario**
+
+In `lab/scenarios/index.js`:
+
+```js
+import { buildStockYMigration } from './stockYMigration.js';
+// ...
+export const scenarios = {
+  baseline: buildBaseline,
+  'stock-overhaul': buildStockOverhaul,
+  stockBackfill: buildStockBackfill,
+  'premade-reservation': buildPremadeReservation,
+  'stock-y-migration': buildStockYMigration,
+};
+```
+
+- [ ] **Step 4: Write red test for pre-condition**
+
+Create `lab/tests/api/migrate-stock-y-model.test.js`:
+
+```js
+// lab/tests/api/migrate-stock-y-model.test.js
+//
+// Integration tests for backend/scripts/migrate-stock-y-model.js.
+// Boots lab Postgres template, runs the script via spawnSync, asserts
+// post-state. Each phase has its own describe block.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import path from 'path';
+import { resetLabDb } from '../../helpers/reset.js';
+import { labPool } from '../../helpers/db.js';
+
+const SCRIPT = path.resolve(process.cwd(), '../backend/scripts/migrate-stock-y-model.js');
+const LAB_DSN = 'postgres://lab:lab@localhost:5433/lab';
+
+function runScript(args = []) {
+  return spawnSync('node', [SCRIPT, ...args], {
+    env: { ...process.env, APPROVE: 'yes', DATABASE_URL: LAB_DSN, PGSSL_DISABLE: 'true' },
+    encoding: 'utf8',
+  });
+}
+
+describe('migrate-stock-y-model — pre-condition', () => {
+  beforeEach(async () => { await resetLabDb(); });
+
+  it('aborts when any stock row has type_name IS NULL', async () => {
+    const pool = labPool();
+    try {
+      await pool.query(
+        `INSERT INTO stock (display_name, current_quantity, type_name) VALUES ('test', 0, NULL)`
+      );
+      const res = runScript(['--dry-run']);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toMatch(/type_name IS NULL/);
+      expect(res.stderr).toMatch(/#292/);
+    } finally {
+      await pool.end();
+    }
+  }, 30_000);
+
+  it('passes pre-condition when all rows have type_name', async () => {
+    const res = runScript(['--dry-run']);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/DRY RUN/);
+  }, 30_000);
+});
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+npm run lab:db:up
+npm run lab:template:rebuild -- --scenario=stock-y-migration
+npm run lab:test:api -- migrate-stock-y-model
+```
+
+Expected: 2/2 passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/scripts/migrate-stock-y-model.js \
+        lab/scenarios/stockYMigration.js \
+        lab/scenarios/index.js \
+        lab/tests/api/migrate-stock-y-model.test.js
+git commit -m "feat(stock-y-migration): scaffold + dry-run + pre-condition (#290)"
+```
+
+---
+
+## Task 2: Phase 1 — split aggregate by Required By
+
+**Files:**
+- Modify: `backend/scripts/migrate-stock-y-model.js`
+- Modify: `lab/scenarios/stockYMigration.js`
+- Modify: `lab/tests/api/migrate-stock-y-model.test.js`
+
+**Red phase mandatory** (new migration logic, Known-Pitfall-adjacent stock-math area).
+
+**Spec excerpt:**
+> Phase 1: For each aggregate Demand Entry: group linked `order_line` rows by their order's Required By with the fallback chain (`Required By → Order Date → today`). Create one dated Demand Entry per distinct date with summed qty. Repoint the order_lines. Delete the original aggregate.
+
+- [ ] **Step 1: Extend `stockYMigration.js` with multi-order aggregate fixture**
+
+Add after the `.map(...)` block, before the return:
+
+```js
+import { makeStockItem, makeOrder, makeOrderLine } from '../factories/index.js';
+
+// Phase 1 fixture: 1 aggregate DE shared by 2 orders crossing 2 dates.
+const PHASE1_VARIETY = 'Peony';
+const PHASE1_COLOUR  = 'Pink';
+const PHASE1_SIZE    = 60;
+const PHASE1_DATE_A  = '2026-06-01';
+const PHASE1_DATE_B  = '2026-06-03';
+
+const aggDE = makeStockItem({
+  type:        'demand',     // qty < 0, no date
+  display_name: 'Peony Pink 60cm',
+  type_name:    PHASE1_VARIETY,
+  colour:       PHASE1_COLOUR,
+  size_cm:      PHASE1_SIZE,
+  current_quantity: -8,
+  date: null,
+});
+stockItems.push(aggDE);
+
+const cust = base.customers[0];
+const orderA = makeOrder({ customerId: cust.id, status: 'New', delivery_type: 'Pickup', required_by: PHASE1_DATE_A });
+const orderB = makeOrder({ customerId: cust.id, status: 'New', delivery_type: 'Pickup', required_by: PHASE1_DATE_B });
+const lineA = makeOrderLine({ orderId: orderA.id, stockItemId: aggDE.id, flower_name: aggDE.display_name, quantity: 5 });
+const lineB = makeOrderLine({ orderId: orderB.id, stockItemId: aggDE.id, flower_name: aggDE.display_name, quantity: 3 });
+```
+
+Return the augmented arrays:
+
+```js
+return {
+  customers:  base.customers,
+  stockItems,
+  orders:     [...base.orders, orderA, orderB],
+  orderLines: [...base.orderLines, lineA, lineB],
+  deliveries: base.deliveries,
+};
+```
+
+Export the fixture markers for tests:
+
+```js
+export const PHASE1_FIXTURE = {
+  aggDEId:    null,  // populated post-build via getter below
+  variety:    PHASE1_VARIETY,
+  colour:     PHASE1_COLOUR,
+  sizeCm:     PHASE1_SIZE,
+  dateA:      PHASE1_DATE_A,
+  dateB:      PHASE1_DATE_B,
+  qtyA:       5,
+  qtyB:       3,
+};
+```
+
+(Tests will discover the aggregate DE by querying on `display_name = 'Peony Pink 60cm' AND date IS NULL`.)
+
+- [ ] **Step 2: Write the failing Phase 1 test**
+
+Append to `migrate-stock-y-model.test.js`:
+
+```js
+describe('migrate-stock-y-model — Phase 1: aggregate split', () => {
+  beforeEach(async () => { await resetLabDb(); });
+
+  it('splits one aggregate DE into per-Required-By dated DEs', async () => {
+    const pool = labPool();
+    try {
+      // Pre: find the aggregate DE by display_name + date IS NULL.
+      const pre = await pool.query(
+        `SELECT id FROM stock WHERE display_name = 'Peony Pink 60cm' AND date IS NULL AND current_quantity = -8`
+      );
+      expect(pre.rows.length).toBe(1);
+      const aggId = pre.rows[0].id;
+
+      const res = runScript();
+      expect(res.status).toBe(0);
+
+      // Post: aggregate gone.
+      const gone = await pool.query(`SELECT id FROM stock WHERE id = $1`, [aggId]);
+      expect(gone.rows.length).toBe(0);
+
+      // Post: 2 dated DEs, one per date, with correct qty.
+      const dated = await pool.query(
+        `SELECT date::text, current_quantity, type_name, colour, size_cm
+         FROM stock WHERE type_name = 'Peony' AND colour = 'Pink' AND size_cm = 60
+                    AND current_quantity < 0 AND date IS NOT NULL
+         ORDER BY date ASC`
+      );
+      expect(dated.rows).toEqual([
+        { date: '2026-06-01', current_quantity: -5, type_name: 'Peony', colour: 'Pink', size_cm: 60 },
+        { date: '2026-06-03', current_quantity: -3, type_name: 'Peony', colour: 'Pink', size_cm: 60 },
+      ]);
+
+      // Post: order_lines repointed to the new dated DEs.
+      const lines = await pool.query(
+        `SELECT ol.stock_item_id, s.date::text
+         FROM order_lines ol JOIN stock s ON s.id::text = ol.stock_item_id
+         WHERE ol.flower_name = 'Peony Pink 60cm'
+         ORDER BY ol.quantity DESC`
+      );
+      expect(lines.rows.length).toBe(2);
+      expect(lines.rows[0].date).toBe('2026-06-01');
+      expect(lines.rows[1].date).toBe('2026-06-03');
+    } finally {
+      await pool.end();
+    }
+  }, 60_000);
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+npm run lab:test:api -- migrate-stock-y-model
+```
+
+Expected: Phase 1 test fails because script does no work yet.
+
+- [ ] **Step 4: Implement Phase 1 in the script**
+
+Insert before the `if (DRY_RUN)` block:
+
+```js
+async function phase1Split(client) {
+  // Find aggregate DEs with linked order_lines.
+  const { rows: aggregates } = await client.query(`
+    SELECT s.id, s.display_name, s.type_name, s.colour, s.size_cm, s.cultivar,
+           s.current_quantity, s.current_cost_price, s.current_sell_price,
+           s.supplier, s.unit, s.category, s.airtable_id
+    FROM stock s
+    WHERE s.current_quantity < 0
+      AND s.date IS NULL
+      AND s.deleted_at IS NULL
+      AND EXISTS (SELECT 1 FROM order_lines ol WHERE ol.stock_item_id = s.id::text)
+  `);
+
+  for (const agg of aggregates) {
+    // Group linked order_lines by Required By fallback chain.
+    const { rows: lines } = await client.query(`
+      SELECT ol.id AS line_id, ol.quantity,
+             COALESCE(o.required_by::text, o.order_date::text, CURRENT_DATE::text) AS due_date
+      FROM order_lines ol
+      JOIN orders o ON o.id = ol.order_id
+      WHERE ol.stock_item_id = $1::text
+    `, [agg.id]);
+
+    const byDate = new Map();
+    for (const l of lines) {
+      const cur = byDate.get(l.due_date) ?? { qty: 0, lineIds: [] };
+      cur.qty += l.quantity;
+      cur.lineIds.push(l.line_id);
+      byDate.set(l.due_date, cur);
+    }
+
+    for (const [date, group] of byDate.entries()) {
+      const { rows: [newRow] } = await client.query(`
+        INSERT INTO stock (
+          display_name, purchase_name, category, current_quantity, unit,
+          current_cost_price, current_sell_price, supplier,
+          type_name, colour, size_cm, cultivar, date, active
+        ) VALUES ($1, NULL, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, true)
+        RETURNING id
+      `, [
+        agg.display_name, agg.category, -group.qty, agg.unit,
+        agg.current_cost_price, agg.current_sell_price, agg.supplier,
+        agg.type_name, agg.colour, agg.size_cm, agg.cultivar, date,
+      ]);
+      // Repoint order_lines.
+      await client.query(
+        `UPDATE order_lines SET stock_item_id = $1 WHERE id = ANY($2::uuid[])`,
+        [newRow.id, group.lineIds]
+      );
+      console.log(`[phase1] split ${agg.id} → ${newRow.id} (date=${date}, qty=${-group.qty}, lines=${group.lineIds.length})`);
+    }
+    // Delete the original aggregate.
+    await client.query(`DELETE FROM stock WHERE id = $1`, [agg.id]);
+  }
+  console.log(`[phase1] Split ${aggregates.length} aggregate DE(s).`);
+}
+```
+
+Wire it in:
+
+```js
+await preCondition(client);
+await phase1Split(client);
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+npm run lab:test:api -- migrate-stock-y-model
+```
+
+Expected: 3/3 passing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/scripts/migrate-stock-y-model.js \
+        lab/scenarios/stockYMigration.js \
+        lab/tests/api/migrate-stock-y-model.test.js
+git commit -m "feat(stock-y-migration): Phase 1 split aggregate by Required By (#290)"
+```
+
+---
+
+## Task 3: Phase 2 — orphan negative aggregate → today-dated DE
+
+**Files:**
+- Modify: `backend/scripts/migrate-stock-y-model.js`
+- Modify: `lab/scenarios/stockYMigration.js`
+- Modify: `lab/tests/api/migrate-stock-y-model.test.js`
+
+**Red phase mandatory** (mutation logic).
+
+**Spec excerpt:**
+> Phase 2: Aggregate Demand Entries with negative qty and no linked orders → convert to a today-dated Demand Entry (Variety = same as original; date = migration day) for owner review.
+
+- [ ] **Step 1: Extend scenario with orphan fixture**
+
+```js
+const orphanDE = makeStockItem({
+  type: 'demand',
+  display_name: 'Tulip Yellow 40cm',
+  type_name:    'Tulip',
+  colour:       'Yellow',
+  size_cm:      40,
+  current_quantity: -4,
+  date: null,
+});
+stockItems.push(orphanDE);
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```js
+describe('migrate-stock-y-model — Phase 2: orphan negative → today', () => {
+  beforeEach(async () => { await resetLabDb(); });
+
+  it('converts orphan aggregate DE to today-dated DE with preserved variety', async () => {
+    const pool = labPool();
+    const today = new Date().toISOString().slice(0, 10);
+    try {
+      const pre = await pool.query(
+        `SELECT id FROM stock WHERE display_name = 'Tulip Yellow 40cm' AND date IS NULL`
+      );
+      expect(pre.rows.length).toBe(1);
+
+      const res = runScript();
+      expect(res.status).toBe(0);
+
+      const post = await pool.query(
+        `SELECT date::text, current_quantity, type_name, colour, size_cm
+         FROM stock WHERE type_name = 'Tulip' AND colour = 'Yellow' AND size_cm = 40
+                    AND current_quantity < 0`
+      );
+      expect(post.rows.length).toBe(1);
+      expect(post.rows[0]).toMatchObject({
+        date: today, current_quantity: -4, type_name: 'Tulip', colour: 'Yellow', size_cm: 40,
+      });
+
+      // Original aggregate gone.
+      const gone = await pool.query(`SELECT id FROM stock WHERE display_name = 'Tulip Yellow 40cm' AND date IS NULL`);
+      expect(gone.rows.length).toBe(0);
+    } finally {
+      await pool.end();
+    }
+  }, 60_000);
+});
+```
+
+- [ ] **Step 3: Run test — confirm fails**
+
+```bash
+npm run lab:test:api -- migrate-stock-y-model
+```
+
+- [ ] **Step 4: Implement Phase 2**
+
+```js
+async function phase2OrphanNegative(client, today) {
+  const { rows: orphans } = await client.query(`
+    SELECT s.id FROM stock s
+    WHERE s.current_quantity < 0
+      AND s.date IS NULL
+      AND s.deleted_at IS NULL
+      AND NOT EXISTS (SELECT 1 FROM order_lines ol WHERE ol.stock_item_id = s.id::text)
+  `);
+  for (const o of orphans) {
+    await client.query(`UPDATE stock SET date = $1, updated_at = NOW() WHERE id = $2`, [today, o.id]);
+  }
+  console.log(`[phase2] Dated ${orphans.length} orphan aggregate DE(s) → ${today}.`);
+}
+```
+
+Wire in:
+
+```js
+await phase1Split(client);
+await phase2OrphanNegative(client, today);
+```
+
+- [ ] **Step 5: Run — confirm pass**
+
+```bash
+npm run lab:test:api -- migrate-stock-y-model
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/scripts/migrate-stock-y-model.js \
+        lab/scenarios/stockYMigration.js \
+        lab/tests/api/migrate-stock-y-model.test.js
+git commit -m "feat(stock-y-migration): Phase 2 orphan negative → today-dated (#290)"
+```
+
+---
+
+## Task 4: Phase 3 — positive-qty undated → synthetic Batch dated migration day
+
+**Files:**
+- Modify: `backend/scripts/migrate-stock-y-model.js`
+- Modify: `lab/scenarios/stockYMigration.js`
+- Modify: `lab/tests/api/migrate-stock-y-model.test.js`
+
+**Red phase mandatory.**
+
+**Spec excerpt:**
+> Phase 3: Aggregate Demand Entries with positive qty (manual edits) → convert to a synthetic Batch dated migration day (Variety = same as original) with the same qty.
+
+Treatment also covers legacy Batches that never had `date` set — they become dated-today Batches preserving qty. The transformation is identical regardless of origin.
+
+- [ ] **Step 1: Extend scenario with positive-undated fixture**
+
+```js
+const manualEdit = makeStockItem({
+  type: 'batch',
+  display_name: 'Rose Red 50cm',
+  type_name:    'Rose',
+  colour:       'Red',
+  size_cm:      50,
+  current_quantity: 12,
+  date: null,
+});
+stockItems.push(manualEdit);
+```
+
+(But note: existing stockOverhaul-base rows already have `current_quantity >= 0 AND date IS NULL` because the factory default leaves `date = null` for `type: 'batch'`. The dedicated fixture row pins a known display_name + qty for assertions.)
+
+- [ ] **Step 2: Write the failing test**
+
+```js
+describe('migrate-stock-y-model — Phase 3: positive undated → synthetic Batch', () => {
+  beforeEach(async () => { await resetLabDb(); });
+
+  it('dates the manually-edited positive row to migration day', async () => {
+    const pool = labPool();
+    const today = new Date().toISOString().slice(0, 10);
+    try {
+      const pre = await pool.query(
+        `SELECT id, current_quantity FROM stock WHERE display_name = 'Rose Red 50cm' AND date IS NULL`
+      );
+      expect(pre.rows.length).toBe(1);
+      const preQty = pre.rows[0].current_quantity;
+
+      const res = runScript();
+      expect(res.status).toBe(0);
+
+      const post = await pool.query(
+        `SELECT date::text, current_quantity FROM stock WHERE id = $1`, [pre.rows[0].id]
+      );
+      expect(post.rows[0]).toEqual({ date: today, current_quantity: preQty });
+
+      // No positive-qty undated rows remain anywhere.
+      const remaining = await pool.query(
+        `SELECT count(*)::int AS n FROM stock WHERE current_quantity >= 0 AND date IS NULL AND deleted_at IS NULL`
+      );
+      expect(remaining.rows[0].n).toBe(0);
+    } finally {
+      await pool.end();
+    }
+  }, 60_000);
+});
+```
+
+- [ ] **Step 3: Confirm test fails**
+
+- [ ] **Step 4: Implement Phase 3**
+
+```js
+async function phase3PositiveUndated(client, today) {
+  const { rowCount } = await client.query(`
+    UPDATE stock SET date = $1, updated_at = NOW()
+    WHERE current_quantity >= 0 AND date IS NULL AND deleted_at IS NULL
+  `, [today]);
+  console.log(`[phase3] Dated ${rowCount} positive-qty undated row(s) → ${today}.`);
+}
+```
+
+Wire in after Phase 2.
+
+- [ ] **Step 5: Confirm test passes**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/scripts/migrate-stock-y-model.js \
+        lab/scenarios/stockYMigration.js \
+        lab/tests/api/migrate-stock-y-model.test.js
+git commit -m "feat(stock-y-migration): Phase 3 positive-undated → dated Batch (#290)"
+```
+
+---
+
+## Task 5: Phase 4 — premade reservation back-add
+
+**Files:**
+- Modify: `backend/scripts/migrate-stock-y-model.js`
+- Modify: `lab/scenarios/stockYMigration.js`
+- Modify: `lab/tests/api/migrate-stock-y-model.test.js`
+
+**Red phase mandatory** (Pitfall #8 area — stock-math adjacent).
+
+**Spec excerpt:**
+> Phase 4: Premade-deduction back-add: SUM `premade_bouquet_lines.quantity` per `stockId` and ADD to the corresponding Batch (or fresh Batch dated migration day if none).
+
+**Pitfall #8 reasoning:** In the legacy model, premade reservations were silently subtracted from `current_quantity`. Y-model treats reservations as a separate informational bucket (see `getVarietyTotals`). The migration must add the reservation back so that `current_quantity` once again means "on-hand stems", not "on-hand minus premade".
+
+- [ ] **Step 1: Extend scenario with premade fixture**
+
+```js
+import { v4 as uuid } from 'uuid';
+
+const targetBatch = makeStockItem({
+  type: 'batch',
+  display_name: 'Hydrangea Blue 30cm (10.May.)',
+  type_name:    'Hydrangea',
+  colour:       'Blue',
+  size_cm:      30,
+  current_quantity: 20,
+  date: '2026-05-10',
+});
+stockItems.push(targetBatch);
+
+// Premade bouquet + 1 line consuming 7 stems from the Batch above.
+const premadeBouquet = {
+  id: uuid(),
+  airtable_id: null,
+  name: 'Migration test bouquet',
+  sell_price: '99.00',
+  active: true,
+  created_at: new Date(),
+  updated_at: new Date(),
+  deleted_at: null,
+};
+const premadeLine = {
+  id: uuid(),
+  airtable_id: null,
+  bouquet_id:  premadeBouquet.id,
+  stock_id:    targetBatch.id,
+  stock_airtable_id: null,
+  flower_name: targetBatch.display_name,
+  quantity:    7,
+  cost_price_per_unit: '0',
+  sell_price_per_unit: '0',
+  created_at: new Date(),
+};
+```
+
+Return them from the scenario:
+
+```js
+return {
+  ...,
+  premadeBouquets:     [premadeBouquet],
+  premadeBouquetLines: [premadeLine],
+};
+```
+
+The `lab/helpers/seed.js` must seed those arrays. If it doesn't already, expand it during this task (check `lab/helpers/seed.js` first — fail-fast if structure unsupported).
+
+- [ ] **Step 2: Write the failing test**
+
+```js
+describe('migrate-stock-y-model — Phase 4: premade back-add', () => {
+  beforeEach(async () => { await resetLabDb(); });
+
+  it('adds SUM(premade_bouquet_lines.quantity) to the matching Batch on-hand', async () => {
+    const pool = labPool();
+    try {
+      const pre = await pool.query(
+        `SELECT id, current_quantity FROM stock WHERE display_name = 'Hydrangea Blue 30cm (10.May.)'`
+      );
+      expect(pre.rows.length).toBe(1);
+      const batchId = pre.rows[0].id;
+      const preQty  = pre.rows[0].current_quantity;
+
+      const res = runScript();
+      expect(res.status).toBe(0);
+
+      const post = await pool.query(`SELECT current_quantity FROM stock WHERE id = $1`, [batchId]);
+      expect(post.rows[0].current_quantity).toBe(preQty + 7);
+    } finally {
+      await pool.end();
+    }
+  }, 60_000);
+});
+```
+
+- [ ] **Step 3: Confirm test fails**
+
+- [ ] **Step 4: Implement Phase 4**
+
+```js
+async function phase4PremadeBackAdd(client) {
+  const { rows: sums } = await client.query(`
+    SELECT stock_id, SUM(quantity)::int AS reserved
+    FROM premade_bouquet_lines
+    WHERE stock_id IS NOT NULL
+    GROUP BY stock_id
+  `);
+  for (const { stock_id, reserved } of sums) {
+    if (reserved > 0) {
+      await client.query(
+        `UPDATE stock SET current_quantity = current_quantity + $1, updated_at = NOW() WHERE id = $2`,
+        [reserved, stock_id]
+      );
+    }
+  }
+  console.log(`[phase4] Back-added premade reservations to ${sums.length} Batch(es).`);
+}
+```
+
+Wire in after Phase 3.
+
+- [ ] **Step 5: Confirm test passes**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/scripts/migrate-stock-y-model.js \
+        lab/scenarios/stockYMigration.js \
+        lab/tests/api/migrate-stock-y-model.test.js \
+        lab/helpers/seed.js
+git commit -m "feat(stock-y-migration): Phase 4 premade reservation back-add (#290)"
+```
+
+---
+
+## Task 6: Phase 5 NOT NULL + idempotency
+
+**Files:**
+- Modify: `backend/scripts/migrate-stock-y-model.js`
+- Modify: `lab/tests/api/migrate-stock-y-model.test.js`
+
+**Skip TDD red phase rationale:** Phase 5 is a single `ALTER TABLE`; the test for it is the idempotency assertion.
+
+**Spec excerpt:**
+> Phase 5: Apply `NOT NULL` on `stock_items.date` and on `stock_items.type_name` once all rows have values. Idempotent: re-running is a no-op once Phase 5 has applied.
+
+- [ ] **Step 1: Implement Phase 5**
+
+```js
+async function phase5SetNotNull(client) {
+  await client.query(`ALTER TABLE stock ALTER COLUMN date SET NOT NULL`);
+  await client.query(`ALTER TABLE stock ALTER COLUMN type_name SET NOT NULL`);
+  console.log('[phase5] Applied NOT NULL on stock.date and stock.type_name.');
+}
+```
+
+Wire in after Phase 4. Skip when `DRY_RUN` (otherwise the rollback can leak structural changes — Postgres rolls back DDL inside a tx, but be explicit).
+
+- [ ] **Step 2: Write idempotency test**
+
+```js
+describe('migrate-stock-y-model — Phase 5 + idempotency', () => {
+  beforeEach(async () => { await resetLabDb(); });
+
+  it('is a no-op when re-run after a clean migration', async () => {
+    const first = runScript();
+    expect(first.status).toBe(0);
+
+    const second = runScript();
+    expect(second.status).toBe(0);
+    // Second run should report zero work in each phase.
+    expect(second.stdout).toMatch(/\[phase1\] Split 0 aggregate/);
+    expect(second.stdout).toMatch(/\[phase2\] Dated 0 orphan/);
+    expect(second.stdout).toMatch(/\[phase3\] Dated 0 positive/);
+  }, 90_000);
+
+  it('applies NOT NULL on stock.date and stock.type_name', async () => {
+    const res = runScript();
+    expect(res.status).toBe(0);
+    const pool = labPool();
+    try {
+      const { rows } = await pool.query(`
+        SELECT column_name, is_nullable
+        FROM information_schema.columns
+        WHERE table_name = 'stock' AND column_name IN ('date', 'type_name')
+        ORDER BY column_name
+      `);
+      expect(rows).toEqual([
+        { column_name: 'date',      is_nullable: 'NO' },
+        { column_name: 'type_name', is_nullable: 'NO' },
+      ]);
+    } finally {
+      await pool.end();
+    }
+  }, 60_000);
+});
+```
+
+- [ ] **Step 3: Run full test file — all green**
+
+```bash
+npm run lab:test:api -- migrate-stock-y-model
+```
+
+Expected: 9/9 passing across all describes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/scripts/migrate-stock-y-model.js \
+        lab/tests/api/migrate-stock-y-model.test.js
+git commit -m "feat(stock-y-migration): Phase 5 NOT NULL + idempotency (#290)"
+```
+
+---
+
+## Task 7: CHANGELOG + verification matrix
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+**Skip TDD red phase rationale:** Docs-only.
+
+- [ ] **Step 1: Prepend CHANGELOG entry**
+
+Above the most recent entry:
+
+```markdown
+## 2026-05-11 — Stock Y-model migration script (#290)
+
+- **NEW:** `backend/scripts/migrate-stock-y-model.js` (DESTRUCTIVE). One-shot script to convert legacy aggregate Demand Entry rows to dated Demand Entries + premade reservation back-add. `--dry-run` mode prints the plan without writing.
+- **Pre-condition:** aborts if any `stock.type_name IS NULL` — Owner runs #292 backfill UI first.
+- **Five phases (single transaction):**
+  - Phase 1: split aggregate DE into per-Required-By dated DEs (`Required By → Order Date → today` fallback).
+  - Phase 2: orphan negative aggregate → today-dated DE (preserves Variety).
+  - Phase 3: positive-qty undated row → Batch dated migration day.
+  - Phase 4: SUM `premade_bouquet_lines.quantity` per stock_id → ADD to that Batch's `current_quantity`.
+  - Phase 5: `ALTER COLUMN date/type_name SET NOT NULL`.
+- **Idempotent:** re-running after Phase 5 = no-op.
+- **Lab regression gate:** `lab/scenarios/stockYMigration.js` extends `stockOverhaul` with prod-shaped fixtures (multi-order aggregate, orphan, positive-qty edit, premade with active lines). `lab/tests/api/migrate-stock-y-model.test.js` asserts post-state per phase + idempotency. `npm run lab:test:api -- migrate-stock-y-model` is green.
+- **NOT in scope:** prod cutover (#291), `STOCK_Y_MODEL=true` flag flip (#291), Variety attribute backfill UI (#292).
+```
+
+- [ ] **Step 2: Run full Pre-PR matrix**
+
+```bash
+cd backend && npx vitest run
+cd .. && npm run lab:db:up
+npm run lab:template:rebuild -- --scenario=stock-y-migration
+npm run lab:test:unit
+npm run lab:test:api
+```
+
+Quote green output in PR body.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(stock-y-migration): CHANGELOG entry (#290)"
+```
+
+---
+
+## Self-review notes
+
+- **Type consistency:** `current_quantity` is integer, `quantity` (in premade_bouquet_lines) is integer, SUM returns numeric in PG — cast to `::int` in Phase 4 query (done).
+- **Spec coverage:** all 8 acceptance criteria mapped — header (T1), pre-condition (T1), dry-run (T1), idempotent (T6), Phases 1-5 (T2-T6), scenario extension (T2-T5), lab:test:api green (T7).
+- **Deep modules:** the script's five phases share `client` + `today` only. Deleting any one phase would scatter complexity (each is a distinct prod row shape). Keep.
+- **Vertical slices:** every task produces a working sub-migration — Phase N's tests pass after Phase N is implemented, regardless of Phase N+1.
+- **No placeholders:** every step has concrete code, exact commands, expected output.

--- a/lab/helpers/seed.js
+++ b/lab/helpers/seed.js
@@ -1,8 +1,13 @@
 // lab/helpers/seed.js
 //
 // Insert a fixture (returned by a scenario builder) into Postgres.
-// Inserts in FK order: customers → stock → orders → order_lines → deliveries.
+// Inserts in FK order:
+//   customers → stock → premade_bouquets → orders → order_lines
+//   → premade_bouquet_lines → deliveries
 // Uses a single transaction so partial seeds don't leave the DB inconsistent.
+//
+// premadeBouquets and premadeBouquetLines are optional keys — older scenarios
+// without them seed fine (defaults to empty arrays).
 
 export async function seedFixture(pool, fixture) {
   const client = await pool.connect();
@@ -10,8 +15,10 @@ export async function seedFixture(pool, fixture) {
     await client.query('BEGIN');
     await insertMany(client, 'customers', fixture.customers ?? []);
     await insertMany(client, 'stock', fixture.stockItems ?? []);
+    await insertMany(client, 'premade_bouquets', fixture.premadeBouquets ?? []);
     await insertMany(client, 'orders', fixture.orders ?? []);
     await insertMany(client, 'order_lines', fixture.orderLines ?? []);
+    await insertMany(client, 'premade_bouquet_lines', fixture.premadeBouquetLines ?? []);
     await insertMany(client, 'deliveries', fixture.deliveries ?? []);
     await client.query('COMMIT');
   } catch (err) {

--- a/lab/scenarios/index.js
+++ b/lab/scenarios/index.js
@@ -2,10 +2,12 @@ import { buildBaseline } from './baseline.js';
 import { buildStockOverhaul } from './stockOverhaul.js';
 import { buildStockBackfill } from './stockBackfill.js';
 import { buildPremadeReservation } from './premadeReservation.js';
+import { buildStockYMigration } from './stockYMigration.js';
 
 export const scenarios = {
   baseline: buildBaseline,
   'stock-overhaul': buildStockOverhaul,
   stockBackfill: buildStockBackfill,
   'premade-reservation': buildPremadeReservation,
+  'stock-y-migration': buildStockYMigration,
 };

--- a/lab/scenarios/stockYMigration.js
+++ b/lab/scenarios/stockYMigration.js
@@ -81,6 +81,21 @@ export function buildStockYMigration() {
   });
   stockItems.push(aggDE);
 
+  // ── Phase 2 fixture: orphan negative DE with no linked order_lines ──
+  // Simulates a "Tulip Yellow 40cm" aggregate DE with qty=-4, no date,
+  // and no order_lines. The script must date it to today (migration day)
+  // while preserving variety attributes and qty.
+  const orphanDE = makeStockItem({
+    type:             'demand',
+    display_name:     'Tulip Yellow 40cm',
+    type_name:        'Tulip',
+    colour:           'Yellow',
+    size_cm:          40,
+    current_quantity: -4,
+    date:             null,
+  });
+  stockItems.push(orphanDE);
+
   const cust = base.customers[0];
   const orderA = makeOrder({ customerId: cust.id, status: 'New', delivery_type: 'Pickup', required_by: PHASE1_DATE_A });
   const orderB = makeOrder({ customerId: cust.id, status: 'New', delivery_type: 'Pickup', required_by: PHASE1_DATE_B });

--- a/lab/scenarios/stockYMigration.js
+++ b/lab/scenarios/stockYMigration.js
@@ -96,6 +96,20 @@ export function buildStockYMigration() {
   });
   stockItems.push(orphanDE);
 
+  // ── Phase 3 fixture: positive-qty undated row → synthetic Batch dated migration day ──
+  // Simulates a "Rose Red 50cm" batch row with qty=12 and no date.
+  // The script must set date = today (migration day) while preserving qty and Variety.
+  const positiveUndated = makeStockItem({
+    type:             'batch',
+    display_name:     'Rose Red 50cm',
+    type_name:        'Rose',
+    colour:           'Red',
+    size_cm:          50,
+    current_quantity: 12,
+    date:             null,
+  });
+  stockItems.push(positiveUndated);
+
   const cust = base.customers[0];
   const orderA = makeOrder({ customerId: cust.id, status: 'New', delivery_type: 'Pickup', required_by: PHASE1_DATE_A });
   const orderB = makeOrder({ customerId: cust.id, status: 'New', delivery_type: 'Pickup', required_by: PHASE1_DATE_B });

--- a/lab/scenarios/stockYMigration.js
+++ b/lab/scenarios/stockYMigration.js
@@ -11,6 +11,7 @@
 // matching the ADR-0002 "one aggregate per variety" invariant.
 
 import { faker } from '@faker-js/faker';
+import { randomUUID } from 'crypto';
 import { buildStockOverhaul } from './stockOverhaul.js';
 import { makeStockItem, makeOrder, makeOrderLine } from '../factories/index.js';
 
@@ -116,11 +117,51 @@ export function buildStockYMigration() {
   const lineA  = makeOrderLine({ orderId: orderA.id, stockItemId: aggDE.id, flower_name: aggDE.display_name, quantity: 5 });
   const lineB  = makeOrderLine({ orderId: orderB.id, stockItemId: aggDE.id, flower_name: aggDE.display_name, quantity: 3 });
 
+  // ── Phase 4 fixture: premade reservation back-add ──
+  // Simulates a "Hydrangea Blue 30cm" Batch with qty=20, linked to one
+  // premade bouquet line with quantity=7. The script must ADD 7 back to
+  // current_quantity → post-state: 27.
+  const targetBatch = makeStockItem({
+    type:             'batch',
+    display_name:     'Hydrangea Blue 30cm (10.May.)',
+    type_name:        'Hydrangea',
+    colour:           'Blue',
+    size_cm:          30,
+    current_quantity: 20,
+    date:             '2026-05-10',
+  });
+  stockItems.push(targetBatch);
+
+  const premadeBouquet = {
+    id:             randomUUID(),
+    airtable_id:    null,
+    name:           'Migration test bouquet',
+    created_by:     '',
+    price_override: null,
+    notes:          '',
+    created_at:     new Date(),
+  };
+
+  const premadeLine = {
+    id:                   randomUUID(),
+    airtable_id:          null,
+    bouquet_id:           premadeBouquet.id,
+    stock_id:             targetBatch.id,
+    stock_airtable_id:    null,
+    flower_name:          targetBatch.display_name,
+    quantity:             7,
+    cost_price_per_unit:  '0',
+    sell_price_per_unit:  '0',
+    created_at:           new Date(),
+  };
+
   return {
-    customers:  base.customers,
+    customers:          base.customers,
     stockItems,
-    orders:     [...base.orders, orderA, orderB],
-    orderLines: [...orderLines, lineA, lineB],
-    deliveries: base.deliveries,
+    orders:             [...base.orders, orderA, orderB],
+    orderLines:         [...orderLines, lineA, lineB],
+    deliveries:         base.deliveries,
+    premadeBouquets:    [premadeBouquet],
+    premadeBouquetLines: [premadeLine],
   };
 }

--- a/lab/scenarios/stockYMigration.js
+++ b/lab/scenarios/stockYMigration.js
@@ -1,0 +1,71 @@
+// lab/scenarios/stockYMigration.js
+//
+// Fixture for the Stock Y-model migration script regression gate
+// (issue #290). Extends stockOverhaul with prod-shaped fixtures and
+// guarantees every stock row has `type_name` set (post-#292 state).
+//
+// The unique index stock_demand_variety_date_idx enforces at-most-one
+// DE per (type_name, colour, size_cm, cultivar, date). Legacy aggregate
+// DEs (date=NULL, qty<0) fall under this when type_name is set — so we
+// deduplicate demand entries by summing quantities into one per variety,
+// matching the ADR-0002 "one aggregate per variety" invariant.
+
+import { faker } from '@faker-js/faker';
+import { buildStockOverhaul } from './stockOverhaul.js';
+
+export function buildStockYMigration() {
+  faker.seed(290);
+  const base = buildStockOverhaul();
+
+  // Separate batch rows (qty >= 0) from demand entries (qty < 0).
+  // For batch rows: assign type_name from display_name if missing.
+  // For demand entries: deduplicate by variety name (ADR-0002: one aggregate per variety).
+  const batchRows = base.stockItems.filter(s => s.current_quantity >= 0);
+  const demandRows = base.stockItems.filter(s => s.current_quantity < 0);
+
+  // Backfill type_name on batch rows — each batch has a unique display_name
+  // (includes date suffix) so no duplicate constraint issues.
+  const backedBatches = batchRows.map(s => ({
+    ...s,
+    type_name: s.type_name ?? (s.display_name.split(' ')[0] || 'Unknown'),
+  }));
+
+  // Deduplicate demand entries: keep first occurrence per variety name
+  // and sum quantities, then assign type_name. This matches ADR-0002's
+  // "at most one aggregate DE per variety" invariant.
+  // Also build an id-remap so order lines pointing to removed duplicates
+  // are updated to point to the surviving row.
+  const seenVariety = new Map(); // varietyKey → surviving stock row
+  const idRemap = new Map();     // removed id → surviving id
+  for (const s of demandRows) {
+    const varietyKey = s.display_name; // demand entries use variety name as display_name
+    if (seenVariety.has(varietyKey)) {
+      // Sum the quantities into the surviving occurrence (both are negative).
+      seenVariety.get(varietyKey).current_quantity += s.current_quantity;
+      idRemap.set(s.id, seenVariety.get(varietyKey).id);
+    } else {
+      seenVariety.set(varietyKey, { ...s });
+    }
+  }
+  const deduplicatedDemands = Array.from(seenVariety.values()).map(s => ({
+    ...s,
+    type_name: s.type_name ?? (s.display_name.split(' ')[0] || 'Unknown'),
+  }));
+
+  // Remap order lines that pointed to removed duplicate demand entries.
+  const orderLines = base.orderLines.map(ol =>
+    idRemap.has(ol.stock_item_id)
+      ? { ...ol, stock_item_id: idRemap.get(ol.stock_item_id) }
+      : ol
+  );
+
+  const stockItems = [...backedBatches, ...deduplicatedDemands];
+
+  return {
+    customers:  base.customers,
+    stockItems,
+    orders:     base.orders,
+    orderLines,
+    deliveries: base.deliveries,
+  };
+}

--- a/lab/scenarios/stockYMigration.js
+++ b/lab/scenarios/stockYMigration.js
@@ -117,6 +117,28 @@ export function buildStockYMigration() {
   const lineA  = makeOrderLine({ orderId: orderA.id, stockItemId: aggDE.id, flower_name: aggDE.display_name, quantity: 5 });
   const lineB  = makeOrderLine({ orderId: orderB.id, stockItemId: aggDE.id, flower_name: aggDE.display_name, quantity: 3 });
 
+  // ── Phase 1 filter fixture: aggregate linked to one New order + one Cancelled order ──
+  // Expect: dated DE only reflects the New order's qty (5), not the Cancelled line (2).
+  // The aggregate's full current_quantity is -7 (-5 active + -2 cancelled),
+  // but Phase 1 must ignore the Cancelled line — only the -5 active demand
+  // gets a dated DE. The Cancelled qty is intentionally dropped.
+  const FILTER_DATE = '2026-07-01';
+  const filterAggDE = makeStockItem({
+    type:             'demand',
+    display_name:     'Lily White 70cm',
+    type_name:        'Lily',
+    colour:           'White',
+    size_cm:          70,
+    current_quantity: -7,  // -5 (active) + -2 (cancelled, qty stays on aggregate)
+    date:             null,
+  });
+  stockItems.push(filterAggDE);
+
+  const orderActive    = makeOrder({ customerId: cust.id, status: 'New',       delivery_type: 'Pickup', required_by: FILTER_DATE });
+  const orderCancelled = makeOrder({ customerId: cust.id, status: 'Cancelled', delivery_type: 'Pickup', required_by: FILTER_DATE });
+  const filterLineActive    = makeOrderLine({ orderId: orderActive.id,    stockItemId: filterAggDE.id, flower_name: filterAggDE.display_name, quantity: 5 });
+  const filterLineCancelled = makeOrderLine({ orderId: orderCancelled.id, stockItemId: filterAggDE.id, flower_name: filterAggDE.display_name, quantity: 2 });
+
   // ── Phase 4 fixture: premade reservation back-add ──
   // Simulates a "Hydrangea Blue 30cm" Batch with qty=20, linked to one
   // premade bouquet line with quantity=7. The script must ADD 7 back to
@@ -158,8 +180,8 @@ export function buildStockYMigration() {
   return {
     customers:          base.customers,
     stockItems,
-    orders:             [...base.orders, orderA, orderB],
-    orderLines:         [...orderLines, lineA, lineB],
+    orders:             [...base.orders, orderA, orderB, orderActive, orderCancelled],
+    orderLines:         [...orderLines, lineA, lineB, filterLineActive, filterLineCancelled],
     deliveries:         base.deliveries,
     premadeBouquets:    [premadeBouquet],
     premadeBouquetLines: [premadeLine],

--- a/lab/scenarios/stockYMigration.js
+++ b/lab/scenarios/stockYMigration.js
@@ -12,6 +12,7 @@
 
 import { faker } from '@faker-js/faker';
 import { buildStockOverhaul } from './stockOverhaul.js';
+import { makeStockItem, makeOrder, makeOrderLine } from '../factories/index.js';
 
 export function buildStockYMigration() {
   faker.seed(290);
@@ -61,11 +62,36 @@ export function buildStockYMigration() {
 
   const stockItems = [...backedBatches, ...deduplicatedDemands];
 
+  // ── Phase 1 fixture: 1 aggregate DE shared by 2 orders on 2 different dates ──
+  // Simulates a "Peony Pink 60cm" aggregate DE with qty=-8 and no date,
+  // linked to two Pickup orders with distinct Required By dates.
+  // The script must split this into two dated DEs (-5 and -3) and repoint
+  // the order_lines to the correct dated DE.
+  const PHASE1_DATE_A = '2026-06-01';
+  const PHASE1_DATE_B = '2026-06-03';
+
+  const aggDE = makeStockItem({
+    type:             'demand',
+    display_name:     'Peony Pink 60cm',
+    type_name:        'Peony',
+    colour:           'Pink',
+    size_cm:          60,
+    current_quantity: -8,
+    date:             null,
+  });
+  stockItems.push(aggDE);
+
+  const cust = base.customers[0];
+  const orderA = makeOrder({ customerId: cust.id, status: 'New', delivery_type: 'Pickup', required_by: PHASE1_DATE_A });
+  const orderB = makeOrder({ customerId: cust.id, status: 'New', delivery_type: 'Pickup', required_by: PHASE1_DATE_B });
+  const lineA  = makeOrderLine({ orderId: orderA.id, stockItemId: aggDE.id, flower_name: aggDE.display_name, quantity: 5 });
+  const lineB  = makeOrderLine({ orderId: orderB.id, stockItemId: aggDE.id, flower_name: aggDE.display_name, quantity: 3 });
+
   return {
     customers:  base.customers,
     stockItems,
-    orders:     base.orders,
-    orderLines,
+    orders:     [...base.orders, orderA, orderB],
+    orderLines: [...orderLines, lineA, lineB],
     deliveries: base.deliveries,
   };
 }

--- a/lab/tests/api/migrate-stock-y-model.test.js
+++ b/lab/tests/api/migrate-stock-y-model.test.js
@@ -167,3 +167,32 @@ describe('migrate-stock-y-model — Phase 3: positive undated → synthetic Batc
     }
   }, 60_000);
 });
+
+describe('migrate-stock-y-model — Phase 4: premade back-add', () => {
+  beforeEach(async () => { await resetLabDb(); });
+
+  it('adds premade_bouquet_lines.quantity back to matching Batch current_quantity', async () => {
+    const pool = labPool();
+    try {
+      // Pre: find the Hydrangea Batch inserted by the scenario fixture.
+      const pre = await pool.query(
+        `SELECT id, current_quantity FROM stock WHERE display_name = 'Hydrangea Blue 30cm (10.May.)'`
+      );
+      expect(pre.rows.length).toBe(1);
+      const { id: batchId, current_quantity: preQty } = pre.rows[0];
+
+      const res = runScript();
+      expect(res.status).toBe(0);
+
+      // Post: current_quantity must have increased by the premade line quantity (7).
+      const post = await pool.query(
+        `SELECT current_quantity FROM stock WHERE id = $1`,
+        [batchId]
+      );
+      expect(post.rows.length).toBe(1);
+      expect(post.rows[0].current_quantity).toBe(preQty + 7);
+    } finally {
+      await pool.end();
+    }
+  }, 60_000);
+});

--- a/lab/tests/api/migrate-stock-y-model.test.js
+++ b/lab/tests/api/migrate-stock-y-model.test.js
@@ -196,3 +196,37 @@ describe('migrate-stock-y-model — Phase 4: premade back-add', () => {
     }
   }, 60_000);
 });
+
+describe('migrate-stock-y-model — Phase 1 filter: terminated orders excluded', () => {
+  beforeEach(async () => { await resetLabDb(); });
+
+  it('sums only active (non-Cancelled, non-Delivered, non-Picked-Up) lines into dated DEs', async () => {
+    const pool = labPool();
+    try {
+      // Pre: aggregate DE exists with qty=-7 (New line: 5, Cancelled line: 2).
+      const pre = await pool.query(
+        `SELECT id FROM stock WHERE display_name = 'Lily White 70cm' AND date IS NULL AND current_quantity = -7`
+      );
+      expect(pre.rows.length).toBe(1);
+
+      const res = runScript();
+      expect(res.status).toBe(0);
+
+      // Post: exactly one dated DE for Lily White 70cm with qty = -5 (only the active line).
+      // The Cancelled line is ignored; the aggregate's residual -2 is dropped on purpose.
+      const dated = await pool.query(
+        `SELECT date::text, current_quantity
+         FROM stock WHERE type_name = 'Lily' AND colour = 'White' AND size_cm = 70
+                    AND current_quantity < 0 AND date IS NOT NULL`
+      );
+      expect(dated.rows.length).toBe(1);
+      expect(dated.rows[0]).toEqual({ date: '2026-07-01', current_quantity: -5 });
+
+      // Original aggregate gone — no undated row remains for this variety.
+      const gone = await pool.query(`SELECT id FROM stock WHERE display_name = 'Lily White 70cm' AND date IS NULL`);
+      expect(gone.rows.length).toBe(0);
+    } finally {
+      await pool.end();
+    }
+  }, 60_000);
+});

--- a/lab/tests/api/migrate-stock-y-model.test.js
+++ b/lab/tests/api/migrate-stock-y-model.test.js
@@ -1,0 +1,46 @@
+// lab/tests/api/migrate-stock-y-model.test.js
+//
+// Integration tests for backend/scripts/migrate-stock-y-model.js.
+// Boots lab Postgres template, runs the script via spawnSync, asserts
+// post-state. Each phase has its own describe block.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import path from 'path';
+import { resetLabDb } from '../../helpers/reset.js';
+import { labPool } from '../../helpers/db.js';
+
+const SCRIPT = path.resolve(process.cwd(), '../backend/scripts/migrate-stock-y-model.js');
+const LAB_DSN = 'postgres://lab:lab@localhost:5433/lab';
+
+function runScript(args = []) {
+  return spawnSync('node', [SCRIPT, ...args], {
+    env: { ...process.env, APPROVE: 'yes', DATABASE_URL: LAB_DSN, PGSSL_DISABLE: 'true' },
+    encoding: 'utf8',
+  });
+}
+
+describe('migrate-stock-y-model — pre-condition', () => {
+  beforeEach(async () => { await resetLabDb(); });
+
+  it('aborts when any stock row has type_name IS NULL', async () => {
+    const pool = labPool();
+    try {
+      await pool.query(
+        `INSERT INTO stock (display_name, current_quantity, type_name) VALUES ('test', 0, NULL)`
+      );
+      const res = runScript(['--dry-run']);
+      expect(res.status).toBe(1);
+      expect(res.stderr).toMatch(/type_name IS NULL/);
+      expect(res.stderr).toMatch(/#292/);
+    } finally {
+      await pool.end();
+    }
+  }, 30_000);
+
+  it('passes pre-condition when all rows have type_name', async () => {
+    const res = runScript(['--dry-run']);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toMatch(/DRY RUN/);
+  }, 30_000);
+});

--- a/lab/tests/api/migrate-stock-y-model.test.js
+++ b/lab/tests/api/migrate-stock-y-model.test.js
@@ -130,3 +130,40 @@ describe('migrate-stock-y-model — Phase 2: orphan negative → today', () => {
     }
   }, 60_000);
 });
+
+describe('migrate-stock-y-model — Phase 3: positive undated → synthetic Batch', () => {
+  beforeEach(async () => { await resetLabDb(); });
+
+  it('dates all positive-qty undated rows to today, preserving qty', async () => {
+    const pool = labPool();
+    const today = new Date().toISOString().slice(0, 10);
+    try {
+      // Pre: find the known fixture row.
+      const pre = await pool.query(
+        `SELECT id, current_quantity FROM stock WHERE display_name = 'Rose Red 50cm' AND date IS NULL`
+      );
+      expect(pre.rows.length).toBe(1);
+      const { id: fixtureId, current_quantity: preQty } = pre.rows[0];
+
+      const res = runScript();
+      expect(res.status).toBe(0);
+
+      // Post: row now has date = today, qty preserved.
+      const post = await pool.query(
+        `SELECT date::text, current_quantity FROM stock WHERE id = $1`,
+        [fixtureId]
+      );
+      expect(post.rows.length).toBe(1);
+      expect(post.rows[0].date).toBe(today);
+      expect(post.rows[0].current_quantity).toBe(preQty);
+
+      // Post: no positive-qty undated rows remain (bulk UPDATE covered all).
+      const remaining = await pool.query(
+        `SELECT count(*)::int AS cnt FROM stock WHERE current_quantity >= 0 AND date IS NULL AND deleted_at IS NULL`
+      );
+      expect(remaining.rows[0].cnt).toBe(0);
+    } finally {
+      await pool.end();
+    }
+  }, 60_000);
+});

--- a/lab/tests/api/migrate-stock-y-model.test.js
+++ b/lab/tests/api/migrate-stock-y-model.test.js
@@ -230,3 +230,37 @@ describe('migrate-stock-y-model — Phase 1 filter: terminated orders excluded',
     }
   }, 60_000);
 });
+
+describe('migrate-stock-y-model — Phase 5 + idempotency', () => {
+  beforeEach(async () => { await resetLabDb(); });
+
+  it('is a no-op when re-run after a clean migration', async () => {
+    const first = runScript();
+    expect(first.status).toBe(0);
+
+    const second = runScript();
+    expect(second.status).toBe(0);
+    // Second run should hit the alreadyMigrated() guard.
+    expect(second.stdout).toMatch(/already complete/i);
+  }, 90_000);
+
+  it('applies NOT NULL on stock.date and stock.type_name', async () => {
+    const res = runScript();
+    expect(res.status).toBe(0);
+    const pool = labPool();
+    try {
+      const { rows } = await pool.query(`
+        SELECT column_name, is_nullable
+        FROM information_schema.columns
+        WHERE table_name = 'stock' AND column_name IN ('date', 'type_name')
+        ORDER BY column_name
+      `);
+      expect(rows).toEqual([
+        { column_name: 'date',      is_nullable: 'NO' },
+        { column_name: 'type_name', is_nullable: 'NO' },
+      ]);
+    } finally {
+      await pool.end();
+    }
+  }, 60_000);
+});

--- a/lab/tests/api/migrate-stock-y-model.test.js
+++ b/lab/tests/api/migrate-stock-y-model.test.js
@@ -4,13 +4,14 @@
 // Boots lab Postgres template, runs the script via spawnSync, asserts
 // post-state. Each phase has its own describe block.
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from 'vitest';
 import { spawnSync } from 'child_process';
 import path from 'path';
 import { resetLabDb } from '../../helpers/reset.js';
 import { labPool } from '../../helpers/db.js';
 
-const SCRIPT = path.resolve(process.cwd(), '../backend/scripts/migrate-stock-y-model.js');
+const REPO_ROOT = path.resolve(process.cwd(), '..');
+const SCRIPT = path.resolve(REPO_ROOT, 'backend/scripts/migrate-stock-y-model.js');
 const LAB_DSN = 'postgres://lab:lab@localhost:5433/lab';
 
 function runScript(args = []) {
@@ -19,6 +20,28 @@ function runScript(args = []) {
     encoding: 'utf8',
   });
 }
+
+function rebuildTemplate(scenario) {
+  const res = spawnSync('node', ['lab/scripts/rebuild-template.js', `--scenario=${scenario}`], {
+    encoding: 'utf8',
+    cwd: REPO_ROOT,
+    stdio: 'pipe',
+  });
+  if (res.status !== 0) {
+    throw new Error(`rebuild-template (${scenario}) failed: ${res.stderr || res.stdout}`);
+  }
+}
+
+// Bootstrap template with our scenario so this test file is self-contained
+// regardless of the CI ordering. Restore baseline on teardown so later
+// suites in the same `lab:test:api` run still see the default fixture.
+beforeAll(() => {
+  rebuildTemplate('stock-y-migration');
+}, 60_000);
+
+afterAll(() => {
+  rebuildTemplate('baseline');
+}, 60_000);
 
 describe('migrate-stock-y-model — pre-condition', () => {
   beforeEach(async () => { await resetLabDb(); });

--- a/lab/tests/api/migrate-stock-y-model.test.js
+++ b/lab/tests/api/migrate-stock-y-model.test.js
@@ -44,3 +44,51 @@ describe('migrate-stock-y-model — pre-condition', () => {
     expect(res.stdout).toMatch(/DRY RUN/);
   }, 30_000);
 });
+
+describe('migrate-stock-y-model — Phase 1: aggregate split', () => {
+  beforeEach(async () => { await resetLabDb(); });
+
+  it('splits one aggregate DE into per-Required-By dated DEs', async () => {
+    const pool = labPool();
+    try {
+      // Pre: find the aggregate DE by display_name + date IS NULL.
+      const pre = await pool.query(
+        `SELECT id FROM stock WHERE display_name = 'Peony Pink 60cm' AND date IS NULL AND current_quantity = -8`
+      );
+      expect(pre.rows.length).toBe(1);
+      const aggId = pre.rows[0].id;
+
+      const res = runScript();
+      expect(res.status).toBe(0);
+
+      // Post: aggregate gone.
+      const gone = await pool.query(`SELECT id FROM stock WHERE id = $1`, [aggId]);
+      expect(gone.rows.length).toBe(0);
+
+      // Post: 2 dated DEs, one per date, with correct qty.
+      const dated = await pool.query(
+        `SELECT date::text, current_quantity, type_name, colour, size_cm
+         FROM stock WHERE type_name = 'Peony' AND colour = 'Pink' AND size_cm = 60
+                    AND current_quantity < 0 AND date IS NOT NULL
+         ORDER BY date ASC`
+      );
+      expect(dated.rows).toEqual([
+        { date: '2026-06-01', current_quantity: -5, type_name: 'Peony', colour: 'Pink', size_cm: 60 },
+        { date: '2026-06-03', current_quantity: -3, type_name: 'Peony', colour: 'Pink', size_cm: 60 },
+      ]);
+
+      // Post: order_lines repointed to the new dated DEs.
+      const lines = await pool.query(
+        `SELECT ol.stock_item_id, s.date::text
+         FROM order_lines ol JOIN stock s ON s.id::text = ol.stock_item_id
+         WHERE ol.flower_name = 'Peony Pink 60cm'
+         ORDER BY ol.quantity DESC`
+      );
+      expect(lines.rows.length).toBe(2);
+      expect(lines.rows[0].date).toBe('2026-06-01');
+      expect(lines.rows[1].date).toBe('2026-06-03');
+    } finally {
+      await pool.end();
+    }
+  }, 60_000);
+});

--- a/lab/tests/api/migrate-stock-y-model.test.js
+++ b/lab/tests/api/migrate-stock-y-model.test.js
@@ -92,3 +92,41 @@ describe('migrate-stock-y-model — Phase 1: aggregate split', () => {
     }
   }, 60_000);
 });
+
+describe('migrate-stock-y-model — Phase 2: orphan negative → today', () => {
+  beforeEach(async () => { await resetLabDb(); });
+
+  it('converts orphan aggregate DE to today-dated DE with preserved variety', async () => {
+    const pool = labPool();
+    const today = new Date().toISOString().slice(0, 10);
+    try {
+      // Pre: orphan row exists with date IS NULL.
+      const pre = await pool.query(
+        `SELECT id FROM stock WHERE display_name = 'Tulip Yellow 40cm' AND date IS NULL`
+      );
+      expect(pre.rows.length).toBe(1);
+
+      const res = runScript();
+      expect(res.status).toBe(0);
+
+      // Post: row now has date = today, qty and variety preserved.
+      const post = await pool.query(
+        `SELECT date::text, current_quantity, type_name, colour, size_cm
+         FROM stock WHERE type_name = 'Tulip' AND colour = 'Yellow' AND size_cm = 40
+                    AND current_quantity < 0`
+      );
+      expect(post.rows.length).toBe(1);
+      expect(post.rows[0]).toMatchObject({
+        date: today, current_quantity: -4, type_name: 'Tulip', colour: 'Yellow', size_cm: 40,
+      });
+
+      // Original aggregate gone (no row with date IS NULL for this variety).
+      const gone = await pool.query(
+        `SELECT id FROM stock WHERE display_name = 'Tulip Yellow 40cm' AND date IS NULL`
+      );
+      expect(gone.rows.length).toBe(0);
+    } finally {
+      await pool.end();
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary

- Idempotent destructive migration script `backend/scripts/migrate-stock-y-model.js` converts legacy aggregate Demand Entry rows to Y-model (dated DEs + premade reservation back-add). Single transaction; `APPROVE=yes` gate + `--dry-run` mode + pre-condition guard + top-of-script idempotency guard.
- Five phases inside a single transaction: (1) split aggregate by `o.required_by → o.order_date → today`; (2) orphan negative → today-dated; (3) positive-qty undated → dated Batch; (4) premade reservation back-add (Pitfall #8); (5) `ALTER COLUMN date/type_name SET NOT NULL`.
- New lab scenario `stockYMigration` + 9 lab API tests; self-bootstraps + restores baseline so the existing CI `lab-api` job catches the regression without extra steps.

## Verification path

- `cd backend && npx vitest run` → **423 passed | 1 todo**
- `npm run lab:test:unit` → **37 passed**
- `npm run lab:db:up && npm run lab:template:rebuild -- --scenario=baseline && npm run lab:test:api` → **17 passed** (cancel-with-return + migrate-stock-y-model + variety-backfill, all green)
- Code-quality reviewer (opus) surfaced 3 high-confidence bugs; all 3 fixed in commit `8e975df` with regression test for the Phase 1 filter case.

## Scope notes

NOT in scope this PR: prod cutover, `STOCK_Y_MODEL=true` flag flip (both #291), Variety attribute backfill UI (#292).

Cutover order reminder: #284 (schema/flag) → #292 (Owner attribute backfill) → #285/#286/#287/#288/#289 (Y-model code paths) → #290 (this script, `APPROVE=yes`) → #291 (flag flip).

Operator note: Phase 1's active-order filter means dated DEs reflect **future** unfulfilled demand only. Aggregate's pre-migration `current_quantity` may include past consumption (Delivered/Picked Up) or returned demand (Cancel-with-return) — both are dropped intentionally; the aggregate is deleted.

## Test plan

- [x] Backend vitest green
- [x] Lab unit green
- [x] Lab API green (incl. self-bootstrap fix so existing CI `lab-api` job covers this)
- [x] Phase 1 filter regression test exercises the New + Cancelled mix
- [x] Idempotency guard exercised — second run logs "already complete" and exits 0
- [x] Pitfall #8 math: Phase 4 ADDS reservations (does not subtract anywhere)
- [x] Dry-run rolls back Phase 5 ALTER COLUMN cleanly

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)