### PR TITLE
fix(bouquet): price pending-PO flowers off their Stock Order, not the stale card sell (#377)

### DIFF
--- a/apps/dashboard/src/components/OrderDetailPanel.jsx
+++ b/apps/dashboard/src/components/OrderDetailPanel.jsx
@@ -8,7 +8,7 @@ import t from '../translations.js';
 import Pills from './Pills.jsx';
 import InlineEdit from './InlineEdit.jsx';
 import useConfigLists from '../hooks/useConfigLists.js';
-import { DissolvePremadesDialog, computePremadeShortfalls, CallButton, BouquetImageEditor, useOrderTerminationFlow, OrderTerminationConfirm } from '@flower-studio/shared';
+import { DissolvePremadesDialog, computePremadeShortfalls, CallButton, BouquetImageEditor, useOrderTerminationFlow, OrderTerminationConfirm, resolveStockLinePrice } from '@flower-studio/shared';
 
 // Split "Rose Red (14.Mar.)" into { name: "Rose Red", batch: "14.Mar." }
 function parseBatchName(displayName) {
@@ -234,7 +234,8 @@ export default function OrderDetailPanel({ orderId, onUpdate, onNavigate }) {
   const editingLineTotal = editingBouquet
     ? editLines.reduce((sum, l) => {
         const si = l.stockItemId ? stockItems.find(s => s.id === l.stockItemId) : null;
-        const price = Number(si?.['Current Sell Price'] ?? l.sellPricePerUnit ?? 0);
+        // Pending-PO flowers price off their PO, not the stale card sell (#377).
+        const price = resolveStockLinePrice(si, pendingPO[l.stockItemId]).sellPricePerUnit || Number(l.sellPricePerUnit) || 0;
         return sum + price * Number(l.quantity || 0);
       }, 0)
     : null;
@@ -595,7 +596,8 @@ export default function OrderDetailPanel({ orderId, onUpdate, onNavigate }) {
             const editCostTotal = editLines.reduce((s, l) => s + Number(l.costPricePerUnit || 0) * Number(l.quantity || 0), 0);
             const editSellTotal = editLines.reduce((sum, l) => {
               const si = l.stockItemId ? stockItems.find(x => x.id === l.stockItemId) : null;
-              const price = Number(si?.['Current Sell Price'] ?? l.sellPricePerUnit ?? 0);
+              // Pending-PO flowers price off their PO, not the stale card sell (#377).
+              const price = resolveStockLinePrice(si, pendingPO[l.stockItemId]).sellPricePerUnit || Number(l.sellPricePerUnit) || 0;
               return sum + price * Number(l.quantity || 0);
             }, 0);
             const editMargin = editSellTotal > 0 ? Math.round(((editSellTotal - editCostTotal) / editSellTotal) * 100) : 0;
@@ -706,8 +708,8 @@ export default function OrderDetailPanel({ orderId, onUpdate, onNavigate }) {
                       .slice(0, 20)
                       .map(s => {
                         const qty = Number(s['Current Quantity']) || 0;
-                        const cost = Number(s['Current Cost Price']) || 0;
-                        const sell = Number(s['Current Sell Price']) || 0;
+                        // Pending-PO flowers price off their PO, not the stale card sell (#377).
+                        const { costPricePerUnit: cost, sellPricePerUnit: sell } = resolveStockLinePrice(s, pendingPO[s.id]);
                         const poQty = pendingPO[s.id]?.ordered || 0;
                         const { name: fn, batch } = parseBatchName(s['Display Name']);
                         return (

--- a/apps/dashboard/src/components/steps/Step2Bouquet.jsx
+++ b/apps/dashboard/src/components/steps/Step2Bouquet.jsx
@@ -5,7 +5,7 @@ import client from '../../api/client.js';
 import t from '../../translations.js';
 import { useToast } from '../../context/ToastContext.jsx';
 import useConfigLists from '../../hooks/useConfigLists.js';
-import { renderStockName, VarietyAllocationPicker, useStockYModelFlag, varietyDisplayName, groupByVariety } from '@flower-studio/shared';
+import { renderStockName, VarietyAllocationPicker, useStockYModelFlag, varietyDisplayName, groupByVariety, resolveStockLinePrice } from '@flower-studio/shared';
 
 const PO_MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
 function formatPoDate(dateStr) {
@@ -131,19 +131,22 @@ export default function Step2Bouquet({
     return l.stockItemId === key || (!l.stockItemId && l.flowerName === key);
   }
 
+  // Pending-PO flowers price off their PO, not the stale card sell (#377).
   const costTotal = useMemo(
     () => orderLines.reduce((s, l) => {
       const si = stock.find(x => x.id === l.stockItemId);
-      return s + Number(si?.['Current Cost Price'] ?? l.costPricePerUnit) * Number(l.quantity);
+      const cost = resolveStockLinePrice(si, pendingPO[l.stockItemId]).costPricePerUnit || Number(l.costPricePerUnit) || 0;
+      return s + cost * Number(l.quantity);
     }, 0),
-    [orderLines, stock]
+    [orderLines, stock, pendingPO]
   );
   const sellTotal = useMemo(
     () => orderLines.reduce((s, l) => {
       const si = stock.find(x => x.id === l.stockItemId);
-      return s + Number(si?.['Current Sell Price'] ?? l.sellPricePerUnit) * Number(l.quantity);
+      const sell = resolveStockLinePrice(si, pendingPO[l.stockItemId]).sellPricePerUnit || Number(l.sellPricePerUnit) || 0;
+      return s + sell * Number(l.quantity);
     }, 0),
-    [orderLines, stock]
+    [orderLines, stock, pendingPO]
   );
   const margin = sellTotal > 0 ? Math.round(((sellTotal - costTotal) / sellTotal) * 100) : 0;
 
@@ -212,12 +215,14 @@ export default function Step2Bouquet({
           l.stockItemId === stockItem.id ? { ...l, quantity: l.quantity + 1 } : l
         );
       }
+      // Pending-PO flower prices off its PO, not the stale card sell (#377).
+      const { costPricePerUnit, sellPricePerUnit } = resolveStockLinePrice(stockItem, pendingPO[stockItem.id]);
       return [...lines, {
         stockItemId:      stockItem.id,
         flowerName:       stockItem['Display Name'],
         quantity:         1,
-        costPricePerUnit: Number(stockItem['Current Cost Price']) || 0,
-        sellPricePerUnit: Number(stockItem['Current Sell Price']) || 0,
+        costPricePerUnit,
+        sellPricePerUnit,
         stockDeferred:    isFutureOrder,
       }];
     });
@@ -574,7 +579,9 @@ export default function Step2Bouquet({
               const stockItem = stock.find(s => s.id === l.stockItemId);
               const availableQty = Number(stockItem?.['Current Quantity']) || 0;
               const overStock = l.stockItemId && !l.stockDeferred && l.quantity > availableQty;
-              const sellPrice = Number(stockItem?.['Current Sell Price'] ?? l.sellPricePerUnit);
+              // Pending-PO flowers price off their PO, not the stale card sell (#377).
+              const sellPrice = resolveStockLinePrice(stockItem, pendingPO[l.stockItemId]).sellPricePerUnit
+                || Number(l.sellPricePerUnit) || 0;
               const lineSell  = sellPrice * Number(l.quantity);
               return (
               <div key={key} className="px-4 py-3">

--- a/apps/florist/src/components/BouquetEditor.jsx
+++ b/apps/florist/src/components/BouquetEditor.jsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from 'react';
 import {
   renderStockName, parseBatchName, findAllMatchingVariety,
   BatchPickerModal, VarietyAllocationPicker, useStockYModelFlag, useAuth,
-  groupByVariety, varietyDisplayName,
+  groupByVariety, varietyDisplayName, resolveStockLinePrice,
 } from '@flower-studio/shared';
 import t from '../translations.js';
 
@@ -249,7 +249,9 @@ export default function BouquetEditor({ editing, saving, detail, isTerminal, isO
                 {editing.editLines.map((line, idx) => {
                   const si = editing.stockItems.find(s => s.id === line.stockItemId);
                   const availableQty = Number(si?.['Current Quantity']) || 0;
-                  const liveSell = Number(si?.['Current Sell Price'] ?? line.sellPricePerUnit ?? 0);
+                  // Pending-PO flowers price off their PO, not the stale card sell (#377).
+                  const liveSell = resolveStockLinePrice(si, editing.pendingPO?.[line.stockItemId]).sellPricePerUnit
+                    || Number(line.sellPricePerUnit) || 0;
                   const lineSell = liveSell * Number(line.quantity || 0);
                   const overStock = line.stockItemId && line.quantity > availableQty;
                   const linePoQty = line.stockItemId ? (editing.pendingPO?.[line.stockItemId]?.ordered || 0) : 0;

--- a/apps/florist/src/components/OrderCard.jsx
+++ b/apps/florist/src/components/OrderCard.jsx
@@ -11,7 +11,7 @@ import t from '../translations.js';
 import fmtDate from '../utils/formatDate.js';
 import DatePicker from './DatePicker.jsx';
 import useConfigLists from '../hooks/useConfigLists.js';
-import { DissolvePremadesDialog, computePremadeShortfalls, BouquetImageEditor, useOrderTerminationFlow, OrderTerminationConfirm, getStatusOptions } from '@flower-studio/shared';
+import { DissolvePremadesDialog, computePremadeShortfalls, BouquetImageEditor, useOrderTerminationFlow, OrderTerminationConfirm, getStatusOptions, resolveStockLinePrice } from '@flower-studio/shared';
 import ExpandableTextarea from './ExpandableTextarea.jsx';
 
 const STATUS_STYLES = {
@@ -91,6 +91,7 @@ function OrderCard({
   isOwner,
   editorStockItems: stockItems = [],
   editorPremadeMap: premadeMap = {},
+  editorPendingPO: pendingPO = {},
   onStockRefresh,
 }) {
   const { paymentMethods: payMethods, timeSlots, drivers } = useConfigLists();
@@ -320,7 +321,8 @@ function OrderCard({
   const editingLineTotal = editingBouquet
     ? editLines.reduce((sum, l) => {
         const si = l.stockItemId ? stockItems.find(s => s.id === l.stockItemId) : null;
-        const price = Number(si?.['Current Sell Price'] ?? l.sellPricePerUnit ?? 0);
+        // Pending-PO flowers price off their PO, not the stale card sell (#377).
+        const price = resolveStockLinePrice(si, pendingPO[l.stockItemId]).sellPricePerUnit || Number(l.sellPricePerUnit) || 0;
         return sum + price * Number(l.quantity || 0);
       }, 0)
     : null;
@@ -509,7 +511,9 @@ function OrderCard({
                     <div className="bg-gray-50 rounded-xl px-3 py-3 space-y-2">
                       {editLines.map((line, idx) => {
                         const si = line.stockItemId ? stockItems.find(s => s.id === line.stockItemId) : null;
-                        const liveSell = Number(si?.['Current Sell Price'] ?? line.sellPricePerUnit ?? 0);
+                        // Pending-PO flowers price off their PO, not the stale card sell (#377).
+                        const liveSell = resolveStockLinePrice(si, pendingPO[line.stockItemId]).sellPricePerUnit
+                          || Number(line.sellPricePerUnit) || 0;
                         const qtyNum = Number(line.quantity || 0);
                         const lineTotal = liveSell * qtyNum;
                         return (
@@ -539,7 +543,8 @@ function OrderCard({
                       {editLines.length > 0 && (() => {
                         const liveSellTotal = editLines.reduce((sum, l) => {
                           const si = l.stockItemId ? stockItems.find(s => s.id === l.stockItemId) : null;
-                          const price = Number(si?.['Current Sell Price'] ?? l.sellPricePerUnit ?? 0);
+                          // Pending-PO flowers price off their PO, not the stale card sell (#377).
+                          const price = resolveStockLinePrice(si, pendingPO[l.stockItemId]).sellPricePerUnit || Number(l.sellPricePerUnit) || 0;
                           return sum + price * Number(l.quantity || 0);
                         }, 0);
                         const originalTotal = Number(detail?.['Sell Total'] || 0);
@@ -591,7 +596,9 @@ function OrderCard({
                               .slice(0, 6)
                               .map(s => {
                                 const stockQty = Number(s['Current Quantity']) || 0;
-                                const stockSell = Number(s['Current Sell Price']) || 0;
+                                // Pending-PO flowers price off their PO, not the stale card sell (#377).
+                                const addPrice = resolveStockLinePrice(s, pendingPO[s.id]);
+                                const stockSell = addPrice.sellPricePerUnit;
                                 return (
                                   <div key={s.id}
                                     onPointerDown={e => {
@@ -601,7 +608,7 @@ function OrderCard({
                                         id: null, stockItemId: s.id,
                                         flowerName: s['Display Name'],
                                         quantity: 1, _originalQty: 0,
-                                        costPricePerUnit: Number(s['Current Cost Price']) || 0,
+                                        costPricePerUnit: addPrice.costPricePerUnit,
                                         sellPricePerUnit: stockSell,
                                       }]);
                                       setFlowerSearch('');
@@ -1344,6 +1351,7 @@ function arePropsEqual(prev, next) {
   if (prev.isOwner !== next.isOwner) return false;
   if (prev.editorStockItems !== next.editorStockItems) return false;
   if (prev.editorPremadeMap !== next.editorPremadeMap) return false;
+  if (prev.editorPendingPO !== next.editorPendingPO) return false;
   if (prev.onStockRefresh !== next.onStockRefresh) return false;
   if (prev.onOrderUpdated !== next.onOrderUpdated) return false;
   if (prev.onOrderDeleted !== next.onOrderDeleted) return false;

--- a/apps/florist/src/components/steps/Step2Bouquet.jsx
+++ b/apps/florist/src/components/steps/Step2Bouquet.jsx
@@ -10,7 +10,7 @@ import { useToast } from '../../context/ToastContext.jsx';
 import { useAuth } from '../../context/AuthContext.jsx';
 import t from '../../translations.js';
 import useConfigLists from '../../hooks/useConfigLists.js';
-import { renderStockName, VarietyAllocationPicker, useStockYModelFlag, varietyDisplayName, groupByVariety } from '@flower-studio/shared';
+import { renderStockName, VarietyAllocationPicker, useStockYModelFlag, varietyDisplayName, groupByVariety, resolveStockLinePrice } from '@flower-studio/shared';
 
 const PO_MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
 function formatPoDate(dateStr) {
@@ -32,7 +32,9 @@ const CONFIDENCE_STYLES = {
 function CartLine({ line: l, stock, onChangeQty, onCommitQty, onCommitPrices, onRemove, isFutureOrder, onToggleDeferred, pendingPO, isOwner }) {
   const stockItem = stock.find(s => s.id === l.stockItemId);
   const availableQty = Number(stockItem?.['Current Quantity']) || 0;
-  const sellPrice = Number(stockItem?.['Current Sell Price'] ?? l.sellPricePerUnit);
+  // Pending-PO flowers price off their PO, not the stale card sell (#377).
+  const sellPrice = resolveStockLinePrice(stockItem, pendingPO?.[l.stockItemId]).sellPricePerUnit
+    || Number(l.sellPricePerUnit) || 0;
   const lineSell  = sellPrice * Number(l.quantity);
   const confidence = l.confidence; // 'high' | 'low' | 'none' | undefined
   // Don't show over-stock warning for deferred lines (they don't pull from inventory)
@@ -251,8 +253,10 @@ export default function Step2Bouquet({
       if (!l.stockItemId) return l;
       const si = stock.find(x => x.id === l.stockItemId);
       if (!si) return l;
-      const newCost = Number(si['Current Cost Price']) || 0;
-      const newSell = Number(si['Current Sell Price']) || 0;
+      // Keep the pending-PO price for not-yet-arrived flowers; only physical
+      // stock re-syncs to the card sell (#377).
+      const { costPricePerUnit: newCost, sellPricePerUnit: newSell } =
+        resolveStockLinePrice(si, pendingPO[l.stockItemId]);
       if (newCost !== l.costPricePerUnit || newSell !== l.sellPricePerUnit) {
         changed = true;
         return { ...l, costPricePerUnit: newCost, sellPricePerUnit: newSell };
@@ -260,22 +264,25 @@ export default function Step2Bouquet({
       return l;
     });
     if (changed) onLinesChange(() => updated);
-  }, [stock, orderLines, onLinesChange]);
+  }, [stock, orderLines, onLinesChange, pendingPO]);
 
-  // Use current stock prices for display totals (snapshot happens at submit)
+  // Use current stock prices for display totals (snapshot happens at submit).
+  // Pending-PO flowers price off their PO, not the stale card sell (#377).
   const costTotal = useMemo(
     () => orderLines.reduce((s, l) => {
       const si = stock.find(x => x.id === l.stockItemId);
-      return s + Number(si?.['Current Cost Price'] ?? l.costPricePerUnit) * Number(l.quantity);
+      const cost = resolveStockLinePrice(si, pendingPO[l.stockItemId]).costPricePerUnit || Number(l.costPricePerUnit) || 0;
+      return s + cost * Number(l.quantity);
     }, 0),
-    [orderLines, stock]
+    [orderLines, stock, pendingPO]
   );
   const sellTotal = useMemo(
     () => orderLines.reduce((s, l) => {
       const si = stock.find(x => x.id === l.stockItemId);
-      return s + Number(si?.['Current Sell Price'] ?? l.sellPricePerUnit) * Number(l.quantity);
+      const sell = resolveStockLinePrice(si, pendingPO[l.stockItemId]).sellPricePerUnit || Number(l.sellPricePerUnit) || 0;
+      return s + sell * Number(l.quantity);
     }, 0),
-    [orderLines, stock]
+    [orderLines, stock, pendingPO]
   );
   const margin = sellTotal > 0 ? Math.round(((sellTotal - costTotal) / sellTotal) * 100) : 0;
 
@@ -351,12 +358,14 @@ export default function Step2Bouquet({
           l.stockItemId === stockItem.id ? { ...l, quantity: l.quantity + 1 } : l
         );
       }
+      // Pending-PO flower prices off its PO, not the stale card sell (#377).
+      const { costPricePerUnit, sellPricePerUnit } = resolveStockLinePrice(stockItem, pendingPO[stockItem.id]);
       return [...lines, {
         stockItemId:      stockItem.id,
         flowerName:       stockItem['Display Name'],
         quantity:         1,
-        costPricePerUnit: Number(stockItem['Current Cost Price']) || 0,
-        sellPricePerUnit: Number(stockItem['Current Sell Price']) || 0,
+        costPricePerUnit,
+        sellPricePerUnit,
         stockDeferred:    isFutureOrder,
       }];
     });

--- a/apps/florist/src/pages/OrderListPage.jsx
+++ b/apps/florist/src/pages/OrderListPage.jsx
@@ -108,6 +108,9 @@ export default function OrderListPage() {
   // owner may still want to reference (prevents duplicate-row creation).
   const [editorStockItems, setEditorStockItems] = useState([]);
   const [editorPremadeMap, setEditorPremadeMap] = useState({});
+  // Pending POs per stock item — lets the card price a not-yet-arrived flower
+  // off its Stock Order instead of the stale card sell (#377).
+  const [editorPendingPO, setEditorPendingPO] = useState({});
 
   // Stock evaluation pending count (florist) / shopping POs count (owner)
   const [evalCount, setEvalCount] = useState(0);
@@ -243,12 +246,14 @@ export default function OrderListPage() {
   // (e.g. after dissolving a premade during save).
   const refreshEditorStock = useCallback(async () => {
     try {
-      const [stockRes, premadeRes] = await Promise.all([
+      const [stockRes, premadeRes, poRes] = await Promise.all([
         cachedGet('/stock?includeEmpty=true&includeInactive=true'),
         cachedGet('/stock/premade-committed').catch(() => ({ data: {} })),
+        cachedGet('/stock/pending-po').catch(() => ({ data: {} })),
       ]);
       setEditorStockItems(stockRes.data);
       setEditorPremadeMap(premadeRes.data || {});
+      setEditorPendingPO(poRes.data || {});
     } catch {
       // non-critical — cards fall back to stale-or-empty; the edit save itself
       // will surface a backend error if something is genuinely wrong.
@@ -575,6 +580,7 @@ export default function OrderListPage() {
                 stockShortfalls={stockShortfalls}
                 editorStockItems={editorStockItems}
                 editorPremadeMap={editorPremadeMap}
+                editorPendingPO={editorPendingPO}
                 onStockRefresh={refreshEditorStock}
                 onOrderUpdated={handleOrderUpdated}
                 onOrderDeleted={handleOrderDeleted}

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -336,7 +336,7 @@ router.get('/pending-po', async (req, res, next) => {
         ? rawQty * lotSize   // old format: qty is lot count
         : rawQty;            // new format: qty is already stems
 
-      if (!result[stockId]) result[stockId] = { ordered: 0, plannedDate: null, pos: [], flowerName: '' };
+      if (!result[stockId]) result[stockId] = { ordered: 0, plannedDate: null, pos: [], flowerName: '', sell: 0, cost: 0 };
       result[stockId].ordered += qty;
       if (!result[stockId].flowerName && line['Flower Name']) {
         result[stockId].flowerName = String(line['Flower Name']);
@@ -344,11 +344,28 @@ router.get('/pending-po', async (req, res, next) => {
 
       const poInfo = poMap[line._poPgId];
       if (poInfo) {
-        result[stockId].pos.push({ id: poInfo.id, number: poInfo.number, quantity: qty, plannedDate: poInfo.plannedDate });
+        // Carry the line's own price so bouquet builders can price a not-yet-arrived
+        // flower off its pending PO rather than the stock card's last-received sell (#377).
+        result[stockId].pos.push({
+          id: poInfo.id, number: poInfo.number, quantity: qty, plannedDate: poInfo.plannedDate,
+          sell: Number(line['Sell Price']) || 0, cost: Number(line['Cost Price']) || 0,
+        });
         if (poInfo.plannedDate && (!result[stockId].plannedDate || poInfo.plannedDate < result[stockId].plannedDate)) {
           result[stockId].plannedDate = poInfo.plannedDate;
         }
       }
+    }
+
+    // Per stock item, expose the sell/cost of the soonest-arriving priced PO
+    // (fall back to the first priced line). This is the price the owner just set
+    // in the pending Stock Order — what a bouquet should use until the PO is
+    // evaluated and the stock card's Current Sell Price catches up (#377).
+    for (const entry of Object.values(result)) {
+      const priced = entry.pos.filter(p => p.sell > 0);
+      if (priced.length === 0) continue;
+      priced.sort((a, b) => String(a.plannedDate || '9999-12-31').localeCompare(String(b.plannedDate || '9999-12-31')));
+      entry.sell = priced[0].sell;
+      entry.cost = priced[0].cost;
     }
 
     // Backfill missing prices: find stock items in the result that have zero

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -46,6 +46,7 @@ utils/
   parseBatchName.js           → Extracts date from batch names like "Rose (14.Mar.)"
   stockName.jsx               → Formats stock display names with age/date labels
   stockMath.js                → getEffectiveStock(qty), hasStockShortfall — LOAD-BEARING per root pitfall #7
+  stockLinePrice.js           → resolveStockLinePrice(stockItem, pendingEntry) → {costPricePerUnit, sellPricePerUnit}. A not-yet-arrived flower (qty ≤ 0) prices off its pending Stock Order, not the stale card sell; physical stock keeps the card price (#377). Single rule shared by every bouquet add/display surface (Step2, useOrderEditing, OrderCard, OrderDetailPanel, BouquetEditor).
   orderStatusOptions.js       → getStatusOptions({role, currentStatus, previousStatuses}) — single source of truth for which status pills a user may pick. Owner = any→any; florist/driver = forward map ∪ previously-held statuses (revert). Mirrors backend orderRepo.transitionStatus.
   stockAllocationEngine.js    → stockAllocationEngine(rows, reservations, requiredBy, qty) — Y-model ranked allocation options for one order line (issue #287, PRD #283)
   varietyKey.js               → 4-tuple identity helpers — `varietyKey`, `groupByVariety`, `varietyDisplayName`. NULL-aware per ADR-0006.

--- a/packages/shared/hooks/useOrderEditing.js
+++ b/packages/shared/hooks/useOrderEditing.js
@@ -8,6 +8,7 @@
 import { useState } from 'react';
 import parseBatchName from '../utils/parseBatchName.js';
 import { varietyDisplayName } from '../utils/varietyKey.js';
+import { resolveStockLinePrice } from '../utils/stockLinePrice.js';
 
 const _DATE_BATCH_RE = /\(\d{1,2}\.\w{3,4}\.?\)$/;
 
@@ -179,14 +180,16 @@ export default function useOrderEditing({ orderId, apiClient, showToast, t }) {
 
   // ── Add flower from existing stock ─────────────────────────────
   function addFlowerFromStock(stockItem) {
+    // Price a not-yet-arrived flower off its pending PO, not the stale card sell (#377).
+    const { costPricePerUnit, sellPricePerUnit } = resolveStockLinePrice(stockItem, pendingPO[stockItem.id]);
     setEditLines(prev => [...prev, {
       id: null,
       stockItemId: stockItem.id,
       flowerName: stockItem['Display Name'],
       quantity: 1,
       _originalQty: 0,
-      costPricePerUnit: Number(stockItem['Current Cost Price']) || 0,
-      sellPricePerUnit: Number(stockItem['Current Sell Price']) || 0,
+      costPricePerUnit,
+      sellPricePerUnit,
     }]);
     setFlowerSearch('');
     setAddingFlower(false);

--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -45,6 +45,7 @@ export {
   reasonBadgeClass,
 } from './utils/lossReasons.js';
 export { getEffectiveStock, hasStockShortfall, getVarietyTotals } from './utils/stockMath.js';
+export { resolveStockLinePrice } from './utils/stockLinePrice.js';
 export { getStatusOptions, ALL_ORDER_STATUSES } from './utils/orderStatusOptions.js';
 export {
   matchesSearch,

--- a/packages/shared/test/stockLinePrice.test.js
+++ b/packages/shared/test/stockLinePrice.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { resolveStockLinePrice } from '../utils/stockLinePrice.js';
+
+const card = (qty, cost, sell) => ({
+  'Current Quantity': qty,
+  'Current Cost Price': cost,
+  'Current Sell Price': sell,
+});
+
+describe('resolveStockLinePrice (#377)', () => {
+  it('uses the pending PO sell when the flower has no physical stock', () => {
+    // The owner priced a fresh PO at 60; the card still shows the last-received 65.
+    const out = resolveStockLinePrice(card(0, 22.64, 65), { sell: 60, cost: 21.27 });
+    expect(out.sellPricePerUnit).toBe(60);
+    expect(out.costPricePerUnit).toBe(21.27);
+  });
+
+  it('keeps the card price when physical stems are on hand', () => {
+    // Real stems were received at 65 — a newer pending PO must not retro-price them.
+    const out = resolveStockLinePrice(card(30, 22.64, 65), { sell: 60, cost: 21.27 });
+    expect(out.sellPricePerUnit).toBe(65);
+    expect(out.costPricePerUnit).toBe(22.64);
+  });
+
+  it('falls back to the card price when there is no pending PO entry', () => {
+    const out = resolveStockLinePrice(card(0, 10, 25), undefined);
+    expect(out).toEqual({ costPricePerUnit: 10, sellPricePerUnit: 25 });
+  });
+
+  it('falls back to the card price when the pending PO line is unpriced (sell 0)', () => {
+    const out = resolveStockLinePrice(card(0, 10, 25), { sell: 0, cost: 0 });
+    expect(out).toEqual({ costPricePerUnit: 10, sellPricePerUnit: 25 });
+  });
+
+  it('keeps the card cost when the pending PO carries a sell but no cost', () => {
+    const out = resolveStockLinePrice(card(0, 12, 30), { sell: 28, cost: 0 });
+    expect(out.sellPricePerUnit).toBe(28);
+    expect(out.costPricePerUnit).toBe(12);
+  });
+
+  it('treats negative on-hand (demand entry) as no physical stock', () => {
+    const out = resolveStockLinePrice(card(-15, 22.64, 65), { sell: 60, cost: 21.27 });
+    expect(out.sellPricePerUnit).toBe(60);
+  });
+
+  it('coerces string-numeric inputs and tolerates a missing stock item', () => {
+    const out = resolveStockLinePrice(
+      { 'Current Quantity': '0', 'Current Cost Price': '22.64', 'Current Sell Price': '65' },
+      { sell: '60', cost: '21.27' },
+    );
+    expect(out.sellPricePerUnit).toBe(60);
+    expect(resolveStockLinePrice(null, null)).toEqual({ costPricePerUnit: 0, sellPricePerUnit: 0 });
+  });
+});

--- a/packages/shared/utils/stockLinePrice.js
+++ b/packages/shared/utils/stockLinePrice.js
@@ -1,0 +1,27 @@
+// Decide cost/sell per unit when a flower is added to a bouquet line.
+//
+// A flower with no physical stock on hand (Current Quantity <= 0) that is
+// arriving via a pending Stock Order must price off that PO's sell — NOT the
+// Stock Item's Current Sell Price. The card price reflects the LAST RECEIVED
+// order and stays stale until the new PO is evaluated, so the owner who just
+// priced the flower at 60 in a fresh PO would otherwise see the previous 65 in
+// the bouquet (#377). Once physical stems are on hand, the card price wins —
+// that's the price those real stems were received at.
+//
+// pendingEntry is one value from the /stock/pending-po map:
+//   { ordered, plannedDate, pos: [...], sell, cost, flowerName }
+export function resolveStockLinePrice(stockItem, pendingEntry) {
+  const cardCost = Number(stockItem?.['Current Cost Price']) || 0;
+  const cardSell = Number(stockItem?.['Current Sell Price']) || 0;
+  const physQty  = Number(stockItem?.['Current Quantity']) || 0;
+  const poSell   = Number(pendingEntry?.sell) || 0;
+  const poCost   = Number(pendingEntry?.cost) || 0;
+
+  if (physQty <= 0 && poSell > 0) {
+    return {
+      costPricePerUnit: poCost > 0 ? poCost : cardCost,
+      sellPricePerUnit: poSell,
+    };
+  }
+  return { costPricePerUnit: cardCost, sellPricePerUnit: cardSell };
+}


### PR DESCRIPTION
Closes #377

## dev-summary

**What changed**
- `backend/src/routes/stock.js` — `GET /stock/pending-po` now returns per-stock-item `sell`/`cost`, taken from the soonest-arriving *priced* pending PO line (each `pos[]` entry also carries its own `sell`/`cost`).
- `packages/shared/utils/stockLinePrice.js` (new) — `resolveStockLinePrice(stockItem, pendingEntry)` → `{costPricePerUnit, sellPricePerUnit}`. Rule: physical stock on hand (`Current Quantity > 0`) → card price; no physical stock + a pending PO sell → the PO price; otherwise card price. Tested in `packages/shared/test/stockLinePrice.test.js` (7 cases).
- Wired the rule into every bouquet add + price-display surface, both apps:
  - `packages/shared/hooks/useOrderEditing.js` `addFlowerFromStock` (edit-flow add)
  - `apps/florist/src/components/steps/Step2Bouquet.jsx` + `apps/dashboard/.../steps/Step2Bouquet.jsx` — create-flow add, per-line display, cost/sell totals; florist re-sync effect routed through the helper too
  - `apps/florist/src/components/OrderCard.jsx` — inline editor add + per-line + total (own state, no shared hook); `editorPendingPO` threaded from `apps/florist/src/pages/OrderListPage.jsx`
  - `apps/dashboard/src/components/OrderDetailPanel.jsx` — add + editing-mode totals (local `pendingPO`)
  - `apps/florist/src/components/BouquetEditor.jsx` — per-line cart display
- Dashboard `BouquetSection` already used the stored line price (no change). Florist `OrderDetailPage` filters `qty===0` so pending-PO flowers aren't selectable there (no change).

**Why**
The bouquet line was priced off the Stock Item's `Current Sell Price`, which only updates when a PO is *evaluated/received*. A flower added from a still-pending PO therefore showed the **last received** price, not the price just set in the new Stock Order. Reproduced in prod: *Hydrangea Pink Verena* card sell = 65 (received 28 May), pending PO line = 60 (`eval_status=""`), bouquet showed 65.

**How it connects**
`/stock/pending-po` is already fetched by every bouquet picker (to show the "arrives DD.Mmm" badge). It now also carries the price, so the one shared helper can decide add-time and display-time price uniformly. Once the PO is evaluated, `receiveIntoStock` writes the real price onto the card and the helper falls back to it — self-correcting, no double-handling.

**What to watch for**
- Boundary is `Current Quantity <= 0`. A flower with physical stems at the old price keeps the card price (those stems were really bought at it); only not-yet-arrived flowers use the pending price. Intentional.
- Multiple pending POs for one item → soonest `plannedDate` priced line wins (undated sorts last).

## owner-summary

**What's new for you**
When you add a flower to a bouquet that's still **on the way from a Stock Order** (not yet received), it now shows the price you set in that Stock Order — not an old price from a previous order.

**Why this helps**
Before, a flower you priced at 60 zł in a new Stock Order could show up as 65 zł (its price from a past order) when you built a bouquet. Now the price you just set is the price you see.

**How to use it**
Nothing to do — build bouquets as usual. Flowers arriving from a Stock Order carry that order's price automatically.

**Watch out for**
If you still have leftover stems of a flower in stock from an earlier order, those keep their original price until the new delivery arrives and is checked in — then everything lines up at the new price.

## Verification
- Backend Vitest: 557 passed
- Shared Vitest: 342 passed (incl. 7 new `stockLinePrice` cases)
- API E2E: 220/220 passed
- Builds: florist, dashboard, delivery all ✓
- Lab unit: 40 passed
- `lab:api` (cancel-with-return regression gate) not run locally — unrelated to this change, no schema change; runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)