### PR TITLE
chore(lab): default STOCK_Y_MODEL=true for lab backend

### DIFF
--- a/lab/scripts/start-lab-backend.js
+++ b/lab/scripts/start-lab-backend.js
@@ -20,6 +20,7 @@ const LAB_ENV = {
   STOCK_BACKEND:                     'postgres',
   ORDER_BACKEND:                     'postgres',
   TEST_BACKEND:                      'mock-airtable',
+  STOCK_Y_MODEL:                     process.env.STOCK_Y_MODEL ?? 'true',
   PORT:                              process.env.PORT || '3003',
 
   PIN_OWNER:                         '1111',


### PR DESCRIPTION
## Summary

- Adds `STOCK_Y_MODEL: process.env.STOCK_Y_MODEL ?? 'true'` to `LAB_ENV` in `lab/scripts/start-lab-backend.js`.
- Lab fixtures (`stockYDemand`, `stockYMigration`) already seed 4-tuple Variety rows, so flag-on is the right default for local end-to-end click-through. Legacy path still exercisable via `STOCK_Y_MODEL=false npm run lab:dev`.

## Why

Unblocks local UI verification of #285-#290 Y-model flows. Before this, `npm run lab:dev` booted a backend that served legacy stock paths even though the fixtures were Y-shaped.

## Test plan

- [x] `npm run lab:db:up && npm run lab:template:rebuild -- --scenario=stockYDemand && npm run lab:dev` boots backend with flag on
- [x] No backend/shared/lab tests touched — single env-default change

🤖 Generated with [Claude Code](https://claude.com/claude-code)