### PR TITLE
feat(picker): collapse Batch options by sell-price tier (Y-model)

### DIFF
--- a/packages/shared/components/VarietyAllocationPicker.jsx
+++ b/packages/shared/components/VarietyAllocationPicker.jsx
@@ -100,14 +100,15 @@ export default function VarietyAllocationPicker({
     return map;
   }, [stockItems]);
 
-  // When a Variety row is expanded, compute engine options for that group.
+  // When a Variety row is expanded, compute engine options for that group,
+  // then collapse Batch options by sell-price tier so the picker mirrors the
+  // Stock-list merge rule (2026-05-31). Demand-Entry and Fresh options are
+  // not collapsed — they remain per-date.
   const expandedOptions = useMemo(() => {
     if (!expandedKey) return null;
     const group = groups.find((g) => g.key === expandedKey);
     if (!group) return null;
 
-    // Adapt snake_case rows to engine's camelCase contract.
-    // isDemandEntry = currentQuantity < 0 per ADR-0005.
     const engineRows = group.rows.map((r) => ({
       id: r.id,
       currentQuantity: Number(r.current_quantity) || 0,
@@ -115,8 +116,9 @@ export default function VarietyAllocationPicker({
       isDemandEntry: (Number(r.current_quantity) || 0) < 0,
     }));
 
-    return stockAllocationEngine(engineRows, reservations, requiredBy, qty);
-  }, [expandedKey, groups, reservations, requiredBy, qty]);
+    const raw = stockAllocationEngine(engineRows, reservations, requiredBy, qty);
+    return collapseBatchTiers(raw, stockById, qty, t);
+  }, [expandedKey, groups, reservations, requiredBy, qty, stockById, t]);
 
   const isOwner = role === 'owner';
 
