### PR TITLE
fix(stock-y): stack Variety identity, inline write-off, clickable DE rows, orderId in trace

### DIFF
--- a/apps/dashboard/src/components/StockTab.jsx
+++ b/apps/dashboard/src/components/StockTab.jsx
@@ -789,7 +789,8 @@ export default function StockTab({ initialFilter, onNavigate, isActive = true })
                           hideType={true}
                           expanded={expandedKey === group.key}
                           onToggle={() => setExpandedKey(k => k === group.key ? null : group.key)}
-                          onBatchClick={(stockId) => setTraceStockId(prev => prev === stockId ? null : stockId)}
+                          onRowClick={(stockId) => setTraceStockId(prev => prev === stockId ? null : stockId)}
+                          onWriteOff={(v) => setWriteOffVariety(v)}
                           premadesByStockId={premadesByStockId}
                           t={t}
                         />
@@ -815,16 +816,6 @@ export default function StockTab({ initialFilter, onNavigate, isActive = true })
                             )}
                           </div>
                         )}
-                        {/* Write-off button per variety row */}
-                        <div className="px-4 pb-2 flex justify-end border-b border-gray-100">
-                          <button
-                            type="button"
-                            onClick={() => setWriteOffVariety(group)}
-                            className="text-[11px] text-ios-red font-medium px-2.5 py-1 rounded-full bg-red-50 hover:bg-red-100"
-                          >
-                            {t.writeOff}
-                          </button>
-                        </div>
                       </div>
                     ))}
                   </div>

