### PR TITLE
feat(orders): FEFO batch router for line stock attribution

### DIFF
--- a/backend/src/__tests__/orderRepo.fefo.integration.test.js
+++ b/backend/src/__tests__/orderRepo.fefo.integration.test.js
@@ -1,0 +1,205 @@
+// FEFO routing inside orderRepo.createOrder — closes #319.
+//
+// When STOCK_Y_MODEL=true and a Variety has multiple positive Batches,
+// the line's stockItemId is rerouted to the oldest Batch that can fully
+// cover the line, regardless of which Batch the picker initially passed.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import { stock, orderLines } from '../db/schema.js';
+import { eq } from 'drizzle-orm';
+
+const dbHolder = { db: null };
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  isPostgresConfigured: true,
+  pool: null,
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+const yModelFlag = { enabled: true };
+vi.mock('../services/configService.js', () => ({
+  getStockYModelEnabled: () => yModelFlag.enabled,
+  getStockXModelEnabled: () => false,
+  getConfig: vi.fn(),
+  updateConfig: vi.fn(),
+  generateOrderId: vi.fn(),
+  getDriverOfDay: vi.fn(),
+  isPastCutoff: vi.fn(),
+  getActiveSeasonalCategory: vi.fn(),
+  loadConfig: vi.fn(),
+  saveConfig: vi.fn(),
+}));
+
+import * as orderRepo from '../repos/orderRepo.js';
+
+let harness;
+let orderIdCounter = 0;
+const config = {
+  getConfig: (k) => ({ defaultDeliveryFee: 25, driverCostPerDelivery: 10 }[k] ?? 0),
+  getDriverOfDay: () => 'Timur',
+  generateOrderId: async () => `BLO-FEFO-${++orderIdCounter}`,
+};
+
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+  yModelFlag.enabled = true;
+  orderIdCounter = 0;
+  vi.clearAllMocks();
+});
+
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+async function seedBatch({ qty, date, typeName = 'Hydrangea', colour = 'White', sizeCm = null, cultivar = null }) {
+  const [row] = await harness.db.insert(stock).values({
+    displayName: `${typeName} ${colour ?? ''} (${date ?? 'undated'})`.trim(),
+    currentQuantity: qty,
+    active: true,
+    typeName,
+    colour,
+    sizeCm,
+    cultivar,
+    date,
+  }).returning();
+  return row;
+}
+
+describe('createOrder FEFO routing (#319)', () => {
+  it('reroutes line FK from newer Batch to older Batch with full cover', async () => {
+    const oldBatch = await seedBatch({ qty: 5, date: '2026-05-16' });
+    const newBatch = await seedBatch({ qty: 2, date: '2026-05-18' });
+
+    const { orderLines: createdLines } = await orderRepo.createOrder({
+      customer: 'recCust1',
+      deliveryType: 'Pickup',
+      orderLines: [
+        { stockItemId: newBatch.id, flowerName: 'Hydrangea White', quantity: 3, sellPricePerUnit: 15, costPricePerUnit: 4 },
+      ],
+      paymentStatus: 'Unpaid',
+      paymentMethod: 'Cash',
+      createdBy: 'florist',
+    }, config, { actor: { actorRole: 'florist' } });
+
+    // Decrement landed on the OLD batch (FEFO), not the picker's newer batch.
+    const [oldAfter] = await harness.db.select().from(stock).where(eq(stock.id, oldBatch.id));
+    const [newAfter] = await harness.db.select().from(stock).where(eq(stock.id, newBatch.id));
+    expect(oldAfter.currentQuantity).toBe(2);  // 5 - 3
+    expect(newAfter.currentQuantity).toBe(2);  // untouched
+
+    // Line FK was rebound to the old Batch.
+    const [line] = await harness.db.select().from(orderLines).where(eq(orderLines.id, createdLines[0].id));
+    expect(line.stockItemId).toBe(oldBatch.id);
+  });
+
+  it('falls back to oldest Batch when none has enough cover (lets it go negative)', async () => {
+    const oldBatch = await seedBatch({ qty: 1, date: '2026-05-16' });
+    const newBatch = await seedBatch({ qty: 2, date: '2026-05-18' });
+
+    await orderRepo.createOrder({
+      customer: 'recCust1',
+      deliveryType: 'Pickup',
+      orderLines: [
+        { stockItemId: newBatch.id, flowerName: 'Hydrangea White', quantity: 5 },
+      ],
+      paymentStatus: 'Unpaid',
+      paymentMethod: 'Cash',
+      createdBy: 'florist',
+    }, config, { actor: { actorRole: 'florist' } });
+
+    const [oldAfter] = await harness.db.select().from(stock).where(eq(stock.id, oldBatch.id));
+    const [newAfter] = await harness.db.select().from(stock).where(eq(stock.id, newBatch.id));
+    expect(oldAfter.currentQuantity).toBe(-4);  // 1 - 5
+    expect(newAfter.currentQuantity).toBe(2);
+  });
+
+  it('prefers newer full-cover Batch over older short Batch', async () => {
+    const oldBatch = await seedBatch({ qty: 2, date: '2026-05-16' });
+    const newBatch = await seedBatch({ qty: 10, date: '2026-05-18' });
+
+    await orderRepo.createOrder({
+      customer: 'recCust1',
+      deliveryType: 'Pickup',
+      orderLines: [
+        { stockItemId: oldBatch.id, flowerName: 'Hydrangea White', quantity: 5 },
+      ],
+      paymentStatus: 'Unpaid',
+      paymentMethod: 'Cash',
+      createdBy: 'florist',
+    }, config, { actor: { actorRole: 'florist' } });
+
+    const [oldAfter] = await harness.db.select().from(stock).where(eq(stock.id, oldBatch.id));
+    const [newAfter] = await harness.db.select().from(stock).where(eq(stock.id, newBatch.id));
+    expect(oldAfter.currentQuantity).toBe(2);   // untouched
+    expect(newAfter.currentQuantity).toBe(5);   // 10 - 5
+  });
+
+  it('does not reroute when only one Batch exists for the Variety', async () => {
+    const only = await seedBatch({ qty: 10, date: '2026-05-16' });
+
+    await orderRepo.createOrder({
+      customer: 'recCust1',
+      deliveryType: 'Pickup',
+      orderLines: [
+        { stockItemId: only.id, flowerName: 'Hydrangea White', quantity: 3 },
+      ],
+      paymentStatus: 'Unpaid',
+      paymentMethod: 'Cash',
+      createdBy: 'florist',
+    }, config, { actor: { actorRole: 'florist' } });
+
+    const [after] = await harness.db.select().from(stock).where(eq(stock.id, only.id));
+    expect(after.currentQuantity).toBe(7);
+  });
+
+  it('skips FEFO when STOCK_Y_MODEL=false (legacy path unchanged)', async () => {
+    yModelFlag.enabled = false;
+    const oldBatch = await seedBatch({ qty: 10, date: '2026-05-16' });
+    const newBatch = await seedBatch({ qty: 5, date: '2026-05-18' });
+
+    await orderRepo.createOrder({
+      customer: 'recCust1',
+      deliveryType: 'Pickup',
+      orderLines: [
+        { stockItemId: newBatch.id, flowerName: 'Hydrangea White', quantity: 2 },
+      ],
+      paymentStatus: 'Unpaid',
+      paymentMethod: 'Cash',
+      createdBy: 'florist',
+    }, config, { actor: { actorRole: 'florist' } });
+
+    const [oldAfter] = await harness.db.select().from(stock).where(eq(stock.id, oldBatch.id));
+    const [newAfter] = await harness.db.select().from(stock).where(eq(stock.id, newBatch.id));
+    // Legacy: decrement lands on whatever picker passed.
+    expect(oldAfter.currentQuantity).toBe(10);
+    expect(newAfter.currentQuantity).toBe(3);
+  });
+
+  it('reproduces #319 shape: 3 rows, oldest negative, picks middle (full cover)', async () => {
+    const drained = await seedBatch({ qty: -2, date: '2026-05-12' });  // already short, excluded
+    const mid     = await seedBatch({ qty: 5,  date: '2026-05-16' });
+    const newest  = await seedBatch({ qty: 2,  date: '2026-05-18' });
+
+    await orderRepo.createOrder({
+      customer: 'recCust1',
+      deliveryType: 'Pickup',
+      orderLines: [
+        { stockItemId: newest.id, flowerName: 'Hydrangea White', quantity: 3 },
+      ],
+      paymentStatus: 'Unpaid',
+      paymentMethod: 'Cash',
+      createdBy: 'florist',
+    }, config, { actor: { actorRole: 'florist' } });
+
+    const [drainedAfter] = await harness.db.select().from(stock).where(eq(stock.id, drained.id));
+    const [midAfter]     = await harness.db.select().from(stock).where(eq(stock.id, mid.id));
+    const [newestAfter]  = await harness.db.select().from(stock).where(eq(stock.id, newest.id));
+    expect(drainedAfter.currentQuantity).toBe(-2); // untouched (excluded — qty < 0)
+    expect(midAfter.currentQuantity).toBe(2);      // 5 - 3 (FEFO target)
+    expect(newestAfter.currentQuantity).toBe(2);   // untouched
+  });
+});

