### PR TITLE
fix(orders): self-heal nextOrderId counter against drift

### DIFF
--- a/backend/src/__tests__/appConfigRepo.integration.test.js
+++ b/backend/src/__tests__/appConfigRepo.integration.test.js
@@ -48,4 +48,57 @@ describe('appConfigRepo', () => {
     expect(may).toBe('202605-001');
     expect(jun).toBe('202606-001');
   });
+
+  // Regression: prod incident 2026-05-19. Counter drifted behind MAX(app_order_id)
+  // — every nextOrderId returned an ID that already existed in orders, blowing
+  // the unique index. Self-healing: counter must jump past any existing IDs for
+  // that month, never return one that already exists.
+  it('nextOrderId skips past existing app_order_ids that are ahead of the counter', async () => {
+    const { orders } = await import('../db/schema.js');
+    // Counter sits at 2 (committed by these two calls).
+    await appConfigRepo.nextOrderId('202605');
+    await appConfigRepo.nextOrderId('202605');
+
+    // Seed an order whose appOrderId is far ahead of the counter — exactly
+    // the prod drift scenario (backfilled/imported orders past the counter).
+    await harness.db.insert(orders).values({
+      airtableId:    null,
+      appOrderId:    '202605-010',
+      customerId:    'recDRIFT',
+      deliveryType:  'Pickup',
+      status:        'New',
+    });
+
+    const next = await appConfigRepo.nextOrderId('202605');
+    expect(next).toBe('202605-011');
+  });
+
+  it('nextOrderId ignores other months when self-healing', async () => {
+    const { orders } = await import('../db/schema.js');
+    // June order should NOT pull the May counter forward.
+    await harness.db.insert(orders).values({
+      airtableId:   null,
+      appOrderId:   '202606-050',
+      customerId:   'recOTHERMONTH',
+      deliveryType: 'Pickup',
+      status:       'New',
+    });
+    const may = await appConfigRepo.nextOrderId('202605');
+    expect(may).toBe('202605-001');
+  });
+
+  it('nextOrderId ignores non-numeric-suffix app_order_ids (legacy / fallback shape)', async () => {
+    const { orders } = await import('../db/schema.js');
+    // generateOrderId() fallback shape is "YYYYMM-T<digits>" — must not poison
+    // the counter via regex match.
+    await harness.db.insert(orders).values({
+      airtableId:   null,
+      appOrderId:   '202605-T99999',
+      customerId:   'recFALLBACK',
+      deliveryType: 'Pickup',
+      status:       'New',
+    });
+    const next = await appConfigRepo.nextOrderId('202605');
+    expect(next).toBe('202605-001');
+  });
 });

--- a/backend/src/repos/appConfigRepo.js
+++ b/backend/src/repos/appConfigRepo.js
@@ -3,8 +3,8 @@
 //   'config'         — main settings object (DEFAULTS + owner overrides)
 //   'orderCounters'  — { 'YYYYMM': N } per-month order counter
 import { db } from '../db/index.js';
-import { appConfig } from '../db/schema.js';
-import { eq } from 'drizzle-orm';
+import { appConfig, orders } from '../db/schema.js';
+import { eq, sql } from 'drizzle-orm';
 
 /** Returns parsed value for key, or null if missing. */
 export async function get(key) {
@@ -25,9 +25,21 @@ export async function set(key, value) {
 /**
  * Atomically increments the per-month order counter and returns the
  * next formatted ID like '202605-001'.
- * Uses a transaction to be safe under concurrent order creation.
- * Note: SELECT FOR UPDATE not used here — pglite (test DB) doesn't support it
- * and the Node.js event loop serializes most concurrent requests in production.
+ *
+ * Self-healing: takes GREATEST(counter[monthKey], MAX numeric suffix already in
+ * orders for monthKey). Prod incident 2026-05-19 — counter drifted behind real
+ * IDs (24 vs 26 in `202605`) and every call returned a value that already
+ * existed, blowing the unique index. Causes of drift: backfills, restores of a
+ * stale config snapshot (Phase 7 cutover), or any insert path that wrote an
+ * explicit appOrderId without bumping the counter.
+ *
+ * Only `YYYYMM-NNN` integer-suffix rows count toward the floor — fallback IDs
+ * shaped `YYYYMM-T<epoch>` (see configService.generateOrderId catch branch) are
+ * ignored so a one-off fallback can't poison the counter.
+ *
+ * SELECT FOR UPDATE intentionally absent — pglite doesn't support it. On real
+ * PG the unique index still catches any race that slips through; the
+ * self-healing read will recover on the next call.
  */
 export async function nextOrderId(monthKey) {
   return db.transaction(async (tx) => {
@@ -37,7 +49,16 @@ export async function nextOrderId(monthKey) {
       .where(eq(appConfig.key, 'orderCounters'));
 
     const counters = row ? (row.value || {}) : {};
-    const next     = (counters[monthKey] || 0) + 1;
+    const counterFloor = counters[monthKey] || 0;
+
+    const result = await tx.execute(sql`
+      SELECT COALESCE(MAX(CAST(SUBSTRING(${orders.appOrderId} FROM '[0-9]+$') AS INTEGER)), 0) AS max_n
+      FROM ${orders}
+      WHERE ${orders.appOrderId} ~ ('^' || ${monthKey} || '-[0-9]+$')
+    `);
+    const dbFloor = Number(result.rows?.[0]?.max_n ?? result[0]?.max_n ?? 0);
+
+    const next = Math.max(counterFloor, dbFloor) + 1;
     counters[monthKey] = next;
 
     if (row) {


### PR DESCRIPTION
## Summary
- Prod outage 2026-05-19: florist app could not create orders. `[ORDER] createOrder failed: duplicate key value violates unique constraint "orders_app_order_id_idx"` on every POST /orders.
- Root cause: `app_config.orderCounters['202605']=24` while `MAX(numeric suffix of app_order_id)` for May was already `26`. `generateOrderId()` returned IDs that already existed (e.g. `202605-025`). Drift between counter and reality could be introduced any time an order was inserted with an explicit appOrderId without bumping the counter (backfills, stale-snapshot restores during the Phase 7 cutover, etc.).
- Fix: inside the existing `nextOrderId` transaction, take `GREATEST(counter[monthKey], MAX(numeric suffix already in orders for that month)) + 1`. Counter now self-heals on the very next call regardless of how it fell behind. Only `YYYYMM-NNN` integer-suffix rows count toward the floor, so the `YYYYMM-T<epoch>` fallback shape (configService.js:438) cannot poison the counter going forward.

## Prod state at incident time
```
orderCounters['202605'] = 24
MAX(numeric suffix in orders, May 2026) = 26
Repeated unique-index collisions in Railway logs
```

Counter was manually bumped to 26 in prod ahead of this PR (owner approved) to unblock order creation immediately. This PR is the permanent fix so drift can't block creation again.

## Test plan
- [x] `cd backend && npx vitest run src/__tests__/appConfigRepo.integration.test.js` — 8/8 (3 new regressions: drift recovery, month isolation, non-numeric-suffix ignore)
- [x] `cd backend && npx vitest run` — full backend suite 430 pass
- [x] `npm run harness` + `npm run test:e2e` — 180/180 pass (includes section 2 "Order creation paths" 21/21)
- [x] No frontend / shared changes; backend-only diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)