--- a/apps/florist/src/pages/StockPanelPage.jsx
+++ b/apps/florist/src/pages/StockPanelPage.jsx
@@ -477,20 +477,11 @@ export default function StockPanelPage() {
                           hideType={true}
                           expanded={expandedKey === group.key}
                           onToggle={() => setExpandedKey(k => k === group.key ? null : group.key)}
-                          onBatchClick={(stockId) => setTraceStockId(stockId)}
+                          onRowClick={(stockId) => setTraceStockId(stockId)}
+                          onWriteOff={(v) => setWriteOffVariety(v)}
                           premadesByStockId={premadesByStockId}
                           t={t}
                         />
-                        {/* Write-off button per variety row (below the variety item) */}
-                        <div className="px-4 pb-2 flex justify-end">
-                          <button
-                            type="button"
-                            onClick={() => setWriteOffVariety(group)}
-                            className="text-[11px] text-ios-red font-medium px-2.5 py-1 rounded-full bg-red-50 active:bg-red-100 active-scale"
-                          >
-                            🗑 {t.writeOff}
-                          </button>
-                        </div>
                         {/* Write-off picker inline when this variety is selected */}
                         {writeOffVariety?.key === group.key && (
                           <div className="px-4 pb-3">

--- a/packages/shared/components/BatchTracePanel.jsx
+++ b/packages/shared/components/BatchTracePanel.jsx
@@ -45,7 +45,14 @@ function typeBadgeClass(type) {
 
 function trailDetail(entry) {
   switch (entry.type) {
-    case 'order':    return entry.customer ?? null;
+    case 'order': {
+      // Show the human-readable order id alongside the customer so the operator
+      // can match the row back to the order list ("Order #202605-00013 — Hayley Abbott").
+      const oid = entry.orderId ?? null;
+      const customer = entry.customer ?? null;
+      if (oid && customer) return `${oid} — ${customer}`;
+      return oid ?? customer ?? null;
+    }
     case 'writeoff': return entry.reason ?? null;
     case 'purchase': return entry.supplier ?? null;
     case 'premade':  return entry.bouquetName ?? null;

--- a/packages/shared/components/VarietyListItem.jsx
+++ b/packages/shared/components/VarietyListItem.jsx
@@ -1,51 +1,40 @@
 /**
  * VarietyListItem — collapsible row for a single Variety in the Y-model Stock list.
  *
- * Sits beneath a <TypeGroupHeader> and shows 4 buckets of aggregated stem counts
- * derived from `getVarietyTotals`. Expanding the row reveals individual Batch and
- * Demand-Entry sub-rows sorted by date ascending.
+ * Layout (left → right):
+ *   - Identity column: Colour / Size / Cultivar stacked vertically (lines omitted
+ *     when null) so each attribute is scannable independently.
+ *   - 4-bucket numeric grid: On hand / Planned / Reserved / Net.
+ *   - Inline write-off button (when `onWriteOff` provided).
+ *
+ * Expanding the row reveals each Batch and Demand-Entry sub-row, each tagged with
+ * a kind badge. Both row kinds are clickable and call `onRowClick(stockId)` so the
+ * host can open BatchTraceModal — the same /stock/:id/usage endpoint surfaces the
+ * trail of orders / writeoffs / purchases for Batches AND linked orders for DEs.
  *
  * Props:
- *   variety     {Object}   — Variety group object from `groupByVariety`:
- *                              { key, type_name, colour, size_cm, cultivar, rows[] }
- *                            Each row must have { id, current_quantity, date }.
- *   reservations {Map<string,number>}
- *                           — Map from stock-row id → reserved stem count (from
- *                             premade_bouquet_lines JOIN). Passed down from the host page.
- *   hideType    {boolean}  — When true (normal case: under a TypeGroupHeader) drop
- *                            the Type prefix from the display name, showing only
- *                            "<Colour> <Size>cm <Cultivar?>".
- *   expanded    {boolean}  — Whether the sub-row expansion is visible.
- *   onToggle    {Function} — Called when the header row is clicked (toggle expand).
- *   onBatchClick {Function} [optional]
- *                           — Called with `stockItemId` when a Batch row is tapped.
- *                             Not called for Demand Entry rows (those are read-only).
- *                             Kind classification: current_quantity < 0 → 'demand',
- *                             else 'batch' (ADR-0005 negative-qty derivation rule).
- *   premadesByStockId {Map<string,Array>} [optional]
- *                           — Map from stock-row id → premade-bouquet lines for
- *                             the reserved-tap detail sheet. Each entry: { id, name, qty }.
- *                             When provided AND reservedForPremades > 0, the reserved
- *                             bucket becomes a tappable button that reveals a sub-list.
- *   t           {Object}   — Translation strings. Required keys:
- *                              onHand, planned, reserved, net, stems.
- *
- * Bucket definitions (ADR-0005, pitfall #8):
- *   onHand            — sum of positive current_quantity rows (physical stems on shelf)
- *   planned           — absolute sum of negative current_quantity rows (shortfall to fill)
- *   reserved          — stems committed to premade bouquets (from reservations Map)
- *   net               — onHand − planned − reserved (effective availability)
+ *   variety     {Object}   — Variety group { key, type_name, colour, size_cm, cultivar, rows[] }.
+ *                            Each row must carry { id, current_quantity, date }.
+ *   reservations {Map<string,number>} — stock-row id → reserved stem count.
+ *   hideType    {boolean}  — when true (under TypeGroupHeader) drop the Type prefix.
+ *   expanded    {boolean}  — whether the expansion is visible.
+ *   onToggle    {Function} — header click handler.
+ *   onRowClick  {Function} — called with stockId when a Batch/Demand row is tapped.
+ *                            (Was previously `onBatchClick`; renamed because both
+ *                            kinds open the same trace view via /stock/:id/usage.)
+ *   onWriteOff  {Function} — called with the variety when the inline write-off
+ *                            button is tapped. When omitted, the button is hidden.
+ *   premadesByStockId {Map<string,Array>} — id → [{ id, name, qty }, ...]. Reserved
+ *                            bucket becomes a button when supplied AND reserved>0.
+ *   t           {Object}   — translation strings. Required keys:
+ *                              onHand, planned, reserved, net, stems, writeOff,
+ *                              batchKind, demandKind.
  *
  * IMPORTANT: Never inline qty − reserved subtraction here. Always call
- * `getVarietyTotals(variety.rows, reservations)`. This is the pitfall #8 hotspot —
- * two prior double-count bugs came from doing the subtraction at the wrong level.
- * See packages/shared/utils/stockMath.js for the full history.
- *
- * References: PRD #283, ADR-0005, ADR-0006, pitfall #8.
+ * `getVarietyTotals(variety.rows, reservations)`. Pitfall #8.
  */
 import { useState } from 'react';
 import { getVarietyTotals } from '../utils/stockMath.js';
-import { varietyDisplayName } from '../utils/varietyKey.js';
 
 export default function VarietyListItem({
   variety,
@@ -53,32 +42,35 @@ export default function VarietyListItem({
   hideType = true,
   expanded = false,
   onToggle,
-  onBatchClick,
+  onRowClick,
+  onBatchClick, // legacy alias — kept for back-compat with un-migrated callers
+  onWriteOff,
   premadesByStockId,
   t,
 }) {
+  const handleRowClick = onRowClick ?? onBatchClick;
+
   // Aggregate the 4 buckets — never inline; always go through the helper (pitfall #8).
   const { onHand, planned, reservedForPremades, net } = getVarietyTotals(
     variety.rows,
     reservations,
   );
 
-  // Build display name. When under a TypeGroupHeader (hideType=true), drop the
-  // type_name prefix so we don't repeat "Rose Rose Pink 60cm" in the list.
-  const displayName = hideType
-    ? varietyDisplayName({ ...variety, type_name: null })
-    : varietyDisplayName(variety);
+  // Identity lines, omitting empties. When hideType is false we also expose Type
+  // on its own line — used by hosts that render Varieties outside a TypeGroupHeader.
+  const identityLines = [];
+  if (!hideType && variety.type_name) identityLines.push(variety.type_name);
+  if (variety.colour)                  identityLines.push(variety.colour);
+  if (variety.size_cm != null)         identityLines.push(`${variety.size_cm}cm`);
+  if (variety.cultivar)                identityLines.push(variety.cultivar);
+  if (identityLines.length === 0)      identityLines.push('—');
 
   const netNegative = net < 0;
 
   // Reserved-bucket tap: local toggle state for the premade sub-list.
   const [premadeOpen, setPremadeOpen] = useState(false);
-
-  // Reserved bucket is interactive only when there are reserved stems AND the host
-  // provided the premades map. Otherwise it's a plain display cell.
   const reservedInteractive = reservedForPremades > 0 && !!premadesByStockId;
 
-  // Aggregate premade lines across all stock rows for this Variety.
   const premadeLines = [];
   if (premadesByStockId) {
     for (const row of variety.rows) {
@@ -87,7 +79,6 @@ export default function VarietyListItem({
     }
   }
 
-  // Header keyboard handler — treat Enter/Space as click for a11y on the div header.
   function handleHeaderKey(e) {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
@@ -97,71 +88,58 @@ export default function VarietyListItem({
 
   return (
     <div className="border-b border-gray-100 last:border-b-0">
-      {/* ── Header row — div+role to allow nested interactive elements (reserved button) ── */}
+      {/* ── Header row ── */}
       <div
         role="button"
         tabIndex={0}
         data-testid="variety-header"
         onClick={onToggle}
         onKeyDown={handleHeaderKey}
-        className="w-full flex items-center px-4 py-2.5 text-left transition-colors active:bg-gray-50 cursor-pointer"
+        className="w-full flex items-center px-4 py-2 text-left transition-colors active:bg-gray-50 cursor-pointer gap-3"
       >
-        {/* Left: Variety display name */}
-        <span className="flex-1 min-w-0 text-sm font-medium text-gray-800 truncate pr-3">
-          {displayName}
-        </span>
-
-        {/* Right: 4-bucket numeric grid — equal columns, values right-aligned */}
-        <span className="grid grid-cols-4 gap-x-4 text-right shrink-0">
-          {/* onHand */}
-          <span className="flex flex-col items-end">
-            <span data-testid="bucket-onHand" className="text-sm font-semibold text-gray-900 tabular-nums">
-              {onHand}
-            </span>
-            <span className="text-[10px] text-gray-400 leading-none">{t.onHand}</span>
-          </span>
-
-          {/* planned */}
-          <span className="flex flex-col items-end">
-            <span data-testid="bucket-planned" className="text-sm font-semibold text-gray-900 tabular-nums">
-              {planned}
-            </span>
-            <span className="text-[10px] text-gray-400 leading-none">{t.planned}</span>
-          </span>
-
-          {/* reserved (for premades) — interactive button when tappable, span otherwise */}
-          <span className="flex flex-col items-end">
-            {reservedInteractive ? (
-              <button
-                type="button"
-                data-testid="bucket-reserved"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setPremadeOpen(open => !open);
-                }}
-                className="text-sm font-semibold text-indigo-600 tabular-nums underline decoration-dotted"
-              >
-                {reservedForPremades}
-              </button>
-            ) : (
-              <span data-testid="bucket-reserved" className="text-sm font-semibold text-gray-900 tabular-nums">
-                {reservedForPremades}
-              </span>
-            )}
-            <span className="text-[10px] text-gray-400 leading-none">{t.reserved}</span>
-          </span>
-
-          {/* net — red when negative */}
-          <span className="flex flex-col items-end">
+        {/* Identity column — stacked attributes, tight line-height */}
+        <span className="flex-1 min-w-0 flex flex-col leading-tight">
+          {identityLines.map((line, i) => (
             <span
-              data-testid="bucket-net"
-              className={`text-sm font-semibold tabular-nums ${netNegative ? 'text-red-600' : 'text-gray-900'}`}
+              key={i}
+              className={`text-sm truncate ${i === 0 ? 'font-medium text-gray-800' : 'text-gray-500'}`}
             >
-              {net}
+              {line}
             </span>
-            <span className="text-[10px] text-gray-400 leading-none">{t.net}</span>
-          </span>
+          ))}
         </span>
+
+        {/* 4-bucket numeric grid */}
+        <span className="grid grid-cols-4 gap-x-3 text-right shrink-0">
+          <Bucket testid="bucket-onHand"   value={onHand}              label={t.onHand} />
+          <Bucket testid="bucket-planned"  value={planned}             label={t.planned} />
+          <Bucket
+            testid="bucket-reserved"
+            value={reservedForPremades}
+            label={t.reserved}
+            onClick={reservedInteractive ? (e) => { e.stopPropagation(); setPremadeOpen(o => !o); } : null}
+            valueClass={reservedInteractive ? 'text-indigo-600 underline decoration-dotted' : 'text-gray-900'}
+          />
+          <Bucket
+            testid="bucket-net"
+            value={net}
+            label={t.net}
+            valueClass={netNegative ? 'text-red-600' : 'text-gray-900'}
+          />
+        </span>
+
+        {/* Inline write-off button — host opts in via onWriteOff prop */}
+        {onWriteOff && (
+          <button
+            type="button"
+            data-testid="variety-writeoff"
+            onClick={(e) => { e.stopPropagation(); onWriteOff(variety); }}
+            className="shrink-0 text-[11px] text-ios-red font-medium px-2 py-1 rounded-full bg-red-50 active:bg-red-100"
+            aria-label={t.writeOff}
+          >
+            🗑
+          </button>
+        )}
       </div>
 
       {/* ── Premade sub-list (tap on reserved bucket) ── */}
@@ -189,39 +167,59 @@ export default function VarietyListItem({
               // ADR-0005 negative-qty derivation rule: negative qty → Demand Entry
               const kind = row.current_quantity < 0 ? 'demand' : 'batch';
               const absQty = Math.abs(row.current_quantity);
-              const label = `(${row.date ?? '—'}) ${absQty} ${t.stems}`;
+              const kindLabel = kind === 'batch' ? (t.batchKind ?? 'Batch') : (t.demandKind ?? 'Demand');
+              const dateLabel = row.date ?? '—';
 
-              if (kind === 'batch') {
-                return (
-                  <li key={row.id}>
-                    <button
-                      type="button"
-                      data-testid="stock-item-row"
-                      data-row-kind="batch"
-                      onClick={() => onBatchClick && onBatchClick(row.id)}
-                      className="w-full text-left px-6 py-2 text-sm text-gray-700 active:bg-gray-100 transition-colors"
-                    >
-                      {label}
-                    </button>
-                  </li>
-                );
-              }
+              const isDemand = kind === 'demand';
+              const baseRow = 'w-full flex items-center justify-between px-6 py-2 text-sm transition-colors active:bg-gray-100';
+              const rowClass = isDemand
+                ? `${baseRow} text-red-700 bg-red-50 hover:bg-red-100`
+                : `${baseRow} text-gray-700 hover:bg-gray-100`;
 
-              // Demand Entry — read-only, visually distinct
               return (
                 <li key={row.id}>
-                  <div
+                  <button
+                    type="button"
                     data-testid="stock-item-row"
-                    data-row-kind="demand"
-                    className="px-6 py-2 text-sm text-red-700 bg-red-50"
+                    data-row-kind={kind}
+                    onClick={() => handleRowClick && handleRowClick(row.id)}
+                    className={rowClass}
                   >
-                    {label}
-                  </div>
+                    <span className="flex items-center gap-2">
+                      <span
+                        className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
+                          isDemand ? 'bg-red-100 text-red-700' : 'bg-gray-200 text-gray-700'
+                        }`}
+                      >
+                        {kindLabel}
+                      </span>
+                      <span className="text-gray-500">{dateLabel}</span>
+                    </span>
+                    <span className="tabular-nums">
+                      {absQty} {t.stems} ›
+                    </span>
+                  </button>
                 </li>
               );
             })}
         </ul>
       )}
     </div>
+  );
+}
+
+function Bucket({ testid, value, label, onClick, valueClass }) {
+  const cls = `text-sm font-semibold tabular-nums ${valueClass ?? 'text-gray-900'}`;
+  return (
+    <span className="flex flex-col items-end">
+      {onClick ? (
+        <button type="button" data-testid={testid} onClick={onClick} className={cls}>
+          {value}
+        </button>
+      ) : (
+        <span data-testid={testid} className={cls}>{value}</span>
+      )}
+      <span className="text-[10px] text-gray-400 leading-none">{label}</span>
+    </span>
   );
 }

--- a/packages/shared/test/VarietyListItem.test.jsx
+++ b/packages/shared/test/VarietyListItem.test.jsx
@@ -11,10 +11,12 @@ const variety = {
 };
 
 describe('VarietyListItem header', () => {
-  it('renders Variety display (drops Type since under TypeGroupHeader): "Pink 60cm"', () => {
+  it('renders identity attrs stacked vertically (drops Type under TypeGroupHeader)', () => {
     render(<VarietyListItem variety={variety} reservations={new Map()} t={t}
       hideType={true} expanded={false} onToggle={() => {}} />);
-    expect(screen.getByText(/Pink 60cm/)).toBeInTheDocument();
+    // Colour and Size live on separate lines now — each scannable independently.
+    expect(screen.getByText('Pink')).toBeInTheDocument();
+    expect(screen.getByText('60cm')).toBeInTheDocument();
     expect(screen.queryByText('Rose')).not.toBeInTheDocument();
   });
 
@@ -81,22 +83,33 @@ describe('VarietyListItem expansion', () => {
     expect(kinds.filter(k => k === 'demand')).toHaveLength(1);
   });
 
-  it('clicking a Batch row fires onBatchClick(stockItemId)', () => {
+  it('clicking a Batch row fires onRowClick(stockItemId)', () => {
+    const onRowClick = vi.fn();
+    render(<VarietyListItem variety={v} reservations={new Map()} t={t}
+      hideType={true} expanded={true} onToggle={() => {}} onRowClick={onRowClick} />);
+    const batches = screen.getAllByTestId('stock-item-row').filter(r => r.getAttribute('data-row-kind') === 'batch');
+    fireEvent.click(batches[0]);
+    expect(onRowClick).toHaveBeenCalledWith('b1');
+  });
+
+  it('clicking a Demand Entry row also fires onRowClick (both kinds open the same trace)', () => {
+    // Both Batches AND DEs are clickable in the redesign — /stock/:id/usage
+    // surfaces the trail for either kind (linked orders for DEs).
+    const onRowClick = vi.fn();
+    render(<VarietyListItem variety={v} reservations={new Map()} t={t}
+      hideType={true} expanded={true} onToggle={() => {}} onRowClick={onRowClick} />);
+    const demand = screen.getAllByTestId('stock-item-row').find(r => r.getAttribute('data-row-kind') === 'demand');
+    fireEvent.click(demand);
+    expect(onRowClick).toHaveBeenCalledWith('d1');
+  });
+
+  it('still honours legacy onBatchClick prop name (back-compat)', () => {
     const onBatchClick = vi.fn();
     render(<VarietyListItem variety={v} reservations={new Map()} t={t}
       hideType={true} expanded={true} onToggle={() => {}} onBatchClick={onBatchClick} />);
     const batches = screen.getAllByTestId('stock-item-row').filter(r => r.getAttribute('data-row-kind') === 'batch');
     fireEvent.click(batches[0]);
     expect(onBatchClick).toHaveBeenCalledWith('b1');
-  });
-
-  it('clicking a Demand Entry row does NOT fire onBatchClick', () => {
-    const onBatchClick = vi.fn();
-    render(<VarietyListItem variety={v} reservations={new Map()} t={t}
-      hideType={true} expanded={true} onToggle={() => {}} onBatchClick={onBatchClick} />);
-    const demand = screen.getAllByTestId('stock-item-row').find(r => r.getAttribute('data-row-kind') === 'demand');
-    fireEvent.click(demand);
-    expect(onBatchClick).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Visual polish on the Y-model Stock list, driven by local owner feedback after testing #305 + #306 stack:

**Layout (image 4 feedback)**
- Colour / Size / Cultivar stack vertically — each attribute on its own line, scannable independently. \`Type\` still suppressed under TypeGroupHeader.
- Write-off button moves inline to header right (opt-in via new \`onWriteOff\` prop). Removes the full-width write-off block that bled into the next Variety row.
- Tighter vertical spacing (\`py-2\` + \`leading-tight\` on identity column).

**Expansion (image 5 feedback)**
- Each expanded row tagged with a \`Batch\` / \`Demand\` badge so kind is obvious.
- Both Batches AND Demand Entries are now clickable. \`onBatchClick\` → \`onRowClick\` (legacy prop name still honoured). Same trace modal opens for either — \`/stock/:id/usage\` already returns linked orders for DEs.
- BatchTracePanel: order trace rows show \`orderId — customer\` (e.g. \`202605-00013 — Hayley Abbott\`) so the row matches the order list.

**Cross-app parity**
- \`apps/florist/src/pages/StockPanelPage.jsx\` ↔ \`apps/dashboard/src/components/StockTab.jsx\` — both lose their separate write-off block, both pass \`onWriteOff\`.

## Verification

- \`cd packages/shared && ../../backend/node_modules/.bin/vitest run\` → **271/271 passing** (VarietyListItem suite updated for new behavior + back-compat assertion on legacy \`onBatchClick\` prop).
- \`cd apps/florist && ./node_modules/.bin/vite build\` → green
- \`cd apps/dashboard && ./node_modules/.bin/vite build\` → green
- \`cd apps/delivery && ./node_modules/.bin/vite build\` → green

## Test plan

- [x] Shared vitest green
- [x] Florist + Dashboard + Delivery builds green
- [x] VarietyListItem renders Colour/Size/Cultivar stacked
- [x] Write-off button inline in header
- [x] DE rows clickable → trace modal opens, shows orderId + customer
- [x] Reserved bucket still tappable when premadesByStockId provided

## Follow-ups

Not in this PR (owner asked for v2):
- Order trace rows could become true nav links to /orders/:id (current PR just surfaces the orderId).
- Drilling further into a Batch's purchase history (PO line back-link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)