@@ -125,7 +127,9 @@ export default function VarietyAllocationPicker({
   }
 
   function handleBatchClick(option) {
-    const original = stockById.get(option.stockId);
+    // FEFO: oldest underlying stock_id drains first.
+    const targetId = option.stockIds?.[0] ?? option.stockId;
+    const original = stockById.get(targetId);
     if (original) onSelectStock(original);
   }
 
@@ -344,6 +348,83 @@ export default function VarietyAllocationPicker({
 }
 
 /**
+ * collapseBatchTiers — merges engine Batch options that share a sell price
+ * into one tier-row per price. stockIds[] inside each tier are FEFO-sorted
+ * (oldest date first) so the host drains oldest stems first. Demand-Entry
+ * (`merge`) and `fresh` options pass through untouched.
+ *
+ * When all batches share a single sell price (or no price is set on any
+ * row), the tier renders without a price label — the picker just shows
+ * "Use stock" so the florist isn't distracted by a single redundant chip.
+ */
+export function collapseBatchTiers(options, stockById, qty, t) {
+  const out = [];
+  const tiers = new Map(); // tierKey → { ...mergedOption }
+
+  for (const opt of options) {
+    if (opt.kind !== 'batch') {
+      out.push(opt);
+      continue;
+    }
+    const row = stockById.get(opt.stockId);
+    const sellRaw = row?.['Current Sell Price'] ?? row?.current_sell_price;
+    const sell =
+      sellRaw != null && sellRaw !== '' && isFinite(Number(sellRaw))
+        ? Number(sellRaw)
+        : null;
+    const tierKey = sell != null ? sell.toFixed(2) : 'null';
+
+    let m = tiers.get(tierKey);
+    if (!m) {
+      m = {
+        kind: 'batch',
+        tierKey,
+        sell,
+        stockIds: [],
+        stockIdDates: [],
+        freeQty: 0,
+        total: 0,
+        reservedQty: 0,
+        sufficient: false,
+        isDefault: false,
+      };
+      tiers.set(tierKey, m);
+      out.push(m);
+    }
+    m.stockIds.push(opt.stockId);
+    m.stockIdDates.push(opt.date);
+    m.freeQty += opt.freeQty;
+    m.total += opt.total;
+    m.reservedQty += opt.reservedQty;
+    if (opt.isDefault) m.isDefault = true;
+  }
+
+  // Finalise each tier: FEFO-sort underlying stockIds + recompute sufficient
+  // (sum may cross the qty threshold even when no individual batch did).
+  const onlyOneTier =
+    [...tiers.values()].filter((m) => m.stockIds.length > 0).length === 1;
+
+  for (const m of tiers.values()) {
+    const pairs = m.stockIds.map((id, i) => ({ id, date: m.stockIdDates[i] }));
+    pairs.sort((a, b) => {
+      if (!a.date && !b.date) return 0;
+      if (!a.date) return 1;
+      if (!b.date) return -1;
+      return a.date.localeCompare(b.date);
+    });
+    m.stockIds = pairs.map((p) => p.id);
+    delete m.stockIdDates;
+    m.sufficient = m.freeQty > 0 && m.freeQty >= qty;
+    m.sellLabel =
+      onlyOneTier || m.sell == null
+        ? null
+        : `${m.sell.toFixed(2)} ${t?.currency ?? 'zł'}`;
+  }
+
+  return out;
+}
+
+/**
  * AllocationPanel — renders the engine options for one expanded Variety.
  * Renders inline below the Variety row header.
  */
@@ -354,13 +435,13 @@ function AllocationPanel({ options, onBatch, onMerge, onFresh, premadesByStockId
 
   return (
     <div className="bg-gray-50 border-t border-gray-100 px-4 py-3 space-y-2">
-      {/* Batch options */}
+      {/* Batch options — one row per sell-price tier */}
       {batchOptions.map((opt) => (
         <BatchOptionButton
-          key={opt.stockId}
+          key={opt.tierKey ?? opt.stockId}
           option={opt}
           onClick={() => onBatch(opt)}
-          premades={premadesByStockId?.get(opt.stockId)}
+          premades={premadesByStockId?.get(opt.stockIds?.[0] ?? opt.stockId)}
           t={t}
         />
       ))}
@@ -426,6 +507,8 @@ function BatchOptionButton({ option, onClick, premades, t }) {
       data-testid="option-batch"
       data-default={String(option.isDefault)}
       data-sufficient={String(option.sufficient)}
+      data-tier-key={option.tierKey ?? ''}
+      data-stock-ids={(option.stockIds ?? [option.stockId]).join(',')}
       onClick={onClick}
       disabled={unusable}
       aria-disabled={unusable}
@@ -439,7 +522,9 @@ function BatchOptionButton({ option, onClick, premades, t }) {
       ].join(' ')}
     >
       <div className="flex items-center justify-between">
-        <span className="font-medium">{option.date}</span>
+        <span className="font-medium">
+          {option.sellLabel ?? (t.useStock ?? 'Use stock')}
+        </span>
         <span className="text-xs text-gray-500">
           <span className={`font-semibold ${unusable ? 'text-gray-400' : 'text-gray-800'}`}>{option.freeQty}</span>
           {' / '}

--- a/packages/shared/test/VarietyAllocationPicker.test.jsx
+++ b/packages/shared/test/VarietyAllocationPicker.test.jsx
@@ -171,6 +171,79 @@ describe('VarietyAllocationPicker — Create new Variety (Owner)', () => {
   });
 });
 
+describe('VarietyAllocationPicker — collapse Batch options by sell tier (2026-05-31)', () => {
+  // Two Rose Pink 60 batches at the same sell price → ONE Batch option.
+  // A third batch at a different sell price → its own Batch option (tier).
+  const tieredRows = [
+    { id: 'b1', type_name: 'Rose', colour: 'Pink', size_cm: 60, cultivar: null,
+      current_quantity: 10, date: '2026-05-10', current_sell_price: 25 },
+    { id: 'b2', type_name: 'Rose', colour: 'Pink', size_cm: 60, cultivar: null,
+      current_quantity: 5,  date: '2026-05-12', current_sell_price: 25 },
+    { id: 'b3', type_name: 'Rose', colour: 'Pink', size_cm: 60, cultivar: null,
+      current_quantity: 7,  date: '2026-05-11', current_sell_price: 30 },
+  ];
+  const tT = { ...t, currency: 'zł', useStock: 'Use stock' };
+
+  it('two batches at same sell price collapse into one tier row', () => {
+    render(<VarietyAllocationPicker stockItems={tieredRows} reservations={new Map()}
+      requiredBy="2026-05-15" qty={1} role="florist" t={tT}
+      onSelectStock={() => {}} onClose={() => {}} />);
+    fireEvent.click(screen.getAllByTestId('variety-row')[0]);
+    const batches = screen.getAllByTestId('option-batch');
+    expect(batches).toHaveLength(2);
+    // FEFO ordering inside the 25 zł tier: b1 (May 10) before b2 (May 12).
+    const ids = batches.map(b => b.getAttribute('data-stock-ids'));
+    expect(ids).toContain('b1,b2');
+    expect(ids).toContain('b3');
+  });
+
+  it('renders sell-price label on each tier when multiple tiers exist', () => {
+    render(<VarietyAllocationPicker stockItems={tieredRows} reservations={new Map()}
+      requiredBy="2026-05-15" qty={1} role="florist" t={tT}
+      onSelectStock={() => {}} onClose={() => {}} />);
+    fireEvent.click(screen.getAllByTestId('variety-row')[0]);
+    const batches = screen.getAllByTestId('option-batch');
+    const labels = batches.map(b => b.textContent);
+    expect(labels.some(l => l.includes('25.00 zł'))).toBe(true);
+    expect(labels.some(l => l.includes('30.00 zł'))).toBe(true);
+  });
+
+  it('hides sell-price label when only one tier exists (renders "Use stock")', () => {
+    const oneTier = tieredRows.filter(r => r.current_sell_price === 25);
+    render(<VarietyAllocationPicker stockItems={oneTier} reservations={new Map()}
+      requiredBy="2026-05-15" qty={1} role="florist" t={tT}
+      onSelectStock={() => {}} onClose={() => {}} />);
+    fireEvent.click(screen.getAllByTestId('variety-row')[0]);
+    const batch = screen.getByTestId('option-batch');
+    expect(batch).toHaveTextContent('Use stock');
+    expect(batch).not.toHaveTextContent('zł');
+  });
+
+  it('clicking a tier targets the FEFO-oldest underlying stock_id', () => {
+    const onSelectStock = vi.fn();
+    render(<VarietyAllocationPicker stockItems={tieredRows} reservations={new Map()}
+      requiredBy="2026-05-15" qty={1} role="florist" t={tT}
+      onSelectStock={onSelectStock} onClose={() => {}} />);
+    fireEvent.click(screen.getAllByTestId('variety-row')[0]);
+    // Pick the 25 zł tier (b1+b2). Oldest = b1.
+    const tier25 = screen.getAllByTestId('option-batch')
+      .find(b => b.getAttribute('data-stock-ids') === 'b1,b2');
+    fireEvent.click(tier25);
+    expect(onSelectStock).toHaveBeenCalledWith(expect.objectContaining({ id: 'b1' }));
+  });
+
+  it('tier freeQty is summed across underlying batches', () => {
+    render(<VarietyAllocationPicker stockItems={tieredRows} reservations={new Map()}
+      requiredBy="2026-05-15" qty={1} role="florist" t={tT}
+      onSelectStock={() => {}} onClose={() => {}} />);
+    fireEvent.click(screen.getAllByTestId('variety-row')[0]);
+    const tier25 = screen.getAllByTestId('option-batch')
+      .find(b => b.getAttribute('data-stock-ids') === 'b1,b2');
+    // 10 + 5 = 15 free, 15 total.
+    expect(tier25).toHaveTextContent('15');
+  });
+});
+
 describe('VarietyAllocationPicker — Order fresh for all', () => {
   it('renders "Order fresh for all" CTA when host passes bulkCandidates', () => {
     const onBulkFresh = vi.fn();


### PR DESCRIPTION
## Summary

Mirrors the Stock-list **merge-by-sell-price** rule (2026-05-31, PR #357) inside the order-line picker. Same-Variety stems at the same Sell price collapse into one Batch option labeled by price (`25.00 zł`). Multiple sell tiers → one Batch option per tier. Single tier → label hidden, plain "Use stock" rendered instead.

Demand-Entry **merge** options and the **Fresh** option stay per-date — their dates carry semantics that price-merging would erase (the other order's required-by, the new fresh arrival date).

## Implementation

- New helper `collapseBatchTiers(options, stockById, qty, t)` in `VarietyAllocationPicker.jsx`. Runs over engine output, groups `kind:'batch'` options by `sell.toFixed(2)`, sums `freeQty / total / reservedQty`, FEFO-sorts `stockIds[]` (oldest date first), recomputes `sufficient` against the summed qty.
- Click handler picks `option.stockIds[0]` (FEFO-oldest underlying batch) and hands the original stockItem to the host's `onSelectStock`.
- `stockAllocationEngine` itself unchanged — collapse is presentation-only, lower risk than rewriting the engine + cascading through 4 host call sites.

## Verification

- 326/326 shared tests pass (5 new tier-merge cases in `VarietyAllocationPicker.test.jsx`)
- Florist / dashboard / delivery all build clean
- Behaviour verified locally in the prod-mirror sandbox under \`STOCK_Y_MODEL=true\`

Refs #291

## Test plan

- [ ] Variety with one sell price → picker shows one Batch option labeled "Use stock"
- [ ] Variety with two sell prices → two Batch options, labeled "X.XX zł"
- [ ] Click the lower-tier option on a variety with multiple underlying batches → order line binds to the FEFO-oldest batch
- [ ] Merge-into-existing-order option still shows the other order's required-by date

🤖 Generated with [Claude Code](https://claude.com/claude-code)