--- a/backend/src/__tests__/orderRepo.fefo.integration.test.js
+++ b/backend/src/__tests__/orderRepo.fefo.integration.test.js
@@ -203,3 +203,70 @@ describe('createOrder FEFO routing (#319)', () => {
     expect(newestAfter.currentQuantity).toBe(2);   // untouched
   });
 });
+
+describe('editBouquetLines FEFO routing (#319)', () => {
+  it('reroutes a NEW line added during edit to the older Batch', async () => {
+    const oldBatch = await seedBatch({ qty: 5, date: '2026-05-16' });
+    const newBatch = await seedBatch({ qty: 8, date: '2026-05-18' });
+
+    // Seed an order via createOrder with an unrelated Variety so we can edit it.
+    const filler = await seedBatch({ qty: 20, date: '2026-05-10', typeName: 'Rose', colour: 'Red' });
+    const { order } = await orderRepo.createOrder({
+      customer: 'recCust1',
+      deliveryType: 'Pickup',
+      orderLines: [
+        { stockItemId: filler.id, flowerName: 'Red Rose', quantity: 2 },
+      ],
+      paymentStatus: 'Unpaid',
+      paymentMethod: 'Cash',
+      createdBy: 'florist',
+    }, config, { actor: { actorRole: 'florist' } });
+
+    // Now edit-add a Hydrangea line; picker passes the NEW Batch.
+    await orderRepo.editBouquetLines(order.id, {
+      lines: [
+        { stockItemId: newBatch.id, flowerName: 'Hydrangea White', quantity: 3 },
+      ],
+      removedLines: [],
+    }, /* isOwner */ false, { actor: { actorRole: 'florist' } });
+
+    const [oldAfter] = await harness.db.select().from(stock).where(eq(stock.id, oldBatch.id));
+    const [newAfter] = await harness.db.select().from(stock).where(eq(stock.id, newBatch.id));
+    expect(oldAfter.currentQuantity).toBe(2);  // 5 - 3 (FEFO)
+    expect(newAfter.currentQuantity).toBe(8);  // untouched
+  });
+
+  it('does NOT reroute existing-line quantity changes (preserves audit trail)', async () => {
+    const oldBatch = await seedBatch({ qty: 10, date: '2026-05-16' });
+    const newBatch = await seedBatch({ qty: 10, date: '2026-05-18' });
+
+    // Create order against newBatch — FEFO routes to oldBatch at create time.
+    const { order, orderLines: created } = await orderRepo.createOrder({
+      customer: 'recCust1',
+      deliveryType: 'Pickup',
+      orderLines: [
+        { stockItemId: newBatch.id, flowerName: 'Hydrangea White', quantity: 2 },
+      ],
+      paymentStatus: 'Unpaid',
+      paymentMethod: 'Cash',
+      createdBy: 'florist',
+    }, config, { actor: { actorRole: 'florist' } });
+
+    // Confirm create-time FEFO landed on oldBatch.
+    expect((await harness.db.select().from(stock).where(eq(stock.id, oldBatch.id)))[0].currentQuantity).toBe(8);
+
+    // Edit increases qty on the existing line. Should adjust against same batch the line already points at — NOT reroute.
+    await orderRepo.editBouquetLines(order.id, {
+      lines: [
+        { id: created[0].id, stockItemId: oldBatch.id, flowerName: 'Hydrangea White', quantity: 4, _originalQty: 2 },
+      ],
+      removedLines: [],
+    }, false, { actor: { actorRole: 'florist' } });
+
+    const [oldAfter] = await harness.db.select().from(stock).where(eq(stock.id, oldBatch.id));
+    const [newAfter] = await harness.db.select().from(stock).where(eq(stock.id, newBatch.id));
+    // _originalQty=2, new qty=4 → delta = 2-4 = -2; adjust by -2 on oldBatch → 8 - 2 = 6.
+    expect(oldAfter.currentQuantity).toBe(6);
+    expect(newAfter.currentQuantity).toBe(10); // untouched
+  });
+});

