### PR TITLE
chore(stock): #329 Variety-backfill tooling (Tier-1 proposal + Tier-2 soft-delete)

### DIFF
--- a/backend/scripts/propose_variety_backfill.mjs
+++ b/backend/scripts/propose_variety_backfill.mjs
@@ -1,0 +1,110 @@
+// SAFE — read-only via claude_ro DSN. #329 Tier-1 mapping proposal.
+//
+// Proposes Variety 4-tuple attrs for the rows that MUST be backfilled before
+// the Y-model cutover (#291): NULL type_name AND not deleted AND
+// (nonzero qty OR active-order consumer OR premade reservation).
+//
+// Two sources per row, in priority order:
+//   1. Authoritative — a stock_order_line (PO line, #304) linked by stock_id
+//      that carries non-null Variety attrs. Owner already entered these.
+//   2. Heuristic — parse display_name (strip date suffix, first token = Type
+//      with synonym normalization, colour lexicon, remainder = cultivar).
+//
+// Output: a review table + a JSON array the owner can approve in the Variety
+// Backfill UI (or feed to PATCH /stock/variety-attrs/bulk). NEVER writes.
+//
+// Run: CLAUDE_RO_URL=... node backend/scripts/propose_variety_backfill.mjs
+import pg from 'pg';
+
+const TYPE_SYNONYMS = {
+  paeonia: 'Peony', peony: 'Peony', peonies: 'Peony',
+  rosa: 'Rose', rose: 'Rose',
+  hydrangea: 'Hydrangea',
+  oxypetalum: 'Oxypetalum',
+  freesia: 'Freesia',
+  dianthus: 'Dianthus',
+  lisianthus: 'Lisianthus',
+  matthiola: 'Matthiola',
+  syringa: 'Syringa',
+  antirrhinum: 'Antirrhinum',
+  tulip: 'Tulip', tulipa: 'Tulip',
+};
+const COLOURS = ['pink', 'white', 'blue', 'red', 'lavender', 'lilac', 'green',
+  'yellow', 'coral', 'orange', 'purple', 'cream', 'peach', 'mix'];
+
+function titleCase(s) { return s ? s.charAt(0).toUpperCase() + s.slice(1).toLowerCase() : s; }
+
+function parseName(name) {
+  // Strip a trailing "(DD.Mon.)" date tag.
+  const base = name.replace(/\s*\(\d{1,2}\.\w{3,4}\.?\)\s*$/, '').trim();
+  const tokens = base.split(/\s+/);
+  const lower = tokens.map(t => t.toLowerCase());
+
+  // Type = first token, normalized via synonyms (else title-cased first token).
+  const typeRaw = lower[0];
+  const type = TYPE_SYNONYMS[typeRaw] ?? titleCase(tokens[0]);
+
+  // Colour = first lexicon hit anywhere after the type token.
+  let colour = null, colourIdx = -1;
+  for (let i = 1; i < lower.length; i++) {
+    if (COLOURS.includes(lower[i])) { colour = titleCase(tokens[i]); colourIdx = i; break; }
+  }
+
+  // Cultivar = remaining middle tokens (between type and colour, or after type
+  // if no colour), title-cased. Heuristic — owner must confirm.
+  const rest = tokens.slice(1).filter((_, i) => (i + 1) !== colourIdx);
+  const cultivar = rest.length ? rest.map(titleCase).join(' ') : null;
+
+  const known = !!TYPE_SYNONYMS[typeRaw];
+  const confidence = known && colour ? 'med' : known ? 'low' : 'low';
+  return { type, colour, size_cm: null, cultivar, confidence };
+}
+
+const c = new pg.Client({ connectionString: process.env.CLAUDE_RO_URL, ssl: { rejectUnauthorized: false } });
+await c.connect();
+
+const rows = await c.query(`
+  WITH n AS (SELECT id, display_name, current_quantity FROM stock WHERE type_name IS NULL AND deleted_at IS NULL)
+  SELECT DISTINCT n.id, n.display_name, n.current_quantity
+  FROM n
+  WHERE n.current_quantity <> 0
+     OR EXISTS (SELECT 1 FROM order_lines ol JOIN orders o ON o.id = ol.order_id
+                WHERE ol.stock_item_id = n.id::text AND ol.deleted_at IS NULL AND o.deleted_at IS NULL
+                  AND o.status NOT IN ('Delivered','Picked Up','Cancelled'))
+     OR EXISTS (SELECT 1 FROM premade_bouquet_lines pl WHERE pl.stock_id = n.id)
+  ORDER BY n.current_quantity
+`);
+
+const proposals = [];
+for (const r of rows.rows) {
+  // Authoritative source: a PO line linked by stock_id with non-null attrs.
+  const po = await c.query(
+    `SELECT type_name, colour, size_cm, cultivar FROM stock_order_lines
+     WHERE stock_id = $1 AND type_name IS NOT NULL
+     ORDER BY id DESC LIMIT 1`, [r.id]);
+  let proposal, source;
+  if (po.rows[0]) {
+    const p = po.rows[0];
+    proposal = { type: p.type_name, colour: p.colour, size_cm: p.size_cm, cultivar: p.cultivar, confidence: 'high' };
+    source = 'PO-line';
+  } else {
+    proposal = parseName(r.display_name);
+    source = 'name-parse';
+  }
+  proposals.push({ id: r.id, display_name: r.display_name, qty: r.current_quantity, source, ...proposal });
+}
+
+console.log(`\n#329 Tier-1 proposals (${proposals.length} rows that MUST be backfilled):\n`);
+console.log('qty  | conf | source     | proposed Type|Colour|Size|Cultivar         <= display_name');
+console.log('-----|------|------------|--------------------------------------------------------------');
+for (const p of proposals) {
+  const key = [p.type ?? '', p.colour ?? '', p.size_cm ?? '', p.cultivar ?? ''].join('|');
+  console.log(
+    String(p.qty).padStart(4), '|',
+    (p.confidence ?? '').padEnd(4), '|',
+    p.source.padEnd(10), '|',
+    key.padEnd(38), '<=', p.display_name);
+}
+console.log('\n--- JSON (for owner review / bulk apply) ---');
+console.log(JSON.stringify(proposals, null, 2));
+await c.end();

--- a/backend/scripts/soft_delete_cleared_null_rows.mjs
+++ b/backend/scripts/soft_delete_cleared_null_rows.mjs
@@ -1,0 +1,84 @@
+// DESTRUCTIVE — mutates prod Railway PG when run with --apply.
+// Requires explicit owner approval phrase. Dry-run is the default.
+//
+// #329 Tier-2: soft-delete the cleared dead Stock rows that block the Y-model
+// cutover (#291) — rows with NULL type_name that carry no live signal:
+//   type_name IS NULL AND deleted_at IS NULL AND current_quantity = 0
+//   AND no active (non-terminal) order consumer
+//   AND no premade reservation line.
+// These are spent historical Batches. Soft-deleting (deleted_at = now()) drops
+// them from /stock?grouped=true and the cutover's "NULL count = 0" gate WITHOUT
+// inventing Variety attrs for flowers no longer in play. Reversible (sets a
+// timestamp; recover with deleted_at = NULL). Trace-by-id still resolves for
+// any past order that referenced them (the usage join does not re-read the
+// stock row's deleted_at).
+//
+// Tier-1 rows (nonzero qty / active order / premade) are EXCLUDED here — they
+// are backfilled with real Variety attrs via the Variety Backfill UI instead
+// (see propose_variety_backfill.mjs).
+//
+// Usage:
+//   Dry-run (default, read-only):
+//     CLAUDE_RO_URL=... node backend/scripts/soft_delete_cleared_null_rows.mjs
+//   Live apply (owner-approved, needs WRITE DSN):
+//     DATABASE_URL=<write> node backend/scripts/soft_delete_cleared_null_rows.mjs \
+//       --apply --confirm "SOFT DELETE 329 CLEARED ROWS"
+import pg from 'pg';
+
+const APPROVAL = 'SOFT DELETE 329 CLEARED ROWS';
+const apply = process.argv.includes('--apply');
+const confirmIdx = process.argv.indexOf('--confirm');
+const confirmPhrase = confirmIdx >= 0 ? process.argv[confirmIdx + 1] : null;
+
+const SELECT_CLEARED = `
+  SELECT id, display_name
+  FROM stock s
+  WHERE s.type_name IS NULL
+    AND s.deleted_at IS NULL
+    AND s.current_quantity = 0
+    AND NOT EXISTS (
+      SELECT 1 FROM order_lines ol JOIN orders o ON o.id = ol.order_id
+      WHERE ol.stock_item_id = s.id::text AND ol.deleted_at IS NULL AND o.deleted_at IS NULL
+        AND o.status NOT IN ('Delivered','Picked Up','Cancelled'))
+    AND NOT EXISTS (
+      SELECT 1 FROM premade_bouquet_lines pl WHERE pl.stock_id = s.id)
+  ORDER BY s.display_name
+`;
+
+if (!apply) {
+  const dsn = process.env.CLAUDE_RO_URL || process.env.DATABASE_URL;
+  const c = new pg.Client({ connectionString: dsn, ssl: { rejectUnauthorized: false } });
+  await c.connect();
+  const r = await c.query(SELECT_CLEARED);
+  console.log(`\n[DRY-RUN] ${r.rows.length} cleared NULL-type rows WOULD be soft-deleted:\n`);
+  for (const row of r.rows) console.log('  ', row.display_name);
+  console.log(`\nNo changes made. To apply: --apply --confirm "${APPROVAL}" with a WRITE DATABASE_URL.`);
+  await c.end();
+  process.exit(0);
+}
+
+// ── Live apply path ──
+if (process.env.NODE_ENV === 'production') {
+  console.error('Refusing: do not run with NODE_ENV=production set locally; pass the prod DATABASE_URL explicitly instead.');
+  process.exit(1);
+}
+if (confirmPhrase !== APPROVAL) {
+  console.error(`Refusing: --apply requires --confirm "${APPROVAL}". Got: ${JSON.stringify(confirmPhrase)}`);
+  process.exit(1);
+}
+if (!process.env.DATABASE_URL) {
+  console.error('Refusing: --apply needs a WRITE DATABASE_URL (claude_ro cannot write).');
+  process.exit(1);
+}
+
+const c = new pg.Client({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+await c.connect();
+const r = await c.query(`
+  UPDATE stock SET deleted_at = now()
+  WHERE id IN (SELECT id FROM (${SELECT_CLEARED}) sub)
+  RETURNING id, display_name
+`);
+console.log(`[APPLIED] Soft-deleted ${r.rows.length} cleared NULL-type rows.`);
+for (const row of r.rows) console.log('  ', row.display_name);
+console.log('\nVerify: SELECT count(*) FROM stock WHERE type_name IS NULL AND deleted_at IS NULL;');
+await c.end();


### PR DESCRIPTION
## Summary
Tooling to clear the **160** NULL-`type_name` Stock rows that block the Y-model cutover (#291). Splits the set by live signal — no auto-invented Varieties for dead flowers.

| Tier | Rows | Action | Script |
|------|------|--------|--------|
| **1 — live** | 11 | owner backfills real attrs (nonzero qty / active order / premade) | `propose_variety_backfill.mjs` (SAFE, read-only) |
| **2 — cleared** | 149 | soft-delete (qty=0, no consumer, no premade) | `soft_delete_cleared_null_rows.mjs` (DESTRUCTIVE, dry-run default) |

11 + 149 = 160 → after both, `SELECT count(*) FROM stock WHERE type_name IS NULL AND deleted_at IS NULL` = **0** (the #291 gate).

## Why
`#327` fixed Variety-attr propagation for *new* receives; these 160 legacy rows stay NULL until cleared. Under `STOCK_Y_MODEL=true`, `listGroupedByVariety` filters `type_name IS NOT NULL`, so a NULL row is invisible in the grouped view — the #323 mechanism, repo-wide. This is a hard cutover blocker.

## propose_variety_backfill.mjs (SAFE)
Read-only. For each Tier-1 row: prefers authoritative PO-line attrs (#304); else a name-parse heuristic (Type-synonym normalized — `Paeonia→Peony`, `Rosa→Rose`; colour lexicon) with a `high/med/low` confidence flag. Emits a review table + JSON for the owner to approve in the Variety Backfill UI or feed to `PATCH /stock/variety-attrs/bulk`. **Owner must confirm** — names are inconsistent free-text (e.g. `Coral Peonies` parses Type=Coral, flagged low; a PO line shows a Pink-vs-Coral colour conflict).

## soft_delete_cleared_null_rows.mjs (DESTRUCTIVE)
Dry-run by default (uses `CLAUDE_RO_URL`). Live run needs `--apply --confirm "SOFT DELETE 329 CLEARED ROWS"` **and** a write `DATABASE_URL`; refuses otherwise and refuses under `NODE_ENV=production`. Sets `deleted_at = now()` — reversible. Trace-by-id still resolves for past orders (the usage join doesn't re-read the stock row's `deleted_at`).

## Verification
- Both scripts dry-run clean against prod (`claude_ro`): Tier-1 = 11 rows, Tier-2 = 149 rows, partition exact (= 160 total).
- No app/src code touched — standalone `backend/scripts/` tooling, SAFE/DESTRUCTIVE headers per the script taxonomy. No test/build impact.

## Owner actions (not done by this PR)
1. Review the Tier-1 proposal, approve/correct the 11 rows in the Variety Backfill tab.
2. Approve the Tier-2 live run (`--apply` with a write DSN) — ideally close to the #291 window so the backlog doesn't refill (NULL count grew 141→160 in 3 days via flag-off paths; #330 is one remaining source).

Refs #329 #291