### PR TITLE
feat(po): typeahead on new-variety/farmer + Qty auto-syncs from Pkgs × LotSize

### DIFF
--- a/apps/dashboard/src/components/StockOrderPanel.jsx
+++ b/apps/dashboard/src/components/StockOrderPanel.jsx
@@ -1,7 +1,7 @@
 // StockOrderPanel — Purchase Order management for the dashboard Stock tab.
 // Like a procurement kanban: create POs, assign drivers, track progress, view history.
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import client from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import t from '../translations.js';
@@ -38,6 +38,26 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
   // Prevents editing an existing PO's driver from changing the new-PO form.
   const [editDrivers, setEditDrivers] = useState({});
   const [committedMap, setCommittedMap] = useState({});
+
+  // Owner ask 2026-05-31: suggest existing Type / Colour / Cultivar / Farmer
+  // values when typing on a new-Variety PO line — prevents duplicates from
+  // misspellings ("Peon" vs "Peony"). Sourced from current Stock.
+  const typeSuggestions = useMemo(
+    () => Array.from(new Set((stock || []).map(s => s['Type'] ?? s.type_name).filter(Boolean))).sort(),
+    [stock],
+  );
+  const colourSuggestions = useMemo(
+    () => Array.from(new Set((stock || []).map(s => s['Colour'] ?? s.colour).filter(Boolean))).sort(),
+    [stock],
+  );
+  const cultivarSuggestions = useMemo(
+    () => Array.from(new Set((stock || []).map(s => s['Cultivar'] ?? s.cultivar).filter(Boolean))).sort(),
+    [stock],
+  );
+  const farmerSuggestions = useMemo(
+    () => Array.from(new Set((stock || []).map(s => s['Farmer'] ?? s.farmer).filter(Boolean))).sort(),
+    [stock],
+  );
 
   const fetchOrders = useCallback(async () => {
     try {
@@ -116,7 +136,21 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
   }
 
   function updateFormLine(idx, patch) {
-    setFormLines(prev => prev.map((l, i) => i === idx ? { ...l, ...patch } : l));
+    setFormLines(prev => prev.map((l, i) => {
+      if (i !== idx) return l;
+      const merged = { ...l, ...patch };
+      // Owner ask 2026-05-31: when both Pkgs and LotSize are set, Qty reflects
+      // the total stems that will actually be ordered (pkgs * lotSize). Owner
+      // can still type Qty manually; only Pkgs / LotSize edits trigger the
+      // auto-sync.
+      const touchedPkgsOrLot = 'packages' in patch || 'lotSize' in patch;
+      if (touchedPkgsOrLot) {
+        const pkgs = Number(merged.packages) || 0;
+        const ls = Number(merged.lotSize) || 0;
+        if (pkgs > 0 && ls > 0) merged.quantity = pkgs * ls;
+      }
+      return merged;
+    }));
   }
 
   function removeFormLine(idx) {
@@ -360,6 +394,20 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
 
   return (
     <div className="space-y-4">
+      {/* Typeahead suggestion sources for new-variety + farmer inputs
+          (issue: duplicate spellings like "Peon" vs "Peony"). */}
+      <datalist id="po-type-suggestions">
+        {typeSuggestions.map(s => <option key={s} value={s} />)}
+      </datalist>
+      <datalist id="po-colour-suggestions">
+        {colourSuggestions.map(s => <option key={s} value={s} />)}
+      </datalist>
+      <datalist id="po-cultivar-suggestions">
+        {cultivarSuggestions.map(s => <option key={s} value={s} />)}
+      </datalist>
+      <datalist id="po-farmer-suggestions">
+        {farmerSuggestions.map(s => <option key={s} value={s} />)}
+      </datalist>
       {/* Header */}
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-bold text-ios-label">{t.stockOrders}</h2>
@@ -505,6 +553,7 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
                       <input
                         type="text"
                         value={line.farmer || ''}
+                        list="po-farmer-suggestions"
                         onChange={e => updateFormLine(line._idx, { farmer: e.target.value })}
                         className="field-input w-28 text-sm"
                         placeholder="—"
@@ -529,15 +578,18 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
                       </p>
                       <div className="grid grid-cols-4 gap-2">
                         <input type="text" value={line.type || ''}
+                          list="po-type-suggestions"
                           onChange={e => updateFormLine(line._idx, { type: e.target.value })}
                           className="field-input text-sm py-1" placeholder={t.varietyType ?? 'Type *'} />
                         <input type="text" value={line.colour || ''}
+                          list="po-colour-suggestions"
                           onChange={e => updateFormLine(line._idx, { colour: e.target.value })}
                           className="field-input text-sm py-1" placeholder={t.varietyColour ?? 'Colour'} />
                         <input type="number" value={line.size || ''}
                           onChange={e => updateFormLine(line._idx, { size: e.target.value })}
                           className="field-input text-sm py-1" placeholder={t.varietySize ?? 'Size (cm)'} />
                         <input type="text" value={line.cultivar || ''}
+                          list="po-cultivar-suggestions"
                           onChange={e => updateFormLine(line._idx, { cultivar: e.target.value })}
                           className="field-input text-sm py-1" placeholder={t.varietyCultivar ?? 'Cultivar'} />
                       </div>

--- a/apps/florist/src/pages/PurchaseOrderPage.jsx
+++ b/apps/florist/src/pages/PurchaseOrderPage.jsx
@@ -1,7 +1,7 @@
 // PurchaseOrderPage — mobile-optimized PO management for the owner in the florist app.
 // Full lifecycle: create POs, edit drafts, send to driver, track status, manage payments.
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import client from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
@@ -71,6 +71,27 @@ export default function PurchaseOrderPage() {
   // Negative stock items for pre-filling new POs
   const negativeStock = stock.filter(s => (Number(s['Current Quantity']) || 0) < 0);
 
+  // Owner ask 2026-05-31: suggest existing Type / Colour / Cultivar / Farmer
+  // values when typing on a new-Variety PO line, to prevent duplicates from
+  // misspellings ("Peon" vs "Peony"). Sourced from current Stock; refreshed
+  // when /stock fetch lands.
+  const typeSuggestions = useMemo(
+    () => Array.from(new Set(stock.map(s => s['Type'] ?? s.type_name).filter(Boolean))).sort(),
+    [stock],
+  );
+  const colourSuggestions = useMemo(
+    () => Array.from(new Set(stock.map(s => s['Colour'] ?? s.colour).filter(Boolean))).sort(),
+    [stock],
+  );
+  const cultivarSuggestions = useMemo(
+    () => Array.from(new Set(stock.map(s => s['Cultivar'] ?? s.cultivar).filter(Boolean))).sort(),
+    [stock],
+  );
+  const farmerSuggestions = useMemo(
+    () => Array.from(new Set(stock.map(s => s['Farmer'] ?? s.farmer).filter(Boolean))).sort(),
+    [stock],
+  );
+
   function emptyLine() {
     return {
       stockItemId: '', flowerName: '', quantity: 1, lotSize: 0, packages: 0,
@@ -112,7 +133,21 @@ export default function PurchaseOrderPage() {
   }
 
   function updateFormLine(idx, patch) {
-    setFormLines(prev => prev.map((l, i) => i === idx ? { ...l, ...patch } : l));
+    setFormLines(prev => prev.map((l, i) => {
+      if (i !== idx) return l;
+      const merged = { ...l, ...patch };
+      // Owner ask 2026-05-31: when both Pkgs and LotSize are set, Qty reflects
+      // the total stems that will actually be ordered (pkgs * lotSize). Owner
+      // can still type Qty manually; only Pkgs / LotSize edits trigger the
+      // auto-sync.
+      const touchedPkgsOrLot = 'packages' in patch || 'lotSize' in patch;
+      if (touchedPkgsOrLot) {
+        const pkgs = Number(merged.packages) || 0;
+        const ls = Number(merged.lotSize) || 0;
+        if (pkgs > 0 && ls > 0) merged.quantity = pkgs * ls;
+      }
+      return merged;
+    }));
   }
 
   function removeFormLine(idx) {
@@ -339,6 +374,21 @@ export default function PurchaseOrderPage() {
 
   return (
     <div className="min-h-screen">
+      {/* Typeahead suggestion sources for new-variety + farmer inputs (issue: dup
+          spellings like "Peon" vs "Peony"). datalist is HTML5-native; the
+          browser handles substring filtering as the user types. */}
+      <datalist id="po-type-suggestions">
+        {typeSuggestions.map(s => <option key={s} value={s} />)}
+      </datalist>
+      <datalist id="po-colour-suggestions">
+        {colourSuggestions.map(s => <option key={s} value={s} />)}
+      </datalist>
+      <datalist id="po-cultivar-suggestions">
+        {cultivarSuggestions.map(s => <option key={s} value={s} />)}
+      </datalist>
+      <datalist id="po-farmer-suggestions">
+        {farmerSuggestions.map(s => <option key={s} value={s} />)}
+      </datalist>
       <header className="glass-nav px-4 py-3 sticky top-0 z-10">
         <div className="flex items-center justify-between max-w-2xl mx-auto">
           <button onClick={() => navigate('/stock')} className="text-brand-600 font-medium text-base active-scale">
@@ -446,6 +496,7 @@ export default function PurchaseOrderPage() {
                   {/* Farmer + Notes */}
                   <div className="flex items-center gap-2">
                     <input type="text" value={line.farmer || ''}
+                      list="po-farmer-suggestions"
                       onChange={e => updateFormLine(idx, { farmer: e.target.value })}
                       className="field-input flex-1 text-sm" placeholder={t.farmer || 'Farmer'} />
                     <input type="text" value={line.notes || ''}
@@ -460,15 +511,18 @@ export default function PurchaseOrderPage() {
                       </p>
                       <div className="grid grid-cols-2 gap-2">
                         <input type="text" value={line.type || ''}
+                          list="po-type-suggestions"
                           onChange={e => updateFormLine(idx, { type: e.target.value })}
                           className="field-input text-sm py-1" placeholder={t.po?.type ?? 'Type *'} />
                         <input type="text" value={line.colour || ''}
+                          list="po-colour-suggestions"
                           onChange={e => updateFormLine(idx, { colour: e.target.value })}
                           className="field-input text-sm py-1" placeholder={t.po?.colour ?? 'Colour'} />
                         <input type="number" value={line.size || ''}
                           onChange={e => updateFormLine(idx, { size: e.target.value })}
                           className="field-input text-sm py-1" placeholder={t.po?.size ?? 'Size (cm)'} />
                         <input type="text" value={line.cultivar || ''}
+                          list="po-cultivar-suggestions"
                           onChange={e => updateFormLine(idx, { cultivar: e.target.value })}
                           className="field-input text-sm py-1" placeholder={t.po?.cultivar ?? 'Cultivar'} />
                       </div>


### PR DESCRIPTION
## Summary

Two owner-reported sandbox issues with the new-PO form (2026-05-31):

**1. Pkgs + LotSize did not update Qty.** Typing Pkgs=5 with LotSize=5 correctly displayed \`= 5 × 5 = 25\` inline and stored 25 on save, but the Qty input stayed at 1 — confusing for the owner who reads Qty as "what will actually be ordered". Now: whenever Pkgs **or** LotSize is edited and both are positive, Qty auto-syncs to \`pkgs * lotSize\`. The owner can still type Qty manually for the no-package path; only Pkgs / LotSize edits trigger the sync. Save logic unchanged.

**2. Duplicate-spelling risk on the new-Variety panel.** Typing "Peon" on the Type field gave no hint that "Peony" already exists in stock — same risk on Colour, Cultivar, Farmer. Added HTML5 \`<datalist>\` typeahead sourced from current Stock for all four fields in both florist \`PurchaseOrderPage.jsx\` and dashboard \`StockOrderPanel.jsx\`. As the owner types, the browser surfaces matching existing values; she can pick one to lock spelling or continue typing a new value.

Suppliers field is already a \`<select>\` from settings — no change there.

## Verification

- 337/337 shared tests pass
- Florist + dashboard build clean
- Verified locally in the prod-mirror sandbox under \`STOCK_Y_MODEL=true\`

Refs #291

## Test plan

- [ ] New PO line → enter Pkgs=5 with LotSize=5 → Qty input flips to 25
- [ ] Switch back: clear Pkgs → Qty stays at last computed value (owner can edit)
- [ ] New-variety panel → type "Peon" in Type → browser shows "Peony" suggestion
- [ ] Same for Colour ("Pin" → "Pink"), Cultivar, Farmer fields
- [ ] Saving picks the spelled-correctly value when user clicks the suggestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)