--- a/backend/src/__tests__/stockRepo.fefo.test.js
+++ b/backend/src/__tests__/stockRepo.fefo.test.js
@@ -1,0 +1,181 @@
+// stockRepo.resolveBatchByFEFO — FEFO router unit tests against pglite.
+//
+// Closes #319: when multiple Batches share a Variety, the order line should
+// drain the oldest non-negative Batch first. Without FEFO routing, the
+// picker's arbitrary choice of representative Batch drove uneven decrement
+// and led to drift (Hydrangea White: one row at -2, six others untouched).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import { stock } from '../db/schema.js';
+
+const dbHolder = { db: null };
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  isPostgresConfigured: true,
+  pool: null,
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+import { resolveBatchByFEFO } from '../repos/stockRepo.js';
+
+let harness;
+
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+});
+
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+// Helper: seed a Batch (positive qty) or DE (negative qty).
+async function seedRow({ qty, date, typeName = 'Hydrangea', colour = 'White', sizeCm = null, cultivar = null }) {
+  const [row] = await harness.db.insert(stock).values({
+    displayName: `${typeName} ${colour ?? ''} (${date ?? 'undated'})`.trim(),
+    currentQuantity: qty,
+    active: true,
+    typeName,
+    colour,
+    sizeCm,
+    cultivar,
+    date,
+  }).returning();
+  return row;
+}
+
+const HYDRANGEA_WHITE = { typeName: 'Hydrangea', colour: 'White', sizeCm: null, cultivar: null };
+
+describe('resolveBatchByFEFO', () => {
+  it('returns the only Batch when one exists', async () => {
+    const b = await seedRow({ qty: 5, date: '2026-05-16' });
+
+    const result = await harness.db.transaction(async (tx) => {
+      return resolveBatchByFEFO(HYDRANGEA_WHITE, 3, tx);
+    });
+
+    expect(result).toBe(b.id);
+  });
+
+  it('returns null when no Batches exist for the Variety', async () => {
+    await seedRow({ qty: 5, date: '2026-05-16', typeName: 'Peony', colour: 'Pink' });
+
+    const result = await harness.db.transaction(async (tx) => {
+      return resolveBatchByFEFO(HYDRANGEA_WHITE, 3, tx);
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('prefers the older Batch when both fully cover the line quantity', async () => {
+    const older = await seedRow({ qty: 10, date: '2026-05-16' });
+    await seedRow({ qty: 10, date: '2026-05-18' });
+
+    const result = await harness.db.transaction(async (tx) => {
+      return resolveBatchByFEFO(HYDRANGEA_WHITE, 5, tx);
+    });
+
+    expect(result).toBe(older.id);
+  });
+
+  it('prefers the Batch that fully covers when older one is short', async () => {
+    await seedRow({ qty: 2, date: '2026-05-16' });
+    const newer = await seedRow({ qty: 10, date: '2026-05-18' });
+
+    const result = await harness.db.transaction(async (tx) => {
+      return resolveBatchByFEFO(HYDRANGEA_WHITE, 5, tx);
+    });
+
+    expect(result).toBe(newer.id);
+  });
+
+  it('falls back to oldest Batch when none can fully cover (will go negative)', async () => {
+    const oldest = await seedRow({ qty: 1, date: '2026-05-16' });
+    await seedRow({ qty: 2, date: '2026-05-18' });
+
+    const result = await harness.db.transaction(async (tx) => {
+      return resolveBatchByFEFO(HYDRANGEA_WHITE, 5, tx);
+    });
+
+    expect(result).toBe(oldest.id);
+  });
+
+  it('skips Demand Entries (negative quantity)', async () => {
+    await seedRow({ qty: -3, date: '2026-05-16' }); // DE
+    const batch = await seedRow({ qty: 5, date: '2026-05-18' });
+
+    const result = await harness.db.transaction(async (tx) => {
+      return resolveBatchByFEFO(HYDRANGEA_WHITE, 2, tx);
+    });
+
+    expect(result).toBe(batch.id);
+  });
+
+  it('returns null when only DEs exist for the Variety', async () => {
+    await seedRow({ qty: -3, date: '2026-05-16' });
+
+    const result = await harness.db.transaction(async (tx) => {
+      return resolveBatchByFEFO(HYDRANGEA_WHITE, 2, tx);
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('matches Variety with NULL-aware equality (empty colour ≠ "Green")', async () => {
+    await seedRow({ qty: 5, date: '2026-05-16', typeName: 'Eucalyptus', colour: 'Green' });
+    const nullColour = await seedRow({ qty: 7, date: '2026-05-18', typeName: 'Eucalyptus', colour: null });
+
+    const result = await harness.db.transaction(async (tx) => {
+      return resolveBatchByFEFO(
+        { typeName: 'Eucalyptus', colour: null, sizeCm: null, cultivar: null },
+        3, tx,
+      );
+    });
+
+    expect(result).toBe(nullColour.id);
+  });
+
+  it('orders NULL date last (legacy rows deprioritised)', async () => {
+    await seedRow({ qty: 10, date: null });            // legacy, no Y-model date
+    const dated = await seedRow({ qty: 10, date: '2026-05-18' });
+
+    const result = await harness.db.transaction(async (tx) => {
+      return resolveBatchByFEFO(HYDRANGEA_WHITE, 5, tx);
+    });
+
+    expect(result).toBe(dated.id);
+  });
+
+  it('skips soft-deleted Batches', async () => {
+    const deleted = await seedRow({ qty: 10, date: '2026-05-16' });
+    await harness.db.update(stock).set({ deletedAt: new Date() }).where(
+      // eslint-disable-next-line no-restricted-syntax
+      (await import('drizzle-orm')).eq(stock.id, deleted.id),
+    );
+    const live = await seedRow({ qty: 5, date: '2026-05-18' });
+
+    const result = await harness.db.transaction(async (tx) => {
+      return resolveBatchByFEFO(HYDRANGEA_WHITE, 3, tx);
+    });
+
+    expect(result).toBe(live.id);
+  });
+
+  it('reproduces #319 shape — 3 Batches, picks oldest with cover', async () => {
+    // Mirrors prod Hydrangea White: old batch already short, mid full, new full.
+    const oldDrained = await seedRow({ qty: -2, date: '2026-05-12' }); // already negative
+    const mid = await seedRow({ qty: 5, date: '2026-05-16' });
+    await seedRow({ qty: 2, date: '2026-05-18' });
+
+    const result = await harness.db.transaction(async (tx) => {
+      return resolveBatchByFEFO(HYDRANGEA_WHITE, 3, tx);
+    });
+
+    // oldDrained is a DE-like negative row → skipped.
+    // mid (5/16, qty=5) fully covers 3 → picked.
+    expect(result).toBe(mid.id);
+  });
+});

--- a/backend/src/repos/orderRepo.js
+++ b/backend/src/repos/orderRepo.js
@@ -10,7 +10,7 @@
 //     bookkeeping, no half-torn-down state.
 
 import * as stockRepo from './stockRepo.js';
-import { getOrCreateDemandEntry, computeDemandDate, updateDemandEntryDate } from './stockRepo.js';
+import { getOrCreateDemandEntry, computeDemandDate, updateDemandEntryDate, resolveBatchByFEFO } from './stockRepo.js';
 import * as stockLossRepo from './stockLossRepo.js';
 import { db } from '../db/index.js';
 import { orders, orderLines, deliveries, stock } from '../db/schema.js';
@@ -594,6 +594,49 @@ export async function createOrder(params, config, opts = {}) {
         stockDeferred:     line.stockDeferred === true,
       }).returning();
       createdLines.push(lineRow);
+    }
+
+    // 3a. Flag-on: FEFO routing for Batch-bound lines (#319).
+    //
+    //     When the picker passes a Variety's representative stockItemId but
+    //     siblings exist, reroute to the oldest non-negative Batch that
+    //     fully covers (falls back to oldest period if none does). Skips
+    //     DEs (qty < 0) — those are handled by step 3b below.
+    if (getStockYModelEnabled() && !skipStockDeduction) {
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line.stockItemId || line.stockDeferred) continue;
+
+        const [stockRow] = await tx.select({
+          typeName:        stock.typeName,
+          colour:          stock.colour,
+          sizeCm:          stock.sizeCm,
+          cultivar:        stock.cultivar,
+          currentQuantity: stock.currentQuantity,
+        }).from(stock)
+          .where(and(eq(stock.id, line.stockItemId), isNull(stock.deletedAt)))
+          .limit(1);
+
+        if (!stockRow?.typeName || Number(stockRow.currentQuantity) < 0) continue;
+
+        const targetId = await resolveBatchByFEFO(
+          {
+            typeName: stockRow.typeName,
+            colour:   stockRow.colour,
+            sizeCm:   stockRow.sizeCm,
+            cultivar: stockRow.cultivar,
+          },
+          Number(line.quantity),
+          tx,
+        );
+        if (targetId && targetId !== line.stockItemId) {
+          await tx.update(orderLines)
+            .set({ stockItemId: targetId, updatedAt: new Date() })
+            .where(eq(orderLines.id, createdLines[i].id));
+          createdLines[i] = { ...createdLines[i], stockItemId: targetId };
+          line.stockItemId = targetId;
+        }
+      }
     }
 
     // 3b. Flag-on: create/deepen Demand Entry for each line whose linked

--- a/backend/src/repos/orderRepo.js
+++ b/backend/src/repos/orderRepo.js
@@ -1033,6 +1033,37 @@ export async function editBouquetLines(orderId, { lines = [], removedLines = [] 
           await tx.update(orderLines).set({ quantity: line.quantity, updatedAt: new Date() }).where(where);
         }
       } else {
+        // FEFO routing for new lines added during edit (#319). Mirrors step 3a
+        // in createOrder. Existing-line quantity changes intentionally skip
+        // FEFO — preserves the line's original audit trail.
+        if (getStockYModelEnabled() && line.stockItemId && !line.stockDeferred) {
+          const [stockRow] = await tx.select({
+            typeName:        stock.typeName,
+            colour:          stock.colour,
+            sizeCm:          stock.sizeCm,
+            cultivar:        stock.cultivar,
+            currentQuantity: stock.currentQuantity,
+          }).from(stock)
+            .where(and(eq(stock.id, line.stockItemId), isNull(stock.deletedAt)))
+            .limit(1);
+
+          if (stockRow?.typeName && Number(stockRow.currentQuantity) >= 0) {
+            const targetId = await resolveBatchByFEFO(
+              {
+                typeName: stockRow.typeName,
+                colour:   stockRow.colour,
+                sizeCm:   stockRow.sizeCm,
+                cultivar: stockRow.cultivar,
+              },
+              Number(line.quantity),
+              tx,
+            );
+            if (targetId && targetId !== line.stockItemId) {
+              line.stockItemId = targetId;
+            }
+          }
+        }
+
         const [created] = await tx.insert(orderLines).values({
           orderId:          order.id,
           stockItemId:      line.stockItemId || null,

--- a/backend/src/repos/stockRepo.js
+++ b/backend/src/repos/stockRepo.js
@@ -207,6 +207,50 @@ export async function updateDemandEntryDate(orderLineId, newDate, tx, actor = { 
   return { demandEntryId: newDe._pgId, action: 'split' };
 }
 
+/**
+ * FEFO router: resolve a Variety to the oldest non-negative Batch that can
+ * fully cover `lineQty`. Falls back to the oldest Batch (will go negative)
+ * if none has enough cover. Returns null when no Batches exist.
+ *
+ * Demand Entries (`current_quantity < 0`) are intentionally excluded —
+ * order_line FK rerouting to a DE is handled separately by step 3b in
+ * `orderRepo.createOrder` via `getOrCreateDemandEntry`.
+ *
+ * Pglite limitation: no `SELECT FOR UPDATE`. Production PG gets row-level
+ * lock isolation on the subsequent UPDATE in `stockRepo.adjustQuantity`.
+ * The small read-modify race window is acceptable for single-studio use.
+ *
+ * @param {{ typeName: string, colour?: string|null, sizeCm?: number|null, cultivar?: string|null }} varietyKey
+ * @param {number} lineQty - quantity the order line will consume
+ * @param {object} tx      - Drizzle transaction handle (required)
+ * @returns {Promise<string|null>} chosen stock_items.id (uuid), or null
+ */
+export async function resolveBatchByFEFO(varietyKey, lineQty, tx) {
+  const { typeName, colour = null, sizeCm = null, cultivar = null } = varietyKey ?? {};
+  if (!typeName) return null;
+
+  const varietyWhere = and(
+    eq(stock.typeName, typeName),
+    colour   ? eq(stock.colour, colour)     : isNull(stock.colour),
+    sizeCm   ? eq(stock.sizeCm, sizeCm)     : isNull(stock.sizeCm),
+    cultivar ? eq(stock.cultivar, cultivar) : isNull(stock.cultivar),
+    sql`${stock.currentQuantity} >= 0`,
+    isNull(stock.deletedAt),
+  );
+
+  const candidates = await tx.select({
+    id:              stock.id,
+    currentQuantity: stock.currentQuantity,
+  }).from(stock)
+    .where(varietyWhere)
+    .orderBy(sql`${stock.date} ASC NULLS LAST`, sql`${stock.createdAt} ASC`);
+
+  if (candidates.length === 0) return null;
+
+  const fullCover = candidates.find(c => Number(c.currentQuantity) >= Number(lineQty));
+  return (fullCover ?? candidates[0]).id;
+}
+
 // ── Backend mode stub ──
 // getBackendMode is always 'postgres' post-Phase-7. Kept until Tasks 3+4
 // remove the callers in orderService.js and wix.js.

--- a/docs/superpowers/plans/2026-05-19-fefo-batch-router.md
+++ b/docs/superpowers/plans/2026-05-19-fefo-batch-router.md
@@ -1,0 +1,153 @@
+# FEFO batch router for order-line stock attribution
+
+**Closes:** #319 (Hydrangea White shortfall on 18.May batch)
+**Precursor to:** #283 (Stock model v1 — Demand Entries + reservation model)
+**Branch:** `feat/fefo-batch-router`
+**Scope:** tactical patch. Schema unchanged. UI unchanged.
+
+## Problem
+
+Under `STOCK_Y_MODEL=true`, the bouquet picker groups `stock_items` by Variety
+(four-tuple: `type_name`, `colour`, `size_cm`, `cultivar` — ADR-0006). When a Variety
+has multiple positive Batches (different arrival dates), the picker returns a single
+representative row. Whichever Batch's `id` the picker passes is decremented by
+`orderRepo.createOrder` step 4 (`stockRepo.adjustQuantity(line.stockItemId, -qty)`).
+
+Result on prod (#319): Hydrangea White had 7 stock rows. Orders bound to one row
+(`recuxLEjqprNAttpr`) drained it to `qty=-2` while a newer Batch (`bd25114d`, qty=2,
+18.May) sat untouched. Picker selection was arbitrary; the underlying model has no
+notion of "which Batch should drain first".
+
+## Fix
+
+Backend self-heals at order-line write time. When a line's `stockItemId` resolves
+to a Y-model Batch (`typeName` set, `currentQuantity >= 0`), reroute the FK to the
+**oldest non-negative Batch** of the same Variety. If none has enough cover, pick
+the oldest Batch period (let it go negative — current semantic). Schema, picker, and
+UI unchanged. Pure backend behavior change inside one transaction.
+
+## Locked design decisions (vs ADRs + CONTEXT.md)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| D1 | FEFO active only when `STOCK_Y_MODEL=true` | Legacy path uses display-name string match; Variety identity isn't reliable. ADR-0007 keeps Batch-decrement model regardless. |
+| D2 | Lazy FEFO — single Batch per line, no splits | Schema `order_lines.stock_item_id` is 1:1. Splitting → multi-line shape, deferred to #283. |
+| D3 | Order: `date ASC NULLS LAST`, then `created_at ASC` | `date` column on `stock_items` is Y-model arrival date (ADR-0005). NULL `date` = legacy/untyped row, deprioritise. |
+| D4 | "Non-negative" = `current_quantity >= line.quantity` (full cover) | Pick oldest Batch that can fully cover. If none fully covers → pick oldest Batch period (will go negative — matches existing semantic that negative = shortfall signal). |
+| D5 | Variety match = exact 4-tuple, NULL-aware | Per ADR-0006. NULL `colour` ≠ `colour='Green'`. |
+| D6 | Apply at create AND edit (orderRepo.createOrder + editOrderBouquet) | Edit path also calls `adjustQuantity(stockItemId, delta)` for new/increased lines. Same drift risk. |
+| D7 | Skip for Demand Entry rows (`current_quantity < 0`) | Step 3b already routes those through `getOrCreateDemandEntry`. FEFO is for Batches only. |
+| D8 | Premade bouquet build path untouched | Under Y, builds use reservation (no Batch decrement). Sale path goes through `createOrder` → FEFO automatic. |
+| D9 | Cancel-with-return unchanged | Refund returns to whichever Batch the line was bound to post-FEFO. Correct by construction. |
+| D10 | Concurrency: `SELECT ... FOR UPDATE` on candidate Batches inside resolver | Production PG only. Pglite tests run single-connection; skip lock there per existing pattern in `getOrCreateDemandEntry`. |
+
+## Out of scope (deferred to #283)
+
+- Splitting a line across multiple Batches.
+- Migrating already-drifted `order_lines.stock_item_id` FKs to point at the right Batch (one-time backfill, separate PR).
+- Reservation model for orders (ADR-0007 explicitly defers).
+- Driver-of-day rebalancing of already-negative Batches.
+
+## Vertical slices
+
+### Slice 1 — `resolveBatchByFEFO` helper
+
+**Files:** `backend/src/repos/stockRepo.js` (+helper), `backend/src/__tests__/stockRepo.fefo.test.js` (new).
+
+**Signature:**
+```js
+export async function resolveBatchByFEFO(varietyKey, lineQty, tx) {
+  // 1. SELECT id, current_quantity, date FROM stock
+  //    WHERE type_name = :typeName
+  //      AND colour IS NOT DISTINCT FROM :colour
+  //      AND size_cm IS NOT DISTINCT FROM :sizeCm
+  //      AND cultivar IS NOT DISTINCT FROM :cultivar
+  //      AND deleted_at IS NULL
+  //      AND current_quantity >= 0          -- Batches only, not DEs
+  //    ORDER BY date ASC NULLS LAST, created_at ASC
+  //   (FOR UPDATE if production PG)
+  // 2. From the result set, pick first row with current_quantity >= lineQty
+  //    Fallback: pick first row (oldest, will go negative)
+  //    If no rows at all: return null (caller skips FEFO)
+}
+```
+
+**Tests (unit + pglite integration):**
+- Single positive Batch → returns it.
+- Two positive Batches (old short, new full) → returns NEW (full-cover wins over date).
+- Two positive Batches (old full, new full) → returns OLD (date wins when both cover).
+- Two positive Batches both short → returns OLD (fallback).
+- Mix of Batch + DE rows → DE rows skipped (only Batches considered).
+- No Batches at all → returns null.
+- NULL `colour` matches only NULL `colour` (not `''`, not `'Green'`).
+
+**LOC:** ~80 helper + ~150 test. **Files touched:** 2.
+
+### Slice 2 — wire into `orderRepo.createOrder`
+
+**Files:** `backend/src/repos/orderRepo.js`, `backend/src/__tests__/orderRepo.fefo.integration.test.js` (new).
+
+Insert FEFO routing block between line insert (current line ~597) and Y-model DE step (current line ~608). For each line whose `stockItemId` resolves to a Batch with `typeName` set and `current_quantity >= 0`:
+
+```js
+const [stockRow] = await tx.select({ ... }).from(stock).where(...).limit(1);
+if (stockRow?.typeName && stockRow.currentQuantity >= 0) {
+  const varietyKey = { typeName, colour, sizeCm, cultivar };
+  const targetId = await resolveBatchByFEFO(varietyKey, line.quantity, tx);
+  if (targetId && targetId !== line.stockItemId) {
+    await tx.update(orderLines)
+      .set({ stockItemId: targetId, updatedAt: new Date() })
+      .where(eq(orderLines.id, createdLines[i].id));
+    createdLines[i] = { ...createdLines[i], stockItemId: targetId };
+    line.stockItemId = targetId;  // so step 4 adjusts the right row
+  }
+}
+```
+
+**Tests (integration — pglite, mirrors #319 shape):**
+- Variety with 2 positive Batches (old 5/16 qty=5, new 5/18 qty=2). Picker passes new (5/18). Create order with qty=3. → 5/16 decrements to 2, 5/18 stays at 2.
+- Variety with 1 positive Batch + 1 DE → still routes to Batch (DE skipped).
+- Variety with 1 positive Batch only → no rerouting, behavior unchanged.
+- STOCK_Y_MODEL=false → no rerouting, behavior unchanged.
+
+**LOC:** ~30 wiring + ~200 test. **Files touched:** 2.
+
+### Slice 3 — wire into `orderRepo.editOrderBouquet`
+
+**Files:** `backend/src/repos/orderRepo.js`, extend `backend/src/__tests__/orderRepo.fefo.integration.test.js`.
+
+Same FEFO routing applied to:
+- New lines added via edit (lines without `id`).
+- Existing lines whose `quantity` is increased AND whose original Batch can no longer cover the new quantity (i.e. the delta would push it negative).
+
+For pure quantity decreases or unchanged lines: skip (would churn FKs needlessly).
+
+**Tests:**
+- Edit adds new line → FEFO routes it.
+- Edit increases qty on a line still covered by original Batch → no reroute.
+- Edit increases qty beyond original Batch cover → reroute (no — DEFERRED, see note below).
+
+**Note:** Re-routing an existing line on edit changes the audit trail (line started against Batch A, ends up against Batch B). Simpler v1: only route NEW lines added during edit. Existing-line quantity changes keep original FK. Deferred to a follow-up if drift is observed.
+
+**LOC:** ~20 wiring + ~80 test. **Files touched:** 1 + 1 test extension.
+
+### Slice 4 — pre-PR matrix + PR
+
+Per CLAUDE.md Pre-PR Verification:
+
+- `cd backend && npx vitest run` (unit + integration)
+- `npm run harness &` + `npm run test:e2e` (E2E suite — no shape change, smoke only)
+- `npm run lab:test:unit` + `npm run lab:test:api` (lab harness gate — backend changed)
+- No frontend touched → no `vite build` needed.
+
+PR body:
+- Closes #319 (separate line — per memory `feedback_pr_closes_syntax`).
+- Names verification path: backend vitest + lab:test:api integration test.
+- Links #283 as structural follow-up.
+
+## Cost target
+
+≤300 LOC implementation, ≤500 LOC tests, ≤4 files touched. Single Opus 5h window
+target. Sonnet implementer per task (no FEFO task touches Known Pitfall files
+listed in CLAUDE.md — stock-math helpers + StockItem.jsx/StockTab.jsx are
+read-only adjacent). Opus reviews only at end-of-feature.


### PR DESCRIPTION
## Summary

Closes #319

When `STOCK_Y_MODEL=true` and a Variety has multiple positive Batches, the bouquet picker arbitrarily passes one representative `stock_item_id`. Whichever Batch was picked got drained while siblings sat full — producing the prod Hydrangea White drift (one row at qty=-2, six untouched).

This PR adds a backend FEFO router that reroutes the order line's `stockItemId` to the oldest non-negative Batch in the same Variety at line-write time. Schema unchanged. Picker UI unchanged. Behavior change is local to `orderRepo.createOrder` (step 3a) and `orderRepo.editBouquetLines` (new-line branch).

**Tactical patch.** The structural fix lives in #283 (Stock model v1 — Demand Entries + reservation model). This PR is the unblock-the-owner-this-week half of the route (3) plan agreed in #319.

## Scope + design

Plan: [docs/superpowers/plans/2026-05-19-fefo-batch-router.md](./docs/superpowers/plans/2026-05-19-fefo-batch-router.md). Decisions stress-tested against ADR-0005 (Y-model), ADR-0006 (Variety 4-tuple), ADR-0007 (Batch decrement model retained).

- **Order:** `date ASC NULLS LAST`, then `created_at ASC` (stable tiebreak).
- **Full-cover preference:** pick the oldest Batch whose `current_quantity >= line.quantity`; fall back to the oldest Batch period if none has cover (will go negative — matches existing shortfall semantic).
- **DEs (`qty < 0`) excluded** — step 3b's `getOrCreateDemandEntry` remains the canonical DE handler.
- **NULL-aware Variety match** per ADR-0006 (empty colour ≠ `'Green'`).
- **Edit path:** new lines added during edit reroute; existing-line quantity changes do NOT reroute (preserves audit trail).
- **Legacy (`STOCK_Y_MODEL=false`):** no-op.

## Verification path

Pre-PR matrix per `CLAUDE.md` (backend + shared changes; no frontend):

- `npx vitest run` (backend): **449 passed**, 1 todo
- `npm run test:e2e` (25-section API suite): **180 passed**
- `npm run lab:test:unit`: **37 passed**
- `npm run lab:test:api`: **18 passed**

FEFO-specific coverage:
- `backend/src/__tests__/stockRepo.fefo.test.js` — 11 pglite unit tests on the resolver (full-cover / short / fallback / DE-skip / NULL-aware match / NULL-date ordering / soft-delete / #319 prod shape).
- `backend/src/__tests__/orderRepo.fefo.integration.test.js` — 8 integration tests across createOrder + editBouquetLines (happy path, fallback, newer-wins, single-Batch no-op, legacy flag-off no-op, #319 prod shape, edit-add reroute, edit-increase no-reroute).

## Test plan

- [ ] Owner sanity-check on prod after merge: place a real test order against a Variety with multiple Batches, confirm the oldest batch's audit row decrements (Railway Postgres + dashboard Stock tab).
- [ ] Watch Hydrangea White over the next 7 days — confirm no new drift accumulates on already-negative rows. New orders should drain the freshest covered Batch first.
- [ ] Verify cancel-with-return refunds the batch the line bound to post-FEFO (audit log).

## Out of scope (deferred)

- Splitting a line across multiple Batches.
- Backfill / reconciliation of already-drifted `order_lines.stock_item_id` FKs.
- Reservation model for orders (ADR-0007 defers; tracked in #283).

🤖 Generated with [Claude Code](https://claude.com/claude-code)