### PR TITLE
fix(po): gate Y-model variety fields behind flag + make Type-only lines sendable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Review this entire file before flipping to production.
 
 ---
 
+## 2026-06-04 — PO new-Variety fields gated behind STOCK_Y_MODEL + send-identity fix
+
+The new-PO form showed the Y-model **"New variety"** identity row (`Type *` / Colour / Size / Cultivar, issue #304) for any off-plan line **regardless of the `STOCK_Y_MODEL` flag** — so it "crept into" prod where the flag is off. The prominent `Type *` lured the owner into filling Type instead of the Flower Name, and the PO then **could not be sent to the driver**: the line persisted with an empty Flower Name + a Type, which `POST /stock-orders/:id/send` rejected as a blank line (`Fill flower name on N blank line(s) before sending`) even though `POST /:id/lines` had accepted Type as valid identity.
+
+### Frontend (gate the Y-model UI)
+- `apps/florist/src/pages/PurchaseOrderPage.jsx` + `apps/dashboard/src/components/StockOrderPanel.jsx` — the Variety identity row (new-PO form **and** inline `DraftLineEditor`) now renders only when `useStockYModelFlag()` is true. Flag off (prod) → the form reverts to the plain Flower Name flow; the Variety fields never appear.
+
+### Backend (consistency / hardening — `backend/src/routes/stockOrders.js`)
+- New `composeFlowerName()` helper. PO line persistence (create, add-line, and Variety-attr PATCH) now composes a driver-readable Flower Name from `Type/Colour/Size/Cultivar` when no explicit name was given — mirrors the frontend wizard compose, so every new-Variety line carries a name.
+- `POST /:id/send` blank-check now counts a line's `Type` as valid identity (matches the line-add rule), so a line accepted on creation can never be rejected on send. This also unblocks any Type-only line already stuck in prod.
+- Regression test: `backend/src/__tests__/stockOrders.sendIdentity.integration.test.js` (create-composes-and-sends, inline-PATCH-composes, genuinely-blank-still-blocks).
+
+### No schema migration
+Behaviour + UI-gating change only. No env vars, no tables. Y-model stays off in prod (`STOCK_Y_MODEL` unset).
+
+---
+
 ## 2026-06-03 — Revert order status (owner any→any, florist history-undo)
 
 A florist who marked the wrong bouquet **Delivered** (or **Picked Up**) had no way back — the order state machine had zero exits from terminal states, so reverting was hard-blocked at the backend (the owner's dashboard `Status` pills returned `400 Cannot move from "Delivered" to "Ready". Allowed: none (terminal)`).

--- a/apps/dashboard/src/components/StockOrderPanel.jsx
+++ b/apps/dashboard/src/components/StockOrderPanel.jsx
@@ -6,6 +6,7 @@ import client from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import t from '../translations.js';
 import useConfigLists from '../hooks/useConfigLists.js';
+import { useStockYModelFlag } from '@flower-studio/shared';
 
 const STATUS_COLORS = {
   Draft:        'bg-gray-100 text-gray-700',
@@ -20,6 +21,9 @@ const STATUS_COLORS = {
 export default function StockOrderPanel({ negativeStock, stock, autoCreate, onClose }) {
   const { suppliers: SUPPLIERS, targetMarkup } = useConfigLists();
   const { showToast } = useToast();
+  // Y-model new-Variety fields (#304) only show when the flag is on. Off in prod
+  // → owner uses the plain Flower Name flow; the Variety row never "creeps in".
+  const yModelOn = useStockYModelFlag();
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
   const [expandedId, setExpandedId] = useState(null);
@@ -521,8 +525,8 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
                       />
                     </div>
                   </div>
-                  {/* Variety identity row — only when no Stock Item link (Y-model #304) */}
-                  {!line.stockItemId && (
+                  {/* Variety identity row — Y-model (#304), only when no Stock Item link */}
+                  {yModelOn && !line.stockItemId && (
                     <div className="rounded-lg border border-indigo-100 bg-indigo-50/40 p-2 space-y-1.5 mt-2">
                       <p className="text-[10px] uppercase tracking-wide text-indigo-600 font-semibold">
                         {t.newVariety ?? 'New variety'}
@@ -713,6 +717,7 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
                           onRemove={(lineId) => removeDraftLine(order.id, lineId)}
                           targetMarkup={targetMarkup}
                           suppliers={SUPPLIERS}
+                          yModelOn={yModelOn}
                         />
                       ))}
                       {order.Status === 'Draft' ? (
@@ -1114,7 +1119,7 @@ function StockSearchInput({ stock, value, onChange, onSelect, onBlur: onBlurCb }
 
 // Inline editor for a single Draft PO line — flower search, qty, cost, sell, supplier, farmer, notes.
 // Auto-saves on blur so changes persist immediately without a "save" button.
-function DraftLineEditor({ line, stock, onUpdate, onRemove, targetMarkup, suppliers }) {
+function DraftLineEditor({ line, stock, onUpdate, onRemove, targetMarkup, suppliers, yModelOn }) {
   const storedLs = Number(line['Lot Size']) || 0;
   const storedQty = Number(line['Quantity Needed']) || 1;
   // Display qty as lots (user enters lots, not stems)
@@ -1303,8 +1308,8 @@ function DraftLineEditor({ line, stock, onUpdate, onRemove, targetMarkup, suppli
         </div>
       </div>
 
-      {/* Variety identity row — only when no Stock Item link (Y-model, #304) */}
-      {!stockItemLinked && (
+      {/* Variety identity row — Y-model (#304), only when no Stock Item link */}
+      {yModelOn && !stockItemLinked && (
         <div className="rounded-lg border border-indigo-100 bg-indigo-50/40 p-2 space-y-1.5">
           <p className="text-[10px] uppercase tracking-wide text-indigo-600 font-semibold">
             {t.newVariety ?? 'New variety'}

--- a/apps/florist/src/pages/PurchaseOrderPage.jsx
+++ b/apps/florist/src/pages/PurchaseOrderPage.jsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import client from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import useConfigLists from '../hooks/useConfigLists.js';
+import { useStockYModelFlag } from '@flower-studio/shared';
 import t from '../translations.js';
 
 const STATUS_COLORS = {
@@ -30,6 +31,9 @@ export default function PurchaseOrderPage() {
   const navigate = useNavigate();
   const { suppliers: SUPPLIERS, targetMarkup, drivers: configDrivers } = useConfigLists();
   const { showToast } = useToast();
+  // Y-model new-Variety fields (#304) only show when the flag is on. Off in prod
+  // → owner uses the plain Flower Name flow; the Variety row never "creeps in".
+  const yModelOn = useStockYModelFlag();
 
   const [orders, setOrders] = useState([]);
   const [stock, setStock] = useState([]);
@@ -452,8 +456,8 @@ export default function PurchaseOrderPage() {
                       onChange={e => updateFormLine(idx, { notes: e.target.value })}
                       className="field-input flex-1 text-sm" placeholder={t.po?.notes || 'Notes'} />
                   </div>
-                  {/* Variety identity row — only when no Stock Item link (Y-model #304) */}
-                  {!line.stockItemId && (
+                  {/* Variety identity row — Y-model (#304), only when no Stock Item link */}
+                  {yModelOn && !line.stockItemId && (
                     <div className="rounded-xl border border-indigo-100 bg-indigo-50/40 p-2 space-y-1.5">
                       <p className="text-[10px] uppercase tracking-wide text-indigo-600 font-semibold">
                         {t.po?.newVariety ?? 'New variety'}
@@ -613,6 +617,7 @@ export default function PurchaseOrderPage() {
                             onRemove={(lineId) => removeDraftLine(order.id, lineId)}
                             targetMarkup={targetMarkup}
                             suppliers={SUPPLIERS}
+                            yModelOn={yModelOn}
                           />
                         ))}
                         {order.Status === 'Draft' ? (
@@ -832,7 +837,7 @@ function StockSearchInput({ stock, value, onChange, onSelect, onBlur: onBlurCb }
 }
 
 // ── Draft line editor (mobile layout) ──
-function DraftLineEditor({ line, stock, onUpdate, onRemove, targetMarkup, suppliers }) {
+function DraftLineEditor({ line, stock, onUpdate, onRemove, targetMarkup, suppliers, yModelOn }) {
   const storedLs = Number(line['Lot Size']) || 0;
   const storedQty = Number(line['Quantity Needed']) || 1;
   // Display qty as lots (user enters lots, not stems)
@@ -990,8 +995,8 @@ function DraftLineEditor({ line, stock, onUpdate, onRemove, targetMarkup, suppli
           className="field-input flex-1 text-sm py-1" placeholder={t.po?.notes || 'Notes'} />
       </div>
 
-      {/* Variety identity row — only when no Stock Item link (Y-model, #304) */}
-      {!stockItemLinked && (
+      {/* Variety identity row — Y-model (#304), only when no Stock Item link */}
+      {yModelOn && !stockItemLinked && (
         <div className="rounded-xl border border-indigo-100 bg-indigo-50/40 p-2 space-y-1.5">
           <p className="text-[10px] uppercase tracking-wide text-indigo-600 font-semibold">
             {t.po?.newVariety ?? 'New variety'}

--- a/backend/src/__tests__/stockOrders.sendIdentity.integration.test.js
+++ b/backend/src/__tests__/stockOrders.sendIdentity.integration.test.js
@@ -1,0 +1,110 @@
+// Regression: a new-Variety PO line (Y-model #304 — Type set, no explicit
+// Flower Name) must compose a Flower Name on persistence and be sendable.
+//
+// The bug ("cannot send PO to driver"): the ungated Variety UI let the owner
+// fill the "Type *" field instead of a Flower Name. The line persisted with an
+// empty Flower Name + Type. POST /:id/lines accepted it (Type counts as
+// identity), but POST /:id/send's blank-check only looked at Stock Item ||
+// Flower Name — so it rejected the line as blank and the PO never reached the
+// driver. Fix: compose Flower Name from the Variety attrs at persistence, and
+// count Type as identity on /send (consistent with line-add).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../services/driverNotifyService.js', () => ({
+  notifyDeliveryAssigned: vi.fn().mockResolvedValue(undefined),
+  notifyDeliveryDigest:   vi.fn().mockResolvedValue(undefined),
+  notifyPoAssigned:       vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../services/notifications.js', () => ({ broadcast: vi.fn() }));
+vi.mock('../services/orderService.js', () => ({ createOrder: vi.fn(), autoMatchStock: vi.fn() }));
+vi.mock('../services/configService.js', () => ({
+  getConfig:      vi.fn((k) => ({}[k] ?? 0)),
+  getDriverOfDay: () => 'Timur',
+}));
+
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import express from 'express';
+import supertest from 'supertest';
+
+const dbHolder = { db: null };
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  isPostgresConfigured: true,
+  pool: null,
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+import stockOrdersRouter from '../routes/stockOrders.js';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => { req.role = 'owner'; next(); });
+  app.use('/api/stock-orders', stockOrdersRouter);
+  app.use((err, _req, res, _next) => res.status(err.statusCode || 500).json({ error: err.message }));
+  return app;
+}
+
+let harness, app;
+const agent = () => supertest(app);
+
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+  vi.clearAllMocks();
+  app = buildApp();
+});
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+describe('PO send — new-Variety line identity (#304 regression)', () => {
+  it('create composes Flower Name from Type/Colour/Size and the PO is sendable', async () => {
+    const created = await agent().post('/api/stock-orders').send({
+      notes: 'y-model',
+      lines: [{ flowerName: '', type: 'Peony', colour: 'Pink', size: 50, quantity: 10, costPrice: 0 }],
+    });
+    expect(created.status).toBe(201);
+    const poId = created.body.id;
+
+    const got = await agent().get(`/api/stock-orders/${poId}`);
+    expect(got.body.lines).toHaveLength(1);
+    expect(got.body.lines[0]['Flower Name']).toBe('Peony Pink 50cm');
+    expect(got.body.lines[0].Type).toBe('Peony');
+
+    const sent = await agent().post(`/api/stock-orders/${poId}/send`).send({ driverName: 'Timur' });
+    expect(sent.status).toBe(200);
+    expect(sent.body.Status).toBe('Sent');
+  });
+
+  it('inline PATCH of Type onto a blank Draft line composes a Flower Name and stays sendable', async () => {
+    const created = await agent().post('/api/stock-orders').send({ lines: [{ flowerName: 'Seed', quantity: 1 }] });
+    const poId = created.body.id;
+
+    const blank = await agent().post(`/api/stock-orders/${poId}/lines`).send({ flowerName: '', quantity: 5 });
+    const lineId = blank.body.id;
+
+    await agent().patch(`/api/stock-orders/${poId}/lines/${lineId}`).send({ Type: 'Rose' });
+
+    const got = await agent().get(`/api/stock-orders/${poId}`);
+    const line = got.body.lines.find(l => l.id === lineId);
+    expect(String(line['Flower Name'] || '').trim()).not.toBe('');
+    expect(line.Type).toBe('Rose');
+
+    const sent = await agent().post(`/api/stock-orders/${poId}/send`).send({ driverName: 'Timur' });
+    expect(sent.status).toBe(200);
+  });
+
+  it('still blocks /send on a genuinely blank line (no stock item, no name, no Type)', async () => {
+    const created = await agent().post('/api/stock-orders').send({ lines: [{ flowerName: 'Real', quantity: 1 }] });
+    const poId = created.body.id;
+    await agent().post(`/api/stock-orders/${poId}/lines`).send({ flowerName: '', quantity: 1 });
+
+    const sent = await agent().post(`/api/stock-orders/${poId}/send`).send({ driverName: 'Timur' });
+    expect(sent.status).toBe(400);
+    expect(sent.body.error).toMatch(/blank line/i);
+  });
+});

--- a/backend/src/routes/stockOrders.js
+++ b/backend/src/routes/stockOrders.js
@@ -20,6 +20,21 @@ import { notifyPoAssigned } from '../services/driverNotifyService.js';
 
 const VALID_STATUSES = VALID_PO_STATUSES;
 
+// Compose a driver-readable Flower Name from Y-model Variety attrs (#304) when
+// a line carries a new-Variety Type but no explicit Flower Name. Mirrors the
+// frontend createPO compose so every Variety line has a name. Without it, a
+// Type-only line (the inline DraftLineEditor patches Type on its own) persisted
+// with an empty Flower Name and the /send identity check rejected it as blank
+// — the "cannot send PO to driver" bug.
+function composeFlowerName({ flowerName, type, colour, size, cultivar } = {}) {
+  const explicit = String(flowerName ?? '').trim();
+  if (explicit) return explicit;
+  return [type, colour, size != null && size !== '' ? `${size}cm` : null, cultivar]
+    .map(v => (v == null ? '' : String(v).trim()))
+    .filter(Boolean)
+    .join(' ');
+}
+
 // Resolve a flower name to an Airtable-safe stock item ID.
 // Uses stockRepo (Postgres) not Airtable — the stock table is frozen in AT.
 // Returns the Airtable recXXX if the item was backfilled, or null for
@@ -179,7 +194,10 @@ router.post('/', authorize('stock-orders', ['owner']), async (req, res, next) =>
       const lineFields = {
         'Stock Orders':    [order._pgId],
         ...(resolvedStockItemId ? { 'Stock Item': [resolvedStockItemId] } : {}),
-        'Flower Name':     line.flowerName || '',
+        'Flower Name':     composeFlowerName({
+          flowerName: line.flowerName, type: line.type,
+          colour: line.colour, size: line.size, cultivar: line.cultivar,
+        }),
         'Quantity Needed': Number(line.quantity) || 0,
         ...(lotSize > 0 ? { 'Lot Size': lotSize } : {}),
         'Driver Status':   PO_LINE_STATUS.PENDING,
@@ -311,6 +329,25 @@ router.patch('/:id/lines/:lineId', authorize('stock-orders'), async (req, res, n
       }
     }
 
+    // When a Draft line gets a new-Variety Type/Colour/Size/Cultivar but no
+    // explicit Flower Name (the inline DraftLineEditor patches Type on its own),
+    // compose a name from the merged attrs so the row stays sendable and the
+    // driver sees what to buy. Without this the line is invisible to /send.
+    if (['Type', 'Colour', 'Size', 'Cultivar'].some(k => k in fields)) {
+      const existing = await stockOrderRepo.getLineById(req.params.lineId);
+      const merged = (k) => (k in fields ? fields[k] : existing[k]);
+      const mergedName = String(merged('Flower Name') ?? '').trim();
+      const mergedType = String(merged('Type') ?? '').trim();
+      if (!mergedName && mergedType) {
+        fields['Flower Name'] = composeFlowerName({
+          type:     merged('Type'),
+          colour:   merged('Colour'),
+          size:     merged('Size'),
+          cultivar: merged('Cultivar'),
+        });
+      }
+    }
+
     const updated = await stockOrderRepo.updateLine(req.params.lineId, fields);
 
     if ('Driver Status' in fields && po.Status === PO_STATUS.SENT) {
@@ -369,7 +406,7 @@ router.post('/:id/lines', authorize('stock-orders', ['owner']), async (req, res,
     const line = await stockOrderRepo.createLine({
       'Stock Orders':    [po._pgId],
       ...(resolvedStockItemId ? { 'Stock Item': [resolvedStockItemId] } : {}),
-      'Flower Name':     flowerName || '',
+      'Flower Name':     composeFlowerName({ flowerName, type, colour, size, cultivar }),
       'Quantity Needed': Number(quantity) || 1,
       Supplier:          supplier || '',
       'Cost Price':      Number(costPrice) || 0,
@@ -440,7 +477,11 @@ router.post('/:id/send', authorize('stock-orders', ['owner']), async (req, res, 
       const blankCount = lines.filter(l => {
         const hasStockItem = Array.isArray(l['Stock Item']) && l['Stock Item'].length > 0;
         const hasFlowerName = String(l['Flower Name'] || '').trim() !== '';
-        return !hasStockItem && !hasFlowerName;
+        // A new-Variety line (Type set) is valid identity too — matches the
+        // line-add rule (hasNewVarietyIntent) so a line accepted on creation
+        // can't be rejected on send. Persistence composes its Flower Name.
+        const hasVariety = String(l['Type'] || '').trim() !== '';
+        return !hasStockItem && !hasFlowerName && !hasVariety;
       }).length;
       if (blankCount > 0) {
         return res.status(400).json({


### PR DESCRIPTION
## Problem (diagnosed via `/diagnose`, deterministic repro)

Creating a PO on prod surfaced the Y-model **"New variety"** identity row (`Type *` / Colour / Size / Cultivar, #304) for any off-plan line — **ungated by `STOCK_Y_MODEL`**, so it crept into prod where the flag is off. The prominent `Type *` lured the owner into filling Type instead of the Flower Name, and **the PO then couldn't be sent to the driver**.

**Root cause (two coupled bugs):**
1. **Frontend ungated.** The Variety row renders on `{!line.stockItemId}` with no flag check in `PurchaseOrderPage.jsx` (florist) or `StockOrderPanel.jsx` (dashboard) — main form *and* inline `DraftLineEditor`.
2. **Backend inconsistent.** `POST /:id/lines` accepts `Type` as line identity (`hasNewVarietyIntent`), but `POST /:id/send`'s blank-check only looked at `Stock Item || Flower Name`. A `Type`-only line (empty Flower Name) was accepted on creation, then rejected on send → `400 "Fill flower name on N blank line(s) before sending."`

**Repro (harness, before fix):** create a PO line with `{type:"Peony", flowerName:""}` → persists with empty Flower Name → `POST /send` → **HTTP 400**. After fix → Flower Name composed `"Peony Pink 50cm"`, `/send` → **200 Sent**.

## Fix (scope: gate UI + harden backend)

**Frontend — gate the Y-model UI:**
- The Variety identity row (new-PO form + inline `DraftLineEditor`) now renders only when `useStockYModelFlag()` is true. Flag off (prod) → plain Flower Name flow; the fields never appear.

**Backend (`stockOrders.js`) — consistency + hardening:**
- `composeFlowerName()` helper. Line persistence (create, add-line, Variety-attr PATCH) composes a driver-readable Flower Name from `Type/Colour/Size/Cultivar` when none was given (mirrors the frontend wizard compose).
- `/send` blank-check counts `Type` as valid identity (matches line-add) — a line accepted on creation can't be rejected on send, and any Type-only line already stuck in prod becomes sendable.

## Verification (gate)
- ✅ Deterministic harness repro before/after (400 → 200, Flower Name composed).
- ✅ New regression test `stockOrders.sendIdentity.integration.test.js` (3): create-composes-and-sends, inline-PATCH-composes-and-sends, genuinely-blank-still-blocks.
- ✅ Backend full suite: `npx vitest run` — **545 passed**.
- ✅ API E2E: `npm run harness` + `npm run test:e2e` — **220 passed, 0 failed**.
- ✅ Built florist / dashboard / delivery (`vite build`) — clean.
- ✅ `lab:test:unit` — 40 passed.
- ⚠️ `lab:test:api` not run locally — **Docker daemon down**; CI `lab-api` runs it. Change doesn't touch cancel-with-return.

Note: `STOCK_Y_MODEL` stays off in prod — this PR makes the Y-model PO UI invisible there while keeping the backend consistent for when it's enabled. I could not pull the live Railway log to confirm the prod error string (CLI/MCP OAuth token expired — `railway login` needed); the harness repro produces the exact same 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)