### PR TITLE
fix(stock-y): emit current_quantity + date on /stock?grouped=true rows

### DIFF
--- a/backend/src/__tests__/stockRepo.listGroupedByVariety.test.js
+++ b/backend/src/__tests__/stockRepo.listGroupedByVariety.test.js
@@ -204,6 +204,11 @@ describe('listGroupedByVariety (issue #289)', () => {
       // rows are StockItem-shaped (wire format from pgToResponse)
       expect(g.rows[0]).toHaveProperty('Display Name');
       expect(g.rows[0]).toHaveProperty('Current Quantity', 7);
+      // …plus Y-model snake-case fields the frontend VarietyListItem +
+      // getVarietyTotals consume directly. Without these the per-Batch
+      // label rendered "NaN stems" and the On-hand bucket collapsed to 0.
+      expect(g.rows[0]).toHaveProperty('current_quantity', 7);
+      expect(g.rows[0]).toHaveProperty('date');
     });
   });
 });

--- a/backend/src/repos/stockRepo.js
+++ b/backend/src/repos/stockRepo.js
@@ -984,7 +984,15 @@ export async function listGroupedByVariety({ includeEmpty = false } = {}) {
       colour:             g.colour,
       size_cm:            g.size_cm,
       cultivar:           g.cultivar,
-      rows:               g._rows.map(pgToResponse),
+      // Each row carries legacy display-case fields (pgToResponse) PLUS the
+      // Y-model snake-case fields that VarietyListItem + getVarietyTotals
+      // consume (`current_quantity`, `date`). Without these, the totals
+      // collapse to 0 and the per-Batch label renders "NaN stems".
+      rows: g._rows.map(r => ({
+        ...pgToResponse(r),
+        current_quantity: r.currentQuantity ?? 0,
+        date:             r.date ?? null,
+      })),
       reservedForPremades,
     });
   }


### PR DESCRIPTION
## Summary

VarietyListItem + getVarietyTotals read row.current_quantity (snake) + row.date — backend mapping through pgToResponse only emitted display-case 'Current Quantity' and dropped date entirely. Result in local UI: header 'On hand: 0' + per-Batch label '(—) NaN stems'.

Fix adds both snake-case fields on top of pgToResponse so frontend Y-model consumers AND any legacy display-case reader continue working.

## Verification

- `cd backend && npx vitest run src/__tests__/stockRepo.listGroupedByVariety.test.js` → 11/11 passing (new assertions on row.current_quantity + row.date)
- Local: lab backend reloaded, `/api/stock?grouped=true` now returns:
  ```json
  { rows: [{ "Current Quantity": 20, current_quantity: 20, date: "2026-05-10", ... }] }
  ```

## Test plan

- [x] Backend vitest green
- [x] Live verified against lab backend with Hydrangea Blue 30cm fixture

## Follow-ups filed

- #303 — inline search dropdown in BouquetEditor / Step2Bouquet still lists raw Stock Items (not Variety groups). Blocks #291 cutover.
- #304 — PO line entry has no Variety attrs + adds blank rows without supplier sort. Blocks #291 cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)