### PR TITLE
fix(telegram): diff-detect PO driver assignment (no re-ping on same-driver save)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Review this entire file before flipping to production.
 
 ---
 
+## 2026-06-02 — PO assignment notification: diff-detection
+
+`PATCH /api/stock-orders/:id` now only sends the driver a Telegram PO-assignment ping when the Assigned Driver genuinely changes. Previously, re-saving a PO with the same driver re-pinged on every save. Mirrors the diff-detection already in the delivery PATCH path. SSE broadcast is unchanged (still fires on every save). Follow-up to PR #369.
+
+### Backend
+- `backend/src/routes/stockOrders.js` — capture prior `Assigned Driver` before the update; gate `notifyPoAssigned` on `newDriver && newDriver !== priorDriver`.
+- `backend/src/__tests__/stockOrders.assign-notify.integration.test.js` (NEW) — proves notify fires on empty→driver and driver→driver changes, and does NOT fire on same-driver re-save.
+
+---
+
 ## 2026-06-02 — Florist New-Order Telegram Notifications (florist half of #336)
 
 Every new Order (In-store, Wix, Flowwow, AI-intake, premade conversion) now sends a Telegram ping to the shared florist phone. Florists register once by sending `/start <PIN_FLORIST>` to the existing alerts bot. Reuses the driver notification infra (ADR-0009) — same bot, same `/start` loop, no new bot token.

--- a/backend/src/__tests__/stockOrders.assign-notify.integration.test.js
+++ b/backend/src/__tests__/stockOrders.assign-notify.integration.test.js
@@ -1,0 +1,134 @@
+// Integration test for PO PATCH diff-detection: notify assigned driver only on
+// a genuine assignment change. Follow-up to PR #369 (driver notifications) —
+// the PATCH path previously re-pinged on every save with a non-empty driver.
+//
+// What we're proving:
+//   • notifyPoAssigned fires when Assigned Driver changes '' → 'Nikita'
+//   • notifyPoAssigned does NOT fire when re-saving the SAME driver
+//   • notifyPoAssigned fires again when the driver actually changes Nikita → Timur
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the notify seam BEFORE importing the router so the route's top-level
+// import resolves to the mock.
+vi.mock('../services/driverNotifyService.js', () => ({
+  notifyDeliveryAssigned: vi.fn().mockResolvedValue(undefined),
+  notifyDeliveryDigest:   vi.fn().mockResolvedValue(undefined),
+  notifyPoAssigned:       vi.fn().mockResolvedValue(undefined),
+}));
+
+// SSE broadcast — no-op (not under test).
+vi.mock('../services/notifications.js', () => ({ broadcast: vi.fn() }));
+
+// orderService is imported by stockOrders.js — stub it out.
+vi.mock('../services/orderService.js', () => ({
+  createOrder: vi.fn(),
+  autoMatchStock: vi.fn(),
+}));
+
+// configService (loaded by the route) — avoid the production config path.
+vi.mock('../services/configService.js', () => ({
+  getConfig:      vi.fn((k) => ({}[k] ?? 0)),
+  getDriverOfDay: () => 'Timur',
+}));
+
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import express from 'express';
+import supertest from 'supertest';
+
+const dbHolder = { db: null };
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  isPostgresConfigured: true,
+  pool: null,
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+// Import AFTER mocks are in place.
+import { notifyPoAssigned } from '../services/driverNotifyService.js';
+import * as stockOrderRepo from '../repos/stockOrderRepo.js';
+import stockOrdersRouter from '../routes/stockOrders.js';
+
+const OWNER_PIN = 'test-owner-pin-po';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.role = req.headers['x-auth-pin'] === OWNER_PIN ? 'owner' : 'owner';
+    next();
+  });
+  app.use('/api/stock-orders', stockOrdersRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(err.statusCode || 500).json({ error: err.message });
+  });
+  return app;
+}
+
+let harness, app, poId;
+
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+  vi.clearAllMocks();
+  app = buildApp();
+
+  const po = await stockOrderRepo.create({
+    Status: 'Draft',
+    'Assigned Driver': '',
+    'Planned Date': '2026-06-03',
+  });
+  poId = po['Stock Order ID'] || po.id;
+});
+
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+describe('PO assignment → driver notification diff-detection', () => {
+  it('notifies when Assigned Driver changes empty → Nikita', async () => {
+    const res = await supertest(app)
+      .patch(`/api/stock-orders/${poId}`)
+      .set('x-auth-pin', OWNER_PIN)
+      .send({ 'Assigned Driver': 'Nikita' });
+
+    expect(res.status).toBe(200);
+    await new Promise(r => setImmediate(r));
+
+    expect(notifyPoAssigned).toHaveBeenCalledTimes(1);
+    expect(notifyPoAssigned.mock.calls[0][0]).toMatchObject({ driverName: 'Nikita' });
+  });
+
+  it('does NOT notify when re-saving the SAME driver', async () => {
+    await supertest(app).patch(`/api/stock-orders/${poId}`)
+      .set('x-auth-pin', OWNER_PIN).send({ 'Assigned Driver': 'Nikita' });
+
+    vi.clearAllMocks();
+
+    const res = await supertest(app).patch(`/api/stock-orders/${poId}`)
+      .set('x-auth-pin', OWNER_PIN).send({ 'Assigned Driver': 'Nikita' });
+
+    expect(res.status).toBe(200);
+    await new Promise(r => setImmediate(r));
+
+    expect(notifyPoAssigned).not.toHaveBeenCalled();
+  });
+
+  it('notifies again when the driver actually changes Nikita → Timur', async () => {
+    await supertest(app).patch(`/api/stock-orders/${poId}`)
+      .set('x-auth-pin', OWNER_PIN).send({ 'Assigned Driver': 'Nikita' });
+
+    vi.clearAllMocks();
+
+    const res = await supertest(app).patch(`/api/stock-orders/${poId}`)
+      .set('x-auth-pin', OWNER_PIN).send({ 'Assigned Driver': 'Timur' });
+
+    expect(res.status).toBe(200);
+    await new Promise(r => setImmediate(r));
+
+    expect(notifyPoAssigned).toHaveBeenCalledTimes(1);
+    expect(notifyPoAssigned.mock.calls[0][0]).toMatchObject({ driverName: 'Timur' });
+  });
+});

