### PR TITLE
fix(florist): show negative stock items in Stock Order creation (#331)

### DIFF
--- a/apps/florist/src/pages/PurchaseOrderPage.jsx
+++ b/apps/florist/src/pages/PurchaseOrderPage.jsx
@@ -64,7 +64,7 @@ export default function PurchaseOrderPage() {
 
   useEffect(() => {
     fetchOrders();
-    client.get('/stock').then(r => setStock(r.data)).catch(() => {});
+    client.get('/stock?includeEmpty=true').then(r => setStock(r.data)).catch(() => {});
     client.get('/settings').then(r => setDrivers(r.data.drivers || [])).catch(() => {});
   }, [fetchOrders]);
 


### PR DESCRIPTION
## Summary
- `PurchaseOrderPage` was fetching `/stock` without `includeEmpty=true`, so the backend silently excluded all items with `qty <= 0` — the exact items that should pre-fill a new PO.
- Fix: add `?includeEmpty=true` to match how `StockPanelPage` already fetches stock.
- No shared-package changes; florist-only diff.

## Test plan
- [ ] Open Purchase Orders in the florist app when there are items with negative qty
- [ ] Click "New Purchase Order" — lines should auto-populate with those shortfall items
- [ ] Badge count on the button should reflect the number of negative items
- [ ] Verify `vite build` passes (done locally: `✓ built in 1.30s`)

Closes #331