### PR TITLE
feat(po): allow owner to edit planned arrival date after PO save

### DIFF
--- a/apps/dashboard/src/components/StockOrderPanel.jsx
+++ b/apps/dashboard/src/components/StockOrderPanel.jsx
@@ -673,6 +673,25 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
                     <p className="text-xs text-ios-secondary">{order.Notes}</p>
                   )}
 
+                  {['Draft', 'Sent', 'Shopping'].includes(order.Status) && (
+                    <div className="flex items-center gap-2">
+                      <label className="text-xs text-ios-tertiary shrink-0">{t.plannedDate || 'Planned date'}</label>
+                      <input
+                        type="date"
+                        value={order['Planned Date'] || ''}
+                        onChange={e => setOrders(prev => prev.map(o => o.id === order.id ? { ...o, 'Planned Date': e.target.value } : o))}
+                        onBlur={async e => {
+                          try {
+                            await client.patch(`/stock-orders/${order.id}`, { 'Planned Date': e.target.value || null });
+                          } catch (err) {
+                            showToast(err.response?.data?.error || t.error, 'error');
+                          }
+                        }}
+                        className="text-sm border border-gray-200 rounded-lg px-2 py-1.5 flex-1"
+                      />
+                    </div>
+                  )}
+
                   {/* Editable POs: Draft + Sent + Shopping. Reviewing/Evaluating/Complete stay read-only. */}
                   {['Draft', 'Sent', 'Shopping'].includes(order.Status) ? (
                     <>

--- a/apps/florist/src/pages/PurchaseOrderPage.jsx
+++ b/apps/florist/src/pages/PurchaseOrderPage.jsx
@@ -567,6 +567,25 @@ export default function PurchaseOrderPage() {
                   <div className="border-t border-gray-100 px-4 py-3 space-y-3">
                     {order.Notes && <p className="text-xs text-ios-secondary">{order.Notes}</p>}
 
+                    {['Draft', 'Sent', 'Shopping'].includes(order.Status) && (
+                      <div className="flex items-center gap-2">
+                        <label className="text-xs text-ios-tertiary shrink-0">{t.po?.plannedDate || 'Planned date'}</label>
+                        <input
+                          type="date"
+                          value={order['Planned Date'] || ''}
+                          onChange={e => setOrders(prev => prev.map(o => o.id === order.id ? { ...o, 'Planned Date': e.target.value } : o))}
+                          onBlur={async e => {
+                            try {
+                              await client.patch(`/stock-orders/${order.id}`, { 'Planned Date': e.target.value || null });
+                            } catch (err) {
+                              showToast(err.response?.data?.error || t.error, 'error');
+                            }
+                          }}
+                          className="field-input text-sm flex-1"
+                        />
+                      </div>
+                    )}
+
                     {['Draft', 'Sent', 'Shopping'].includes(order.Status) ? (
                       /* ── Editable PO: Draft + Sent + Shopping ── */
                       <>


### PR DESCRIPTION
## Summary
- Adds inline editable Planned Date field in the expanded PO panel for Draft / Sent / Shopping statuses
- Mirrors the change across both the florist app (`PurchaseOrderPage.jsx`) and dashboard (`StockOrderPanel.jsx`) per cross-app parity rule
- Backend `PATCH /stock-orders/:id` already allowed `Planned Date` for owner — no backend or schema change

Closes #342

## Test plan
- [x] `apps/florist` vite build passes
- [x] `apps/dashboard` vite build passes
- [ ] Owner opens an existing PO (Draft/Sent/Shopping), date input visible and editable
- [ ] Saving a PO with no date → reopen → date input still present and editable
- [ ] Changing date → blur → PATCH fires, value persists on refetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)