--- a/backend/src/routes/stockOrders.js
+++ b/backend/src/routes/stockOrders.js
@@ -234,16 +234,23 @@ router.patch('/:id', authorize('stock-orders'), async (req, res, next) => {
       }
     }
 
+    // Capture the prior driver so we only notify on a genuine assignment change
+    // (mirrors deliveries.js — re-saving a PO with the same driver must not re-ping).
+    const priorDriver = ('Assigned Driver' in fields)
+      ? ((await stockOrderRepo.getById(req.params.id).catch(() => null))?.['Assigned Driver'] || '')
+      : '';
+
     const updated = await stockOrderRepo.update(req.params.id, fields);
 
     if ('Assigned Driver' in fields) {
+      const newDriver = fields['Assigned Driver'] || '';
       broadcast({
         type: 'stock_pickup_assigned',
         stockOrderId: req.params.id,
-        driverName: fields['Assigned Driver'] || '',
+        driverName: newDriver,
       });
-      if (fields['Assigned Driver']) {
-        notifyPoAssigned({ stockOrderId: req.params.id, driverName: fields['Assigned Driver'] })
+      if (newDriver && newDriver !== priorDriver) {
+        notifyPoAssigned({ stockOrderId: req.params.id, driverName: newDriver })
           .catch(err => console.error('[DRIVER_NOTIFY] po patch hook failed:', err.message));
       }
     }


### PR DESCRIPTION
Follow-up to #369. The PO PATCH path re-sent the driver's Telegram PO-assignment ping on **every** save with a non-empty Assigned Driver — re-saving an unrelated field (or the same driver) re-pinged.

## Fix
`backend/src/routes/stockOrders.js` — capture the prior `Assigned Driver` before the update and gate `notifyPoAssigned` on `newDriver && newDriver !== priorDriver`. Mirrors the diff-detection already in `deliveries.js`. The SSE `stock_pickup_assigned` broadcast is left firing on every save (cheap, idempotent on the client) — only the Telegram ping is gated.

## Test
`backend/src/__tests__/stockOrders.assign-notify.integration.test.js` (new): notify fires on empty→Nikita and Nikita→Timur; does NOT fire on same-driver re-save. Red-phase confirmed (the same-driver test fails without the fix).

## Verification
- New + sibling regression tests: 13 passed (`stockOrders.assign-notify`, `stockOrders.receiveIntoStock`, `deliveries.assign-notify`)
- API E2E suite: 216 passed, 0 failed
- Backend-only, no schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)