### PR TITLE
fix(feedback): resize report screenshot client-side; surface multer 413

### DIFF
--- a/backend/src/__tests__/feedback.publishUpload.test.js
+++ b/backend/src/__tests__/feedback.publishUpload.test.js
@@ -1,0 +1,78 @@
+// Route-level test for POST /api/feedback/publish multipart upload.
+//
+// Reproduces the 2026-05-29 incident: the owner could not create reports from
+// the dashboard. Root cause — desktop screenshots exceed multer's 5MB cap, and
+// the resulting MulterError fell through the central errorHandler as an opaque
+// 500 ("Internal server error") with no hint it was the image. The florist app
+// (phone-sized screenshots) stayed under the cap, so reports worked there.
+//
+// We mount the REAL feedback router (real multer config) + the REAL errorHandler
+// and mock only the service + auth boundaries. Asserts:
+//   • oversized image → 413 with a clear, surfaceable message (not opaque 500)
+//   • small image → publishSession called, 200 with issue url
+//   • the message survives production masking (the owner saw a masked 500)
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+vi.mock('../middleware/auth.js', () => ({
+  authorize: () => (req, _res, next) => { req.role = 'owner'; next(); },
+}));
+vi.mock('../services/feedbackService.js', () => ({
+  publishSession: vi.fn(),
+}));
+
+const feedbackService = await import('../services/feedbackService.js');
+
+async function buildApp() {
+  const app = express();
+  const routes = (await import('../routes/feedback.js')).default;
+  const { errorHandler } = await import('../middleware/errorHandler.js');
+  app.use('/api/feedback', routes);
+  app.use(errorHandler);
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv('NODE_ENV', 'production'); // reproduce the owner's prod experience
+});
+
+describe('POST /api/feedback/publish — screenshot upload', () => {
+  it('rejects an oversized screenshot with a clear 413 (not an opaque 500)', async () => {
+    feedbackService.publishSession.mockResolvedValue({ issueUrl: 'x', issueNumber: 1 });
+    const app = await buildApp();
+
+    const big = Buffer.alloc(6 * 1024 * 1024, 0); // 6MB > 5MB cap
+
+    const res = await request(app)
+      .post('/api/feedback/publish')
+      .field('sessionId', 'sess-1')
+      .attach('image', big, { filename: 'screenshot.png', contentType: 'image/png' });
+
+    expect(res.status).toBe(413);
+    expect(res.body.error).toMatch(/too large|5\s?MB/i);
+    expect(res.body.error).not.toMatch(/internal server error/i);
+    expect(feedbackService.publishSession).not.toHaveBeenCalled();
+  });
+
+  it('accepts a small screenshot and publishes the report', async () => {
+    feedbackService.publishSession.mockResolvedValue({
+      issueUrl: 'https://github.com/OliwerO/flower-studio/issues/42',
+      issueNumber: 42,
+    });
+    const app = await buildApp();
+
+    const small = Buffer.alloc(64 * 1024, 1); // 64KB
+
+    const res = await request(app)
+      .post('/api/feedback/publish')
+      .field('sessionId', 'sess-2')
+      .attach('image', small, { filename: 'shot.jpg', contentType: 'image/jpeg' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.issueNumber).toBe(42);
+    expect(feedbackService.publishSession).toHaveBeenCalledOnce();
+  });
+});

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -2,8 +2,20 @@
 // All unhandled errors land here and get a consistent JSON response.
 // Express identifies this as an error handler because it takes 4 arguments.
 
+import multer from 'multer';
+
 export function errorHandler(err, req, res, next) {
   console.error(`[ERROR] ${req.method} ${req.path}`, err);
+
+  // Multipart upload errors are safe to surface (no secrets) and must NOT be
+  // masked as a generic 500 — an opaque 500 here is what left the owner unable
+  // to file a report (oversized desktop screenshot, 2026-05-29) with no clue why.
+  if (err instanceof multer.MulterError) {
+    const message = err.code === 'LIMIT_FILE_SIZE'
+      ? 'Image too large — please attach a smaller screenshot (max 5MB).'
+      : `Upload error: ${err.message}`;
+    return res.status(413).json({ error: message });
+  }
 
   // Airtable API errors carry a statusCode
   const status = err.statusCode || err.status || 500;

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -7,6 +7,7 @@ Cross-app utilities shared by all three frontend apps. Anything used by 2+ apps 
 api/
   client.js                   → Axios instance with auto-attached PIN header + opt-in cachedGet/in-flight GET dedupe helper
   uploadImage.js              → uploadBouquetImage / removeBouquetImage (products) + uploadOrderImage / removeOrderImage (per-order override) — multipart wrappers
+  feedback.js                 → publishFeedback({ sessionId, imageFile }) — multipart POST /feedback/publish. Resizes the screenshot client-side first (5MB multer cap) like uploadImage.js. Consumed by FeedbackModal.
 context/
   AuthContext.jsx             → PIN, role, login/logout — wraps all apps
   ToastContext.jsx            → showToast(msg, type) — success/error toasts
@@ -33,7 +34,7 @@ components/
   WixPushModal.jsx            → Async-job progress modal for /products/push (florist + dashboard)
   BouquetImageEditor.jsx      → Click/paste image slot. Pass `wixProductId` for storefront product images OR `orderId` for per-order overrides. Owner-only remove via `canRemove`.
   BouquetImageView.jsx        → Read-only thumbnail with tap-to-zoom fullscreen modal for the driver delivery card
-  FeedbackModal.jsx           → AI-assisted bug/feature report modal. Drives /feedback/start → /feedback/continue → /feedback/preview → /feedback/publish conversation. Props: t, apiClient, reporterRole, reporterName, appArea, onClose. Uses inline SVG icons (no lucide-react dep).
+  FeedbackModal.jsx           → AI-assisted bug/feature report modal. Drives /feedback/start → /feedback/continue → /feedback/preview conversation, then publishes via the shared `publishFeedback` wrapper (api/feedback.js — resizes the screenshot before upload). Props: t, reporterRole, reporterName, appArea, onClose. Surfaces the backend error message on failure. Uses inline SVG icons (no lucide-react dep).
 hooks/
   useOrderEditing.js          → Shared bouquet editing logic (stock filtering, line management)
   useOrderPatching.js         → Shared order/delivery PATCH helpers (patchOrder, patchDelivery)

--- a/packages/shared/api/feedback.js
+++ b/packages/shared/api/feedback.js
@@ -1,0 +1,34 @@
+// Wraps the multipart POST /feedback/publish call.
+//
+// Resizes the screenshot client-side first to stay well under the backend's 5MB
+// multer cap. Desktop (dashboard) screenshots are large PNGs that routinely
+// exceed 5MB — sending the raw file is what blocked the owner from filing
+// reports on 2026-05-29 (the florist app's phone-sized screenshots stayed under
+// the cap, so it worked there). Mirrors api/uploadImage.js.
+
+import client from './client.js';
+import { resizeImageBlob } from '../utils/imageResize.js';
+
+export async function publishFeedback({ sessionId, imageFile }) {
+  const form = new FormData();
+  form.append('sessionId', sessionId);
+
+  if (imageFile) {
+    let blob = imageFile;
+    try {
+      // 1600px long edge keeps UI text legible while landing well under 5MB.
+      blob = await resizeImageBlob(imageFile, { maxEdge: 1600, quality: 0.85 });
+    } catch {
+      // Resize can fail on unsupported/corrupt input; fall back to the raw file.
+      // The backend now returns a clear 413 if it is still too large.
+      blob = imageFile;
+    }
+    const name = imageFile.name?.replace(/\.[^.]+$/, '.jpg') || 'screenshot.jpg';
+    form.append('image', blob, name);
+  }
+
+  const res = await client.post('/feedback/publish', form, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return res.data; // { issueUrl, issueNumber }
+}

--- a/packages/shared/components/FeedbackModal.jsx
+++ b/packages/shared/components/FeedbackModal.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback } from 'react';
 import client from '../api/client.js';
+import { publishFeedback } from '../api/feedback.js';
 
 /*
  * FeedbackModal — drives the full AI-assisted Report conversation.
@@ -71,6 +72,7 @@ export default function FeedbackModal({ t, reporterRole, reporterName, appArea, 
   const [sessionId, setSessionId] = useState(null);
   const [summary, setSummary]   = useState('');
   const [issueUrl, setIssueUrl] = useState('');
+  const [errorMsg, setErrorMsg] = useState('');
   const [loading, setLoading]   = useState(false);
   const [imageFile, setImageFile] = useState(null);
   const fileRef = useRef();
@@ -136,16 +138,11 @@ export default function FeedbackModal({ t, reporterRole, reporterName, appArea, 
   async function handlePublish() {
     setLoading(true);
     try {
-      const form = new FormData();
-      form.append('sessionId', sessionId);
-      if (imageFile) form.append('image', imageFile, imageFile.name);
-
-      await client.post('/feedback/publish', form, {
-        headers: { 'Content-Type': 'multipart/form-data' },
-      });
+      await publishFeedback({ sessionId, imageFile });
       setPhase('done');
     } catch (err) {
       console.error('[FeedbackModal] publish error', err);
+      setErrorMsg(err.response?.data?.error || '');
       setPhase('error');
     } finally {
       setLoading(false);
@@ -269,9 +266,9 @@ export default function FeedbackModal({ t, reporterRole, reporterName, appArea, 
           {/* Phase: error */}
           {phase === 'error' && (
             <div className="space-y-3">
-              <p className="text-sm text-red-500 dark:text-red-400">{t.reportError}</p>
+              <p className="text-sm text-red-500 dark:text-red-400">{errorMsg || t.reportError}</p>
               <button
-                onClick={() => { setPhase('input'); setSessionId(null); setQuestion(''); setAnswer(''); setSummary(''); setIssueUrl(''); }}
+                onClick={() => { setPhase('input'); setSessionId(null); setQuestion(''); setAnswer(''); setSummary(''); setIssueUrl(''); setErrorMsg(''); }}
                 className={btnSecondary + ' w-full'}>
                 {t.reportRetry}
               </button>

--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -58,6 +58,7 @@ export { default as BouquetImageEditor } from './components/BouquetImageEditor.j
 export { default as BouquetImageView }   from './components/BouquetImageView.jsx';
 export { resizeImageBlob }               from './utils/imageResize.js';
 export { uploadBouquetImage, removeBouquetImage } from './api/uploadImage.js';
+export { publishFeedback } from './api/feedback.js';
 export { default as BatchPickerModal } from './components/BatchPickerModal.jsx';
 export { findAllMatchingVariety } from './hooks/useOrderEditing.js';
 export { default as FeedbackModal } from './components/FeedbackModal.jsx';

--- a/packages/shared/test/feedbackApi.test.js
+++ b/packages/shared/test/feedbackApi.test.js
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+//
+// Regression guard for the 2026-05-29 incident: the owner could not publish
+// reports with a desktop screenshot because the raw file exceeded the backend
+// 5MB multer cap. publishFeedback must resize the screenshot BEFORE uploading
+// (mirrors api/uploadImage.js). If this test goes red, we've regressed to
+// shipping raw screenshots.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { postMock, resizeMock } = vi.hoisted(() => ({
+  postMock: vi.fn(),
+  resizeMock: vi.fn(),
+}));
+
+vi.mock('../api/client.js', () => ({ default: { post: postMock } }));
+vi.mock('../utils/imageResize.js', () => ({ resizeImageBlob: resizeMock }));
+
+const { publishFeedback } = await import('../api/feedback.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  postMock.mockResolvedValue({ data: { issueUrl: 'u', issueNumber: 7 } });
+});
+
+describe('publishFeedback', () => {
+  it('resizes the screenshot before uploading and sends the resized blob', async () => {
+    const resized = new Blob([new Uint8Array([1, 2, 3])], { type: 'image/jpeg' });
+    resizeMock.mockResolvedValue(resized);
+    const file = new File([new Uint8Array(10 * 1024 * 1024)], 'screenshot.png', { type: 'image/png' });
+
+    const out = await publishFeedback({ sessionId: 's1', imageFile: file });
+
+    expect(resizeMock).toHaveBeenCalledOnce();
+    expect(resizeMock.mock.calls[0][0]).toBe(file);
+    expect(resizeMock.mock.calls[0][1]).toMatchObject({ maxEdge: 1600 });
+
+    const [url, form] = postMock.mock.calls[0];
+    expect(url).toBe('/feedback/publish');
+    expect(form.get('sessionId')).toBe('s1');
+    // The uploaded blob is the small resized one (3 bytes), NOT the 10MB raw file.
+    expect(form.get('image').size).toBe(resized.size);
+    expect(form.get('image').type).toBe('image/jpeg');
+    expect(out).toEqual({ issueUrl: 'u', issueNumber: 7 });
+  });
+
+  it('uploads without an image when none is attached (no resize call)', async () => {
+    await publishFeedback({ sessionId: 's2', imageFile: null });
+
+    expect(resizeMock).not.toHaveBeenCalled();
+    const [url, form] = postMock.mock.calls[0];
+    expect(url).toBe('/feedback/publish');
+    expect(form.get('sessionId')).toBe('s2');
+    expect(form.get('image')).toBeNull();
+  });
+
+  it('falls back to the raw file if resize throws', async () => {
+    resizeMock.mockRejectedValue(new Error('decode failed'));
+    const file = new File([new Uint8Array(100)], 'shot.webp', { type: 'image/webp' });
+
+    await publishFeedback({ sessionId: 's3', imageFile: file });
+
+    const [, form] = postMock.mock.calls[0];
+    // Resize failed → the raw file (100 bytes) is uploaded as a fallback.
+    expect(form.get('image').size).toBe(file.size);
+  });
+});


