### PR TITLE
fix(stock-y): UI polish — trace in By-Batch, DD.MM.YYYY, per-Batch +/-, tighter columns

### DIFF
--- a/apps/dashboard/src/components/StockTab.jsx
+++ b/apps/dashboard/src/components/StockTab.jsx
@@ -827,12 +827,37 @@ export default function StockTab({ initialFilter, onNavigate, isActive = true })
               </button>
             </div>
             {viewMode === 'batch' ? (
-              <BatchArrivalList
-                groups={filteredGroups}
-                reservations={reservationsMap}
-                t={t}
-                onRowClick={(stockId) => setTraceStockId(prev => prev === stockId ? null : stockId)}
-              />
+              <div className="glass-card overflow-hidden">
+                <BatchArrivalList
+                  groups={filteredGroups}
+                  reservations={reservationsMap}
+                  t={t}
+                  onRowClick={(stockId) => setTraceStockId(prev => prev === stockId ? null : stockId)}
+                />
+                {/* Inline trace panel — By Batch view sets traceStockId on row
+                    click; render the same panel here (it previously only existed
+                    in the By Variety branch, so batch-view clicks showed nothing). */}
+                {traceStockId && (
+                  <div className="px-4 py-3 bg-blue-50/60 border-t border-blue-100">
+                    <div className="flex items-center justify-between mb-2">
+                      <span className="text-xs font-semibold text-blue-700 uppercase tracking-wide">
+                        {t.batchTraceTitle}
+                      </span>
+                      <button
+                        onClick={() => { setTraceStockId(null); setTraceTrail(null); }}
+                        className="text-xs text-blue-400 hover:text-blue-600"
+                      >
+                        ✕
+                      </button>
+                    </div>
+                    {traceLoading ? (
+                      <p className="text-xs text-ios-tertiary">{t.loading}</p>
+                    ) : (
+                      <BatchTracePanel trail={traceTrail || []} t={t} />
+                    )}
+                  </div>
+                )}
+              </div>
             ) : (
             <div className="glass-card overflow-hidden">
               {Array.from(typeGroups.entries()).map(([typeName, typeRows]) => {

--- a/apps/dashboard/src/components/StockTab.jsx
+++ b/apps/dashboard/src/components/StockTab.jsx
@@ -215,6 +215,23 @@ export default function StockTab({ initialFilter, onNavigate, isActive = true })
     }
   }
 
+  // Y-model quick-adjust: qty lives on the per-Batch row inside `groups`, not the
+  // legacy flat `stock` array. Optimistically bump the matching row's
+  // current_quantity, POST the delta, revert on failure.
+  async function adjustGroupQty(id, delta) {
+    const bump = (rows, d) =>
+      (rows || []).map(r =>
+        r.id === id ? { ...r, current_quantity: (Number(r.current_quantity) || 0) + d } : r
+      );
+    setGroups(prev => prev.map(g => ({ ...g, rows: bump(g.rows, delta) })));
+    try {
+      await client.post(`/stock/${id}/adjust`, { delta });
+    } catch {
+      setGroups(prev => prev.map(g => ({ ...g, rows: bump(g.rows, -delta) })));
+      showToast(t.error, 'error');
+    }
+  }
+
   async function patchStock(id, fields) {
     try {
       await client.patch(`/stock/${id}`, fields);
@@ -893,6 +910,7 @@ export default function StockTab({ initialFilter, onNavigate, isActive = true })
                           onToggle={() => setExpandedKey(k => k === group.key ? null : group.key)}
                           onRowClick={(stockId) => setTraceStockId(prev => prev === stockId ? null : stockId)}
                           onWriteOff={(v) => setWriteOffVariety(v)}
+                          onAdjust={adjustGroupQty}
                           premadesByStockId={premadesByStockId}
                           t={t}
                         />

--- a/apps/florist/src/pages/StockPanelPage.jsx
+++ b/apps/florist/src/pages/StockPanelPage.jsx
@@ -129,6 +129,22 @@ export default function StockPanelPage() {
     } catch (err) { showToast(err.response?.data?.error || t.adjustError, 'error'); }
   }
 
+  // Y-model quick-adjust: qty lives on the per-Batch row inside `groups`.
+  // Optimistically bump current_quantity, POST the delta, revert on failure.
+  async function handleAdjustGroup(id, delta) {
+    const bump = (rows, d) =>
+      (rows || []).map(r =>
+        r.id === id ? { ...r, current_quantity: (Number(r.current_quantity) || 0) + d } : r
+      );
+    setGroups(prev => prev.map(g => ({ ...g, rows: bump(g.rows, delta) })));
+    try {
+      await client.post(`/stock/${id}/adjust`, { delta });
+    } catch (err) {
+      setGroups(prev => prev.map(g => ({ ...g, rows: bump(g.rows, -delta) })));
+      showToast(err.response?.data?.error || t.adjustError, 'error');
+    }
+  }
+
   async function handleWriteOff(id, quantity, reason) {
     try {
       const res = await client.post(`/stock/${id}/write-off`, { quantity, reason: reason || undefined });
@@ -560,6 +576,7 @@ export default function StockPanelPage() {
                           onToggle={() => setExpandedKey(k => k === group.key ? null : group.key)}
                           onRowClick={(stockId) => setTraceStockId(stockId)}
                           onWriteOff={(v) => setWriteOffVariety(v)}
+                          onAdjust={handleAdjustGroup}
                           premadesByStockId={premadesByStockId}
                           t={t}
                         />

--- a/packages/shared/components/BatchArrivalList.jsx
+++ b/packages/shared/components/BatchArrivalList.jsx
@@ -14,11 +14,12 @@
  */
 import { useMemo, useState } from 'react';
 
-// Right-side numeric columns kept compact so Variety identity (the column the
-// owner scans for at a glance) keeps real room on tablet widths. Below ~640px
-// the row reflows: Variety drops onto a second line under Type, all numeric
-// columns stay in a single tight row.
-const GRID_COLS = 'grid-cols-[6rem_minmax(0,1fr)_3.75rem_3.5rem_3rem_3rem_3rem_4.5rem]';
+// Variety identity is BOUNDED (not 1fr): a greedy 1fr left a wide empty cell
+// between the variety name and the batch tag, so the eye couldn't connect a
+// flower to its batch/cost/sell at a glance. Bounding Variety lets identity →
+// tag → cost → sell cluster tightly on the left; the flexible slack goes to
+// Supplier (rightmost, least-scanned), which truncates.
+const GRID_COLS = 'grid-cols-[5rem_minmax(6rem,12rem)_3.5rem_3.25rem_3rem_3rem_3rem_minmax(4rem,1fr)]';
 
 const COLS = [
   { key: 'type',       label: 'type',       align: 'left'   },
@@ -72,7 +73,7 @@ export default function BatchArrivalList({ groups, reservations = new Map(), t, 
 
   return (
     <div data-testid="batch-arrival-list" className="ios-card overflow-hidden">
-      <div className={`grid ${GRID_COLS} gap-2 px-4 py-2 text-[10px] uppercase tracking-wide bg-gray-50 border-b border-gray-100 select-none`}>
+      <div className={`grid ${GRID_COLS} gap-1.5 px-4 py-2 text-[10px] uppercase tracking-wide bg-gray-50 border-b border-gray-100 select-none`}>
         {COLS.map(c => {
           const active = sortKey === c.key;
           const arrow = active ? (sortDir === 'asc' ? '↑' : '↓') : '';
@@ -113,7 +114,7 @@ function BatchRow({ b, t, onRowClick }) {
         type="button"
         data-testid="batch-arrival-row"
         onClick={() => onRowClick && onRowClick(b.id)}
-        className={`w-full grid ${GRID_COLS} gap-2 px-4 py-2 text-sm text-left items-baseline active:bg-gray-50 transition-colors`}
+        className={`w-full grid ${GRID_COLS} gap-1.5 px-4 py-2 text-sm text-left items-baseline active:bg-gray-50 transition-colors`}
       >
         <span className="font-semibold text-gray-900 truncate">
           {b.type || '—'}

--- a/packages/shared/components/BatchTracePanel.jsx
+++ b/packages/shared/components/BatchTracePanel.jsx
@@ -1,3 +1,5 @@
+import { formatDateDMY } from '../utils/formatDate.js';
+
 /**
  * BatchTracePanel — presentational component rendering the per-batch usage trail.
  * Used directly by dashboard (inline). Mounted inside BatchTraceModal by florist.
@@ -6,6 +8,10 @@
  *   trail  — array of trace events from /stock/:id/usage response
  *   t      — translation strings (traceTypeOrder, traceTypeWriteoff, traceTypePurchase,
  *             traceTypePremade, traceEmpty, stems)
+ *
+ * Sort: chronological oldest → newest so the column reads top-to-bottom as
+ * time progresses. Undated events (e.g. ongoing premade reservations) sort to
+ * the bottom as "current". Dates render day-month-year (formatDateDMY).
  */
 export default function BatchTracePanel({ trail = [], t }) {
   if (!trail || trail.length === 0) {
@@ -14,9 +20,17 @@ export default function BatchTracePanel({ trail = [], t }) {
     );
   }
 
+  const sorted = [...trail].sort((a, b) => {
+    // Undated entries last; otherwise ascending by ISO date string.
+    if (!a.date && !b.date) return 0;
+    if (!a.date) return 1;
+    if (!b.date) return -1;
+    return a.date.localeCompare(b.date);
+  });
+
   return (
     <ul className="divide-y divide-gray-50 bg-white rounded-lg border border-gray-100 overflow-hidden max-h-64 overflow-y-auto">
-      {trail.map((entry, i) => (
+      {sorted.map((entry, i) => (
         <TraceRow key={i} entry={entry} t={t} />
       ))}
     </ul>
@@ -80,7 +94,7 @@ function TraceRow({ entry, t }) {
       </div>
       <div className="flex items-center gap-2 shrink-0 ml-2">
         {entry.date && (
-          <span className="text-[10px] text-gray-400">{entry.date}</span>
+          <span className="text-[10px] text-gray-400">{formatDateDMY(entry.date)}</span>
         )}
         <span className={`text-xs font-semibold tabular-nums ${qty > 0 ? 'text-green-600' : 'text-red-600'}`}>
           {qty > 0 ? '+' : ''}{qty} {t.stems}

--- a/packages/shared/components/VarietyListItem.jsx
+++ b/packages/shared/components/VarietyListItem.jsx
@@ -38,6 +38,7 @@ export default function VarietyListItem({
   onRowClick,
   onBatchClick, // legacy alias
   onWriteOff,
+  onAdjust, // (stockId, delta) — per-Batch quick-adjust; only rendered on Batch rows
   premadesByStockId,
   t,
 }) {
@@ -175,32 +176,57 @@ export default function VarietyListItem({
 
               const isDemand = kind === 'demand';
               const rowClass = isDemand
-                ? 'w-full flex items-center justify-between px-6 py-2 text-sm text-red-700 bg-red-50 hover:bg-red-100 transition-colors active:bg-red-100'
-                : 'w-full flex items-center justify-between px-6 py-2 text-sm text-gray-700 hover:bg-gray-100 transition-colors active:bg-gray-100';
+                ? 'w-full flex items-center justify-between px-6 py-2 text-sm text-red-700 bg-red-50'
+                : 'w-full flex items-center justify-between px-6 py-2 text-sm text-gray-700';
+              const showAdjust = !!onAdjust && !isDemand;
 
               return (
-                <li key={row.id}>
+                <li key={row.id} className={rowClass} data-row-kind={kind}>
                   <button
                     type="button"
                     data-testid="stock-item-row"
                     data-row-kind={kind}
                     onClick={() => handleRowClick && handleRowClick(row.id)}
-                    className={rowClass}
+                    className={`flex items-center gap-2 min-w-0 flex-1 text-left rounded transition-colors ${
+                      isDemand ? 'hover:bg-red-100 active:bg-red-100' : 'hover:bg-gray-100 active:bg-gray-100'
+                    }`}
                   >
-                    <span className="flex items-center gap-2">
-                      <span
-                        className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
-                          isDemand ? 'bg-red-100 text-red-700' : 'bg-gray-200 text-gray-700'
-                        }`}
-                      >
-                        {kindLabel}
-                      </span>
-                      <span className="text-gray-500">{dateLabel}</span>
+                    <span
+                      className={`text-[10px] font-medium px-1.5 py-0.5 rounded ${
+                        isDemand ? 'bg-red-100 text-red-700' : 'bg-gray-200 text-gray-700'
+                      }`}
+                    >
+                      {kindLabel}
                     </span>
+                    <span className="text-gray-500">{dateLabel}</span>
+                  </button>
+                  <span className="flex items-center gap-2 shrink-0 ml-2">
+                    {showAdjust && (
+                      <span className="flex items-center gap-1">
+                        <button
+                          type="button"
+                          data-testid="variety-adjust-dec"
+                          onClick={(e) => { e.stopPropagation(); onAdjust(row.id, -1); }}
+                          className="w-6 h-6 flex items-center justify-center rounded-full bg-gray-200 text-gray-700 text-sm leading-none active:bg-gray-300"
+                          aria-label={t.decrease ?? 'Remove one stem'}
+                        >
+                          −
+                        </button>
+                        <button
+                          type="button"
+                          data-testid="variety-adjust-inc"
+                          onClick={(e) => { e.stopPropagation(); onAdjust(row.id, 1); }}
+                          className="w-6 h-6 flex items-center justify-center rounded-full bg-gray-200 text-gray-700 text-sm leading-none active:bg-gray-300"
+                          aria-label={t.increase ?? 'Add one stem'}
+                        >
+                          +
+                        </button>
+                      </span>
+                    )}
                     <span className="tabular-nums">
                       {absQty} {t.stems} ›
                     </span>
-                  </button>
+                  </span>
                 </li>
               );
             })}

--- a/packages/shared/components/VarietyListItem.jsx
+++ b/packages/shared/components/VarietyListItem.jsx
@@ -26,6 +26,7 @@
  */
 import { useState } from 'react';
 import { getVarietyTotals } from '../utils/stockMath.js';
+import { formatDateDMY } from '../utils/formatDate.js';
 import VarietyIdentity from './VarietyIdentity.jsx';
 
 export default function VarietyListItem({
@@ -170,7 +171,7 @@ export default function VarietyListItem({
               const kind = row.current_quantity < 0 ? 'demand' : 'batch';
               const absQty = Math.abs(row.current_quantity);
               const kindLabel = kind === 'batch' ? (t.batchKind ?? 'Batch') : (t.demandKind ?? 'Demand');
-              const dateLabel = row.date ?? '—';
+              const dateLabel = row.date ? formatDateDMY(row.date) : '—';
 
               const isDemand = kind === 'demand';
               const rowClass = isDemand

--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -3,6 +3,7 @@ export { default as useOrderPatching } from './hooks/useOrderPatching.js';
 export { default as useLongPress } from './hooks/useLongPress.js';
 export { default as useDebouncedValue } from './hooks/useDebouncedValue.js';
 export { default as parseBatchName } from './utils/parseBatchName.js';
+export { formatDateDMY } from './utils/formatDate.js';
 export { getAvailableSlots } from './utils/timeSlots.js';
 export { renderStockName, stockBaseName, renderDateTag } from './utils/stockName.jsx';
 export { ToastProvider, useToast } from './context/ToastContext.jsx';

--- a/packages/shared/test/BatchTracePanel.test.jsx
+++ b/packages/shared/test/BatchTracePanel.test.jsx
@@ -48,7 +48,20 @@ describe('BatchTracePanel', () => {
     ];
     render(<BatchTracePanel trail={trail} t={t} />);
     const rows = screen.getAllByTestId('trace-row');
-    expect(rows[0]).toHaveAttribute('data-trace-kind', 'order');
-    expect(rows[1]).toHaveAttribute('data-trace-kind', 'writeoff');
+    // Sorted chronologically oldest → newest, so the 05-09 writeoff precedes
+    // the 05-10 order regardless of input order.
+    expect(rows[0]).toHaveAttribute('data-trace-kind', 'writeoff');
+    expect(rows[1]).toHaveAttribute('data-trace-kind', 'order');
+  });
+
+  it('sorts events chronologically oldest → newest, undated last', () => {
+    const trail = [
+      { type: 'order',    date: '2026-05-10', qty: 5 },
+      { type: 'premade',  date: null,         qty: 3 },
+      { type: 'purchase', date: '2026-05-08', qty: 30 },
+    ];
+    render(<BatchTracePanel trail={trail} t={t} />);
+    const kinds = screen.getAllByTestId('trace-row').map(r => r.getAttribute('data-trace-kind'));
+    expect(kinds).toEqual(['purchase', 'order', 'premade']);
   });
 });

--- a/packages/shared/test/VarietyListItem.test.jsx
+++ b/packages/shared/test/VarietyListItem.test.jsx
@@ -108,10 +108,10 @@ describe('VarietyListItem expansion', () => {
     expect(screen.queryAllByTestId('stock-item-row')).toHaveLength(0);
   });
 
-  it('row label includes (date) suffix per ADR-0006', () => {
+  it('row label includes (date) suffix per ADR-0006, formatted DD.MM.YYYY', () => {
     render(<VarietyListItem variety={v} reservations={new Map()} t={t}
       hideType={true} expanded={true} onToggle={() => {}} />);
-    expect(screen.getByText(/2026-05-10/)).toBeInTheDocument();
+    expect(screen.getByText(/10\.05\.2026/)).toBeInTheDocument();
   });
 
   it('Demand Entry rows are visually distinct (data-row-kind="demand")', () => {
@@ -150,6 +150,51 @@ describe('VarietyListItem expansion', () => {
     const batches = screen.getAllByTestId('stock-item-row').filter(r => r.getAttribute('data-row-kind') === 'batch');
     fireEvent.click(batches[0]);
     expect(onBatchClick).toHaveBeenCalledWith('b1');
+  });
+});
+
+describe('VarietyListItem per-Batch quick-adjust', () => {
+  const v = {
+    key: 'Rose|Pink|60|',
+    type_name: 'Rose', colour: 'Pink', size_cm: 60, cultivar: null,
+    rows: [
+      { id: 'b1', current_quantity: 10, date: '2026-05-10' },
+      { id: 'b2', current_quantity:  5, date: '2026-05-11' },
+      { id: 'd1', current_quantity: -3, date: '2026-05-12' },
+    ],
+  };
+
+  it('renders no +/- controls when onAdjust is absent', () => {
+    render(<VarietyListItem variety={v} reservations={new Map()} t={t}
+      hideType={true} expanded={true} onToggle={() => {}} />);
+    expect(screen.queryAllByTestId('variety-adjust-inc')).toHaveLength(0);
+    expect(screen.queryAllByTestId('variety-adjust-dec')).toHaveLength(0);
+  });
+
+  it('renders +/- on Batch rows only, never on Demand rows', () => {
+    render(<VarietyListItem variety={v} reservations={new Map()} t={t}
+      hideType={true} expanded={true} onToggle={() => {}} onAdjust={() => {}} />);
+    // 2 Batch rows → 2 inc + 2 dec; the Demand row gets none.
+    expect(screen.getAllByTestId('variety-adjust-inc')).toHaveLength(2);
+    expect(screen.getAllByTestId('variety-adjust-dec')).toHaveLength(2);
+  });
+
+  it('clicking + fires onAdjust(stockId, +1) without firing onRowClick', () => {
+    const onAdjust = vi.fn();
+    const onRowClick = vi.fn();
+    render(<VarietyListItem variety={v} reservations={new Map()} t={t}
+      hideType={true} expanded={true} onToggle={() => {}} onAdjust={onAdjust} onRowClick={onRowClick} />);
+    fireEvent.click(screen.getAllByTestId('variety-adjust-inc')[0]);
+    expect(onAdjust).toHaveBeenCalledWith('b1', 1);
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it('clicking - fires onAdjust(stockId, -1)', () => {
+    const onAdjust = vi.fn();
+    render(<VarietyListItem variety={v} reservations={new Map()} t={t}
+      hideType={true} expanded={true} onToggle={() => {}} onAdjust={onAdjust} />);
+    fireEvent.click(screen.getAllByTestId('variety-adjust-dec')[0]);
+    expect(onAdjust).toHaveBeenCalledWith('b1', -1);
   });
 });
 

--- a/packages/shared/test/formatDate.test.js
+++ b/packages/shared/test/formatDate.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { formatDateDMY } from '../utils/formatDate.js';
+
+describe('formatDateDMY', () => {
+  it('formats an ISO date as DD.MM.YYYY', () => {
+    expect(formatDateDMY('2026-05-07')).toBe('07.05.2026');
+    expect(formatDateDMY('2026-12-31')).toBe('31.12.2026');
+  });
+
+  it('truncates an ISO timestamp to the date part', () => {
+    expect(formatDateDMY('2026-05-07T10:00:00Z')).toBe('07.05.2026');
+  });
+
+  it('returns empty string for null/undefined/empty', () => {
+    expect(formatDateDMY(null)).toBe('');
+    expect(formatDateDMY(undefined)).toBe('');
+    expect(formatDateDMY('')).toBe('');
+  });
+
+  it('returns the input unchanged when not a recognisable ISO date', () => {
+    expect(formatDateDMY('14.May.')).toBe('14.May.');
+    expect(formatDateDMY('not a date')).toBe('not a date');
+  });
+});

--- a/packages/shared/utils/formatDate.js
+++ b/packages/shared/utils/formatDate.js
@@ -1,0 +1,17 @@
+// Format an ISO date (YYYY-MM-DD) as day-month-year with dot separators —
+// the convention used across the Blossom UI (matches the batch tag style
+// "14.May."). Returns the input unchanged if it is not a recognisable ISO date.
+//
+// Examples:
+//   formatDateDMY('2026-05-07') → '07.05.2026'
+//   formatDateDMY('2026-05-07T10:00:00Z') → '07.05.2026'
+//   formatDateDMY(null) → ''
+export function formatDateDMY(value) {
+  if (!value) return '';
+  const iso = String(value).slice(0, 10);
+  const m = iso.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) return String(value);
+  return `${m[3]}.${m[2]}.${m[1]}`;
+}
+
+export default formatDateDMY;


### PR DESCRIPTION
## Summary
Owner-UAT polish for the Y-model Stock UI (all behind `STOCK_Y_MODEL`, off in prod). Follows #343 (#327), now rebased onto master. (Supersedes #344, auto-closed when its stacked base branch was deleted on #343 merge.)

- **Trace in By-Batch view** — the inline `BatchTracePanel` only rendered in the By-Variety branch, so By-Batch row clicks showed nothing. Now rendered in both.
- **DD.MM.YYYY dates** — new `formatDateDMY` shared util; wired into `BatchTracePanel` + `VarietyListItem` sub-rows (was raw ISO).
- **Chronological trace sort** — oldest → newest, undated entries last.
- **Per-Batch +/- quick-adjust** — re-adds the legacy quick-adjust, now on the expanded Batch sub-rows (qty is per-Batch in the Y-model). Groups-aware optimistic adjust in both `StockTab` (dashboard) and `StockPanelPage` (florist).
- **Tighter By-Batch columns** — Variety was `minmax(0,1fr)` (greedy, left a dead gap before the batch tag); bounded it and moved slack to Supplier so identity → tag → cost → sell cluster and scan at a glance.

## Verification
- Shared vitest **314 pass** (added per-Batch adjust + chronological-sort tests; fixed two assertions left stale by the date/sort changes).
- All three app builds green (florist / dashboard / delivery).
- Browser-verified in lab (`STOCK_Y_MODEL=true`): +/- adjusts 18→19 without firing trace; By-Batch columns cluster correctly.

## For the owner
On the stock screen: tap a flower to expand its batches, then use − / + to correct a batch's count on the spot. Dates now read day.month.year, the batch history reads top-to-bottom oldest-first, and the "By Batch" table is packed tighter so you can scan name → batch → cost → price at a glance.

Refs #324