### PR TITLE
fix(dashboard): BouquetSection ReferenceError on flowerSearch under STOCK_Y_MODEL

### DIFF
--- a/apps/dashboard/src/components/order/BouquetSection.jsx
+++ b/apps/dashboard/src/components/order/BouquetSection.jsx
@@ -27,9 +27,11 @@ export default function BouquetSection({ order, editing, isTerminal, saving, tar
   const [yPickerStockItems, setYPickerStockItems] = useState([]);
 
   // Y-model: group the search-filtered stock by Variety 4-tuple.
+  // `editing.flowerSearch` is the hook-owned search state — destructuring it as
+  // a local would only work inside the editing-mode IIFE further down.
   const varGroups = useMemo(() => {
     if (!yEnabled) return [];
-    const raw = editing.getFilteredStock(flowerSearch);
+    const raw = editing.getFilteredStock(editing.flowerSearch);
     const adapted = raw.map(s => ({
       ...s,
       type_name: s.Type ?? null,
@@ -53,7 +55,7 @@ export default function BouquetSection({ order, editing, isTerminal, saving, tar
       poDate:      g.rows.map(r => editing.pendingPO?.[r.id]?.plannedDate).find(Boolean) ?? null,
     }));
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [yEnabled, editing.stockItems, editing.pendingPO, flowerSearch]);
+  }, [yEnabled, editing.stockItems, editing.pendingPO, editing.flowerSearch]);
 
   if (!o.orderLines?.length) return null;
 


### PR DESCRIPTION
Reviewing PR #312 (#303) surfaced a runtime bug in the dashboard's `BouquetSection.jsx`:

The Y-model `varGroups` `useMemo` near the top of the component referenced bare `flowerSearch`. That name is only destructured from the `editing` hook inside the editing-mode IIFE further down (line ~76) — at module scope it's undefined. When `STOCK_Y_MODEL=true` and the user enters Edit mode on an order's bouquet, the render throws `ReferenceError: flowerSearch is not defined` before the dropdown ever paints.

Preview builds passed because Vite doesn't catch undefined-identifier errors statically, and the legacy (`yEnabled=false`) branch took an early `return []` before the throw site, so the bug only triggers under the Y-model flag — i.e. exactly the path #312 was shipping.

## Fix

Switch both the call and the dep-array entry to `editing.flowerSearch` (the hook-owned state, parallel to `editing.setFlowerSearch` which the file already uses).

## Verification

- ✅ Dashboard `vite build` clean
- ✅ Florist `vite build` clean
- ✅ 296 shared tests green
- ✅ Manual inspection of all four #303 surfaces — only this one had the typo. Florist `BouquetEditor.jsx` uses its own local `flowerSearch` state; both `Step2Bouquet` files use a local `flowerQuery`.

Closes part of #303 follow-up (no separate issue filed — bug introduced and caught in same week).

🤖 Generated with [Claude Code](https://claude.com/claude-code)