### PR TITLE
feat(florist): owner can edit cost + sell price on Stock Item (#332)

### DIFF
--- a/apps/florist/src/components/StockItem.jsx
+++ b/apps/florist/src/components/StockItem.jsx
@@ -6,6 +6,61 @@ import { stockBaseName, renderDateTag, LOSS_REASONS, reasonLabel, getEffectiveSt
 import fmtDate from '../utils/formatDate.js';
 
 /**
+ * PriceField — inline-editable number field for owner-only price editing.
+ * Shows a styled number; tapping switches to a text input, blur saves.
+ */
+function PriceField({ label, value, onSave }) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+
+  function startEdit(e) {
+    e.stopPropagation();
+    setDraft(value != null && value > 0 ? String(value) : '');
+    setEditing(true);
+  }
+
+  function commitSave(e) {
+    e.stopPropagation();
+    setEditing(false);
+    const num = parseFloat(draft);
+    const next = isNaN(num) ? 0 : num;
+    if (next !== value) onSave(next);
+  }
+
+  if (editing) {
+    return (
+      <div className="flex items-center gap-1" onClick={e => e.stopPropagation()}>
+        <span className="text-[10px] text-ios-tertiary shrink-0">{label}</span>
+        <input
+          type="number"
+          inputMode="decimal"
+          value={draft}
+          autoFocus
+          onChange={e => setDraft(e.target.value)}
+          onBlur={commitSave}
+          onKeyDown={e => { if (e.key === 'Enter') e.target.blur(); if (e.key === 'Escape') { setEditing(false); } }}
+          className="w-16 text-right text-[11px] font-semibold border border-brand-300 rounded-lg px-1.5 py-0.5 bg-white outline-none"
+        />
+        <span className="text-[10px] text-ios-tertiary">zł</span>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={startEdit}
+      className="flex items-center gap-1 active-scale"
+      title={`${t.edit || 'Edit'} ${label}`}
+    >
+      <span className="text-[10px] text-ios-tertiary">{label}:</span>
+      <span className="text-[11px] font-semibold text-ios-label underline decoration-dotted underline-offset-2">
+        {value != null && value > 0 ? `${Number(value).toFixed(0)}zł` : '—'}
+      </span>
+    </button>
+  );
+}
+
+/**
  * StockItem — a single compact row in the stock panel.
  *
  * Two modes controlled by the `editMode` prop:
@@ -14,7 +69,7 @@ import fmtDate from '../utils/formatDate.js';
  *
  * Tapping the row expands it to show which orders consume this flower.
  */
-export default function StockItem({ item, editMode, onAdjust, onWriteOff, onPatch, committedData, premadeData }) {
+export default function StockItem({ item, editMode, onAdjust, onWriteOff, onPatch, onPatchPrice, committedData, premadeData, role }) {
   const navigate = useNavigate();
   const qty       = item['Current Quantity'] || 0;
   const dead      = item['Dead/Unsold Stems'] || 0;
@@ -67,6 +122,11 @@ export default function StockItem({ item, editMode, onAdjust, onWriteOff, onPatc
       setWriteOffQty(1);
       setReason('');
     }
+  }
+
+  function handlePriceSave(field, value) {
+    // onPatchPrice handles PATCH + success/error toasts in StockPanelPage.
+    if (onPatchPrice) onPatchPrice({ [field]: value });
   }
 
   const isNeg = qty < 0;
@@ -226,6 +286,22 @@ export default function StockItem({ item, editMode, onAdjust, onWriteOff, onPatc
       {expanded && !editMode && committed === 0 && (
         <div className="px-3 pb-2 ml-4">
           <p className="text-[10px] text-ios-tertiary">{t.noCommitments}</p>
+        </div>
+      )}
+
+      {/* Owner-only: cost + sell price inline editors */}
+      {expanded && !editMode && role === 'owner' && (
+        <div className="px-3 pb-2 ml-4 flex items-center gap-4" onClick={e => e.stopPropagation()}>
+          <PriceField
+            label={t.costPrice}
+            value={item['Current Cost Price']}
+            onSave={v => handlePriceSave('Current Cost Price', v)}
+          />
+          <PriceField
+            label={t.sellPrice}
+            value={item['Current Sell Price']}
+            onSave={v => handlePriceSave('Current Sell Price', v)}
+          />
         </div>
       )}
 

--- a/apps/florist/src/pages/StockPanelPage.jsx
+++ b/apps/florist/src/pages/StockPanelPage.jsx
@@ -169,6 +169,14 @@ export default function StockPanelPage() {
     } catch (err) { showToast(err.response?.data?.error || t.adjustError, 'error'); }
   }
 
+  async function handlePatchPrice(id, fields) {
+    try {
+      const res = await client.patch(`/stock/${id}`, fields);
+      setStock(prev => prev.map(s => s.id === id ? { ...s, ...res.data } : s));
+      showToast(t.stockUpdated, 'success');
+    } catch (err) { showToast(err.response?.data?.error || t.adjustError, 'error'); }
+  }
+
   function toggleSort(key) {
     if (sortKey === key) setSortAsc(v => !v);
     else { setSortKey(key); setSortAsc(true); }
@@ -615,8 +623,10 @@ export default function StockPanelPage() {
                   onAdjust={delta => handleAdjust(item.id, delta)}
                   onWriteOff={(qty, reason) => handleWriteOff(item.id, qty, reason)}
                   onPatch={fields => handlePatch(item.id, fields)}
+                  onPatchPrice={fields => handlePatchPrice(item.id, fields)}
                   committedData={committedMap[item.id]}
                   premadeData={premadeMap[item.id]}
+                  role={role}
                 />
               ))}
             </div>

--- a/apps/florist/src/translations.js
+++ b/apps/florist/src/translations.js
@@ -90,6 +90,7 @@ const en = {
   updated:              'Updated!',
   updateError:          'Failed to update.',
   loadError:            'Failed to load details.',
+  stockUpdated:         'Stock updated',
 
   // New order wizard
   newOrderTitle:    'New Order',
@@ -869,6 +870,7 @@ const ru = {
   updated:              'Обновлено!',
   updateError:          'Не удалось обновить.',
   loadError:            'Не удалось загрузить детали.',
+  stockUpdated:         'Склад обновлён',
 
   // New order wizard
   newOrderTitle:    'Новый заказ',


### PR DESCRIPTION
## Summary
- Adds a `PriceField` inline-edit component (tap → input → blur saves) to `StockItem.jsx`
- Owner-only: cost and sell price editors appear in the tap-to-expand row; florists see read-only view (no change)
- New `handlePatchPrice` in `StockPanelPage` shows a success toast after save; error toast on failure
- Added `stockUpdated` translation key (EN + RU) to florist `translations.js`

## API endpoint
`PATCH /stock/:id` — same endpoint the dashboard already uses

## Role gate
`role === 'owner'` (line 289 of `StockItem.jsx`), sourced from `useAuth()` in `StockPanelPage` and passed as a prop

## Test plan
- [ ] Log in as **owner** → Stock tab → tap any stock item → see Cost and Sell Price fields with dotted underline
- [ ] Tap Cost field → input appears → enter new value → blur (or press Enter) → toast "Склад обновлён" appears
- [ ] Close and reopen the item → new cost value persists
- [ ] Repeat for Sell Price
- [ ] Log in as **florist** (non-owner PIN) → expand stock item → no price edit fields visible
- [ ] Press Escape while editing → input closes without saving

## Build
`cd apps/florist && vite build` → ✓ built in 1.31s (0 errors)

Closes #332