### PR DESCRIPTION
## Summary
Owner could not publish Reports with a desktop screenshot from the dashboard. Raw desktop PNGs exceeded multer's 5MB cap; the resulting `MulterError` was masked by the central error handler as an opaque `500`, so the modal showed a generic error with no hint it was the image. The florist app (phone-sized screenshots) stayed under the cap, so reporting worked there.

Diagnosed via prod evidence (owner-bug-intake): pipeline healthy (owner published #336–#338, #340 today), GitHub token valid, rate limit fine, backend code unchanged across the working/failing window — the only asymmetry was the un-resized screenshot path. `FeedbackModal` was the one multipart upload missing the client-side resize that `uploadImage.js` already does.

- **New** `packages/shared/api/feedback.js` — `publishFeedback()` resizes the screenshot (1600px / q0.85) before the multipart POST, mirroring `uploadImage.js`. Falls back to the raw file if resize throws.
- `FeedbackModal.jsx` uses `publishFeedback` and surfaces the backend error message instead of a generic one.
- `errorHandler.js` maps `multer.MulterError` → clear **413** instead of opaque 500.

## Verification
- `backend/src/__tests__/feedback.publishUpload.test.js` — route-level: oversize→413 (reproduced the bug RED first), small→200. ✅
- `packages/shared/test/feedbackApi.test.js` — wrapper resizes before upload (regression guard). ✅
- Full suites: backend **458 passed**, shared **305 passed**. ✅
- Built all three apps (shared barrel reaches each): florist, dashboard, delivery. ✅

## Test plan
- [x] Backend vitest
- [x] Shared vitest
- [x] vite build florist / dashboard / delivery
- [ ] Manual: file a dashboard Report with a >5MB screenshot → publishes (resized); oversize direct upload → clear 413 message

🤖 Generated with [Claude Code](https://claude.com/claude-code)