### PR TITLE
fix(premade): split editPremadeBouquetLines into Y-model + legacy paths (#330)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Review this entire file before flipping to production.
 
 ---
 
+## 2026-05-30 — Premade edit path joins the Y-model reservation model (#330)
+
+Closes the last unsplit flag-off/flag-on path in `premadeBouquetService`. `editPremadeBouquetLines` was unconditionally calling `stockRepo.adjustQuantity` on add / qty-change / remove — under `STOCK_Y_MODEL=true` that double-counts on top of the reservation ledger. Cutover-blocker fix.
+
+### Backend
+- `backend/src/services/premadeBouquetService.js` — split `editPremadeBouquetLines` into `_editPremadeBouquetLinesYModel` and `_editPremadeBouquetLinesLegacy`. Y-model path: removed lines drop the row only; added lines run through `validateFreeQty` then `tx.insert(premadeBouquetLines)`; qty changes update the line and only validate the delta when increasing. NEVER touches `stockRepo.adjustQuantity`. All under one `db.transaction` so `validateFreeQty`'s row-lock (production PG) covers each line atomically. Legacy path byte-for-byte preserved.
+
+### Verification
+- `backend/src/__tests__/premadeBouquetService.integration.test.js` — 6 new flag-on tests (add / increase / decrease / remove / over-subscribe new line / over-subscribe increase) all assert `stock.currentQuantity` unchanged and `premade_bouquet_lines` reflect the intended state. 14/14 in the file pass.
+- Full backend suite green.
+
+---
+
 ## 2026-05-29 — Per-Variety trace surface (#346, PRD #324 T5)
 
 Read-only trace spanning every Batch + Demand Entry in a Variety. No schema change.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -47,7 +47,7 @@ scripts/           → Backfill, shadow-health, start-test-backend, etc.
 | File | Purpose |
 |------|---------|
 | orderService.js | Order state machine, auto-match stock, create with rollback, cancel with stock return, edit bouquet lines. All paths via orderRepo (Postgres). |
-| premadeBouquetService.js | Build / dissolve / sell Premade Bouquets. Flag-on path (STOCK_Y_MODEL=true, issue #285) uses reservation model — `premade_bouquet_lines` are the ledger; Batch quantity is touched only at sale via standard allocation. Legacy path preserved under `_*Legacy` functions. Persistence via `premadeBouquetRepo` (Postgres, Phase 7). |
+| premadeBouquetService.js | Build / edit / dissolve / sell Premade Bouquets. Flag-on path (STOCK_Y_MODEL=true, issue #285 + #330) uses reservation model — `premade_bouquet_lines` are the ledger; Batch quantity is touched only at sale via standard allocation. Legacy path preserved under `_*Legacy` functions. Persistence via `premadeBouquetRepo` (Postgres, Phase 7). |
 | notifications.js | SSE broadcast to all connected clients (heartbeat every 30s). No catch-up buffer yet — clients miss events while disconnected. |
 | wix.js | Wix webhook processor — parses payload, creates order + lines + delivery. |
 | wixProductSync.js | Bidirectional Wix product pull/push with sync logging. `runPush` accepts `onProgress(entry)` and parallelizes Wix API calls per phase via `p-queue` (concurrency 8) so the full push lands in 10–20s. Pull mirrors Wix prices and descriptions into the local product_config table (the 2026-04-22 lockout was specific to the legacy `runSync` flow, which the UI no longer calls). (1200+ L — split candidate.) |

--- a/backend/src/__tests__/premadeBouquetService.integration.test.js
+++ b/backend/src/__tests__/premadeBouquetService.integration.test.js
@@ -271,3 +271,94 @@ describe('createPremadeBouquet flag-on (STOCK_Y_MODEL=true) — issue #285', () 
     expect(after.currentQuantity).toBe(5);
   });
 });
+
+// ── #330: editPremadeBouquetLines under flag-on must NOT touch Batch qty ──
+import { editPremadeBouquetLines } from '../services/premadeBouquetService.js';
+
+describe('editPremadeBouquetLines flag-on (STOCK_Y_MODEL=true) — issue #330', () => {
+  let flagSpy;
+  beforeEach(() => { flagSpy = vi.spyOn(configService, 'getStockYModelEnabled').mockReturnValue(true); });
+  afterEach(() => { flagSpy.mockRestore(); });
+
+  async function seedBouquetWithLine(stockId, qty) {
+    const [bq] = await harness.db.insert(premadeBouquets).values({ name: 'Edit-test' }).returning();
+    const [ln] = await harness.db.insert(premadeBouquetLines).values({
+      bouquetId: bq.id, stockId, flowerName: 'X', quantity: qty,
+      costPricePerUnit: '1', sellPricePerUnit: '5',
+    }).returning();
+    return { bouquet: bq, line: ln };
+  }
+
+  it('adding a new line leaves Batch qty unchanged + writes the reservation row', async () => {
+    const [rose] = await harness.db.insert(stock).values({ displayName: 'Rose', currentQuantity: 10, typeName: 'Rose' }).returning();
+    const [bq] = await harness.db.insert(premadeBouquets).values({ name: 'B' }).returning();
+    await editPremadeBouquetLines(bq.id, {
+      lines: [{ stockItemId: rose.id, flowerName: 'Rose', quantity: 3, costPricePerUnit: 1, sellPricePerUnit: 5 }],
+    });
+    const [after] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
+    expect(after.currentQuantity).toBe(10);
+    const lines = await harness.db.select().from(premadeBouquetLines).where(eq(premadeBouquetLines.bouquetId, bq.id));
+    expect(lines).toHaveLength(1);
+    expect(lines[0].quantity).toBe(3);
+  });
+
+  it('increasing line qty leaves Batch qty unchanged + updates the reservation row', async () => {
+    const [rose] = await harness.db.insert(stock).values({ displayName: 'Rose', currentQuantity: 10, typeName: 'Rose' }).returning();
+    const { bouquet, line } = await seedBouquetWithLine(rose.id, 3);
+    await editPremadeBouquetLines(bouquet.id, {
+      lines: [{ id: line.id, stockItemId: rose.id, flowerName: 'X', quantity: 5, _originalQty: 3 }],
+    });
+    const [after] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
+    expect(after.currentQuantity).toBe(10);
+    const [updatedLine] = await harness.db.select().from(premadeBouquetLines).where(eq(premadeBouquetLines.id, line.id));
+    expect(updatedLine.quantity).toBe(5);
+  });
+
+  it('decreasing line qty leaves Batch qty unchanged + updates the reservation row', async () => {
+    const [rose] = await harness.db.insert(stock).values({ displayName: 'Rose', currentQuantity: 10, typeName: 'Rose' }).returning();
+    const { bouquet, line } = await seedBouquetWithLine(rose.id, 5);
+    await editPremadeBouquetLines(bouquet.id, {
+      lines: [{ id: line.id, stockItemId: rose.id, flowerName: 'X', quantity: 2, _originalQty: 5 }],
+    });
+    const [after] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
+    expect(after.currentQuantity).toBe(10);
+    const [updatedLine] = await harness.db.select().from(premadeBouquetLines).where(eq(premadeBouquetLines.id, line.id));
+    expect(updatedLine.quantity).toBe(2);
+  });
+
+  it('removing a line leaves Batch qty unchanged + deletes the reservation row', async () => {
+    const [rose] = await harness.db.insert(stock).values({ displayName: 'Rose', currentQuantity: 10, typeName: 'Rose' }).returning();
+    const { bouquet, line } = await seedBouquetWithLine(rose.id, 3);
+    await editPremadeBouquetLines(bouquet.id, {
+      removedLines: [{ lineId: line.id, stockItemId: rose.id, quantity: 3 }],
+    });
+    const [after] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
+    expect(after.currentQuantity).toBe(10);
+    const lines = await harness.db.select().from(premadeBouquetLines).where(eq(premadeBouquetLines.bouquetId, bouquet.id));
+    expect(lines).toHaveLength(0);
+  });
+
+  it('adding a line that exceeds free qty throws + Batch + lines unchanged', async () => {
+    const [rose] = await harness.db.insert(stock).values({ displayName: 'Rose', currentQuantity: 5, typeName: 'Rose' }).returning();
+    const { bouquet } = await seedBouquetWithLine(rose.id, 4);
+    await expect(editPremadeBouquetLines(bouquet.id, {
+      lines: [{ stockItemId: rose.id, flowerName: 'Rose', quantity: 3, costPricePerUnit: 1, sellPricePerUnit: 5 }],
+    })).rejects.toThrow(/Insufficient free stems/);
+    const [after] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
+    expect(after.currentQuantity).toBe(5);
+    const lines = await harness.db.select().from(premadeBouquetLines).where(eq(premadeBouquetLines.bouquetId, bouquet.id));
+    expect(lines).toHaveLength(1);
+  });
+
+  it('increasing qty past free qty throws + Batch unchanged', async () => {
+    const [rose] = await harness.db.insert(stock).values({ displayName: 'Rose', currentQuantity: 5, typeName: 'Rose' }).returning();
+    const { bouquet, line } = await seedBouquetWithLine(rose.id, 4);
+    await expect(editPremadeBouquetLines(bouquet.id, {
+      lines: [{ id: line.id, stockItemId: rose.id, flowerName: 'X', quantity: 10, _originalQty: 4 }],
+    })).rejects.toThrow(/Insufficient free stems/);
+    const [after] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
+    expect(after.currentQuantity).toBe(5);
+    const [unchanged] = await harness.db.select().from(premadeBouquetLines).where(eq(premadeBouquetLines.id, line.id));
+    expect(unchanged.quantity).toBe(4);
+  });
+});

--- a/backend/src/services/premadeBouquetService.js
+++ b/backend/src/services/premadeBouquetService.js
@@ -23,6 +23,7 @@ import { autoMatchStock, createOrder } from './orderService.js';
 import { getStockYModelEnabled } from './configService.js';
 import { db } from '../db/index.js';
 import { premadeBouquets, premadeBouquetLines } from '../db/schema.js';
+import { eq } from 'drizzle-orm';
 
 export async function getPremadeBouquet(id) {
   const bouquet = await premadeBouquetRepo.getById(id);
@@ -210,7 +211,85 @@ export async function updatePremadeBouquet(id, patch) {
   return await getPremadeBouquet(id);
 }
 
-export async function editPremadeBouquetLines(id, { lines = [], removedLines = [] }) {
+export async function editPremadeBouquetLines(id, payload) {
+  if (getStockYModelEnabled()) return await _editPremadeBouquetLinesYModel(id, payload);
+  return await _editPremadeBouquetLinesLegacy(id, payload);
+}
+
+// ── Y-model edit path (STOCK_Y_MODEL=true) — issue #330 ──
+// Reservation ledger lives in premade_bouquet_lines; editing lines mutates
+// the reservation only, NEVER Batch qty. validateFreeQty gates new lines and
+// qty increases (delta only) so reservations stay coherent; decreases skip
+// validation (they release reservation back to free qty).
+async function _editPremadeBouquetLinesYModel(id, { lines = [], removedLines = [] }) {
+  const bouquet = await premadeBouquetRepo.getById(id);
+
+  // Removed lines: drop the row only. No credit to Batch qty (nothing was
+  // deducted at build time under the reservation model).
+  for (const rem of removedLines) {
+    if (rem.lineId) {
+      await premadeBouquetRepo.deleteLineById(rem.lineId).catch(err =>
+        console.error(`[PREMADE] Failed to delete removed line ${rem.lineId}:`, err.message),
+      );
+    }
+  }
+
+  const newUnmatched = lines.filter(l => !l.id && !l.stockItemId && l.flowerName);
+  if (newUnmatched.length > 0) await autoMatchStock(newUnmatched);
+
+  const orphans = lines.filter(l => !l.id && !l.stockItemId);
+  if (orphans.length > 0) {
+    const names = orphans.map(o => o.flowerName || '(unnamed)').join(', ');
+    const err = new Error(
+      `Bouquet line(s) without a Stock Item are not allowed: ${names}. ` +
+      `Create the flower in Stock first.`,
+    );
+    err.statusCode = 400;
+    throw err;
+  }
+
+  // All inserts/updates run on the same tx so validateFreeQty's row-lock
+  // (production PG) covers each line and the reservation row write atomically.
+  // Bypass the repo here (repo methods use their own connection, which would
+  // deadlock against this open tx in pglite).
+  const createdLines = [];
+  await db.transaction(async (tx) => {
+    for (const line of lines) {
+      if (line.id) {
+        if (line._originalQty != null && line.quantity !== line._originalQty) {
+          const newQty = Number(line.quantity);
+          const oldQty = Number(line._originalQty);
+          if (line.stockItemId && newQty > oldQty) {
+            await stockRepo.validateFreeQty(line.stockItemId, newQty - oldQty, tx);
+          }
+          await tx.update(premadeBouquetLines)
+            .set({ quantity: newQty })
+            .where(eq(premadeBouquetLines.id, line.id));
+          // NO stockRepo.adjustQuantity — reservation ledger only.
+        }
+      } else {
+        if (line.stockItemId) {
+          await stockRepo.validateFreeQty(line.stockItemId, Number(line.quantity), tx);
+        }
+        const [created] = await tx.insert(premadeBouquetLines).values({
+          bouquetId:        bouquet._pgId,
+          stockId:          line.stockItemId || null,
+          flowerName:       line.flowerName,
+          quantity:         Number(line.quantity),
+          costPricePerUnit: String(Number(line.costPricePerUnit) || 0),
+          sellPricePerUnit: String(Number(line.sellPricePerUnit) || 0),
+        }).returning();
+        createdLines.push(created);
+        // NO stockRepo.adjustQuantity — reservation ledger only.
+      }
+    }
+  });
+
+  return { updated: true, createdLines };
+}
+
+// ── Legacy edit path (STOCK_Y_MODEL=false) — byte-for-byte unchanged ──
+async function _editPremadeBouquetLinesLegacy(id, { lines = [], removedLines = [] }) {
   const bouquet = await premadeBouquetRepo.getById(id);
 
   for (const rem of removedLines) {


### PR DESCRIPTION
## Summary
Closes the last unsplit flag-off/flag-on path in `premadeBouquetService`. `editPremadeBouquetLines` was calling `stockRepo.adjustQuantity` on add / qty-change / remove unconditionally — under `STOCK_Y_MODEL=true` that double-counts on top of the reservation ledger (the source half of #330's audit log). **Cutover blocker.**

`createPremadeBouquet`, `returnPremadeBouquetToStock`, and `matchPremadeBouquetToOrder` were already split. This brings `editPremadeBouquetLines` to parity.

## Y-model edit path
- Removed lines: drop the row only — no qty credit (nothing was deducted at build).
- Added lines: `validateFreeQty` → `tx.insert(premadeBouquetLines)` (no `adjustQuantity`).
- Qty changes: only validate the *delta* on increases; update the line row.
- Single `db.transaction` so `validateFreeQty`'s row-lock covers each line atomically in production PG.
- Bypasses the repo for inserts/updates inside the tx (pglite single-connection limit; matches the build path).

Legacy path: byte-for-byte preserved.

## Verification
- `backend/src/__tests__/premadeBouquetService.integration.test.js` — **6 new flag-on tests**: add / increase / decrease / remove / over-subscribe new / over-subscribe increase. All assert `stock.currentQuantity` unchanged and `premade_bouquet_lines` reflect the intended state.
- Full backend suite **464 pass**.

## For the owner
When the new stock model is switched on, editing a premade bouquet (adding flowers, changing a quantity, removing a flower) won't accidentally bump your stock numbers up or down. The premade bouquet is its own reservation; only making it or breaking it should move the count.

Closes #330
Refs #291