### PR TITLE
feat(hours): show florist shift windows (from→till) in owner payroll views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Review this entire file before flipping to production.
 
 ---
 
+## 2026-06-09 — Owner sees florist shift windows (from→till), not just total hours
+
+Follow-up to the payroll breakdown below. When a florist logs hours, the FROM→TO windows they enter (e.g. `10:30–15:30, 16:30–18:30`) were collapsed into a total and persisted only as a string inside the entry's `Notes`. The owner could see *how many* hours someone worked on a day, but not *when*. The owner asked to see the actual worked windows per day.
+
+### Frontend only (cross-app parity)
+- **New shared util `packages/shared/utils/parseShiftWindows.js`** (+ `test/parseShiftWindows.test.js`, 12 cases) — `parseShiftWindows(notes)` → `{ windows:[{from,to}], note }`, `formatShiftWindows`, and `shiftWindowsLabel(notes)` → `"10:30–15:30, 16:30–18:30"`. The leading `|`-segment is treated as windows only when *every* comma token is a valid `HH:MM-HH:MM`, so manually-entered notes with no windows pass through untouched.
+- **Florist app** `pages/FloristHoursPage.jsx` (owner view) + **Dashboard** `components/FinancialTab.jsx` — the per-day payroll table now shows the worked windows as a secondary line under each date.
+
+### No schema migration, no new translation keys
+Windows are read out of the existing `Notes` already returned by `GET /florist-hours/payroll`. Pure display change — no backend, no DB, no env. Windows are bare times, so no Russian strings were needed.
+
+---
+
 ## 2026-06-09 — Per-florist payroll breakdown by custom date range (#378)
 
 The owner could only see florist hours as **per-florist monthly totals** (dashboard FinancialTab merged `/summary` across months; florist-app owner view used a month picker). There was no way to pick one florist + an arbitrary date range and see a **day-by-day** breakdown of hours, hourly rate, and earnings — the detail the owner asked for in #378.

--- a/apps/dashboard/src/components/FinancialTab.jsx
+++ b/apps/dashboard/src/components/FinancialTab.jsx
@@ -11,6 +11,7 @@ import client from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import t from '../translations.js';
 import { DashboardSkeleton } from './Skeleton.jsx';
+import { shiftWindowsLabel } from '@flower-studio/shared';
 
 // ── Date range presets ──
 function getPresetRange(preset) {
@@ -505,17 +506,23 @@ export default function FinancialTab({ onNavigate }) {
                         </tr>
                       </thead>
                       <tbody>
-                        {payroll.days.map(d => (
+                        {payroll.days.map(d => {
+                          const windows = shiftWindowsLabel(d.notes);
+                          return (
                           <tr key={d.id} className="border-b border-gray-50">
-                            <td className="px-3 py-2 text-ios-label">{d.date}</td>
-                            {payrollName === '__all' && <td className="px-3 py-2 text-ios-secondary">{d.name}</td>}
-                            <td className="px-3 py-2 text-right text-ios-secondary">{d.hours.toFixed(1)}</td>
-                            <td className="px-3 py-2 text-right text-ios-secondary">{d.hourlyRate.toFixed(0)} {t.zl}</td>
-                            <td className="px-3 py-2 text-right text-ios-secondary">{d.bonus > 0 ? `+${d.bonus.toFixed(0)}` : '—'}</td>
-                            <td className="px-3 py-2 text-right text-ios-secondary">{d.deduction > 0 ? `-${d.deduction.toFixed(0)}` : '—'}</td>
-                            <td className="px-3 py-2 text-right font-medium text-brand-700">{d.earnings.toFixed(0)} {t.zl}</td>
+                            <td className="px-3 py-2 text-ios-label align-top">
+                              {d.date}
+                              {windows && <span className="block text-[11px] text-ios-tertiary">{windows}</span>}
+                            </td>
+                            {payrollName === '__all' && <td className="px-3 py-2 text-ios-secondary align-top">{d.name}</td>}
+                            <td className="px-3 py-2 text-right text-ios-secondary align-top">{d.hours.toFixed(1)}</td>
+                            <td className="px-3 py-2 text-right text-ios-secondary align-top">{d.hourlyRate.toFixed(0)} {t.zl}</td>
+                            <td className="px-3 py-2 text-right text-ios-secondary align-top">{d.bonus > 0 ? `+${d.bonus.toFixed(0)}` : '—'}</td>
+                            <td className="px-3 py-2 text-right text-ios-secondary align-top">{d.deduction > 0 ? `-${d.deduction.toFixed(0)}` : '—'}</td>
+                            <td className="px-3 py-2 text-right font-medium text-brand-700 align-top">{d.earnings.toFixed(0)} {t.zl}</td>
                           </tr>
-                        ))}
+                          );
+                        })}
                       </tbody>
                       <tfoot>
                         <tr className="border-t-2 border-gray-200 font-semibold">

--- a/apps/florist/src/pages/FloristHoursPage.jsx
+++ b/apps/florist/src/pages/FloristHoursPage.jsx
@@ -10,6 +10,7 @@ import { useToast } from '../context/ToastContext.jsx';
 import useConfigLists from '../hooks/useConfigLists.js';
 import client from '../api/client.js';
 import t from '../translations.js';
+import { shiftWindowsLabel } from '@flower-studio/shared';
 
 function todayISO() {
   return new Date().toISOString().split('T')[0];
@@ -390,15 +391,20 @@ function OwnerHoursSummary() {
                   </tr>
                 </thead>
                 <tbody>
-                  {payroll.days.map(d => (
+                  {payroll.days.map(d => {
+                    const windows = shiftWindowsLabel(d.notes);
+                    return (
                     <tr key={d.id} className="border-b border-gray-50 dark:border-gray-800">
-                      <td className="py-2 text-ios-label dark:text-dark-label">{d.date}</td>
-                      {payrollName === '__all' && <td className="py-2 text-ios-secondary">{d.name}</td>}
-                      <td className="py-2 text-right text-ios-secondary">{d.hours.toFixed(1)}</td>
-                      <td className="py-2 text-right text-ios-secondary">{d.hourlyRate.toFixed(0)} zł</td>
-                      <td className="py-2 text-right font-semibold text-brand-600">{d.earnings.toFixed(0)} zł</td>
+                      <td className="py-2 text-ios-label dark:text-dark-label align-top">
+                        {d.date}
+                        {windows && <span className="block text-[11px] font-normal text-ios-tertiary">{windows}</span>}
+                      </td>
+                      {payrollName === '__all' && <td className="py-2 text-ios-secondary align-top">{d.name}</td>}
+                      <td className="py-2 text-right text-ios-secondary align-top">{d.hours.toFixed(1)}</td>
+                      <td className="py-2 text-right text-ios-secondary align-top">{d.hourlyRate.toFixed(0)} zł</td>
+                      <td className="py-2 text-right font-semibold text-brand-600 align-top">{d.earnings.toFixed(0)} zł</td>
                     </tr>
-                  ))}
+                  );})}
                 </tbody>
                 <tfoot>
                   <tr className="border-t-2 border-gray-200 dark:border-gray-700 font-semibold">

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -48,6 +48,7 @@ utils/
   stockMath.js                → getEffectiveStock(qty), hasStockShortfall — LOAD-BEARING per root pitfall #7
   stockLinePrice.js           → resolveStockLinePrice(stockItem, pendingEntry) → {costPricePerUnit, sellPricePerUnit}. A not-yet-arrived flower (qty ≤ 0) prices off its pending Stock Order, not the stale card sell; physical stock keeps the card price (#377). Single rule shared by every bouquet add/display surface (Step2, useOrderEditing, OrderCard, OrderDetailPanel, BouquetEditor).
   orderStatusOptions.js       → getStatusOptions({role, currentStatus, previousStatuses}) — single source of truth for which status pills a user may pick. Owner = any→any; florist/driver = forward map ∪ previously-held statuses (revert). Mirrors backend orderRepo.transitionStatus.
+  parseShiftWindows.js        → parseShiftWindows / formatShiftWindows / shiftWindowsLabel — recover a florist's FROM→TO worked windows from an hours-entry Notes string ("10:30-15:30, 16:30-18:30 | note"). Owner payroll views (FloristHoursPage owner mode + dashboard FinancialTab) show WHEN someone worked, not just the total hours.
   stockAllocationEngine.js    → stockAllocationEngine(rows, reservations, requiredBy, qty) — Y-model ranked allocation options for one order line (issue #287, PRD #283)
   varietyKey.js               → 4-tuple identity helpers — `varietyKey`, `groupByVariety`, `varietyDisplayName`. NULL-aware per ADR-0006.
   timeSlots.js                → Time slot generation with lead-time filtering

--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -47,6 +47,7 @@ export {
 export { getEffectiveStock, hasStockShortfall, getVarietyTotals } from './utils/stockMath.js';
 export { resolveStockLinePrice } from './utils/stockLinePrice.js';
 export { getStatusOptions, ALL_ORDER_STATUSES } from './utils/orderStatusOptions.js';
+export { parseShiftWindows, formatShiftWindows, shiftWindowsLabel } from './utils/parseShiftWindows.js';
 export {
   matchesSearch,
   matchesFilters,

--- a/packages/shared/test/parseShiftWindows.test.js
+++ b/packages/shared/test/parseShiftWindows.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { parseShiftWindows, formatShiftWindows, shiftWindowsLabel } from '../utils/parseShiftWindows.js';
+
+describe('parseShiftWindows', () => {
+  it('returns empty for null / blank input', () => {
+    expect(parseShiftWindows(null)).toEqual({ windows: [], note: '' });
+    expect(parseShiftWindows('')).toEqual({ windows: [], note: '' });
+    expect(parseShiftWindows('   ')).toEqual({ windows: [], note: '' });
+  });
+
+  it('parses a single window', () => {
+    expect(parseShiftWindows('10:30-15:30')).toEqual({
+      windows: [{ from: '10:30', to: '15:30' }],
+      note: '',
+    });
+  });
+
+  it('parses a split shift (multiple windows)', () => {
+    expect(parseShiftWindows('10:30-15:30, 16:30-18:30')).toEqual({
+      windows: [
+        { from: '10:30', to: '15:30' },
+        { from: '16:30', to: '18:30' },
+      ],
+      note: '',
+    });
+  });
+
+  it('separates windows from a trailing free-form note', () => {
+    expect(parseShiftWindows('10:30-15:30, 16:30-18:30 | covered for Anya')).toEqual({
+      windows: [
+        { from: '10:30', to: '15:30' },
+        { from: '16:30', to: '18:30' },
+      ],
+      note: 'covered for Anya',
+    });
+  });
+
+  it('keeps a note that itself contains a pipe', () => {
+    expect(parseShiftWindows('09:00-17:00 | wedding | overtime')).toEqual({
+      windows: [{ from: '09:00', to: '17:00' }],
+      note: 'wedding | overtime',
+    });
+  });
+
+  it('treats a note with no leading windows as pure note', () => {
+    expect(parseShiftWindows('Sick day, half pay')).toEqual({
+      windows: [],
+      note: 'Sick day, half pay',
+    });
+  });
+
+  it('does not partially parse a mixed first segment', () => {
+    // If the leading segment is not entirely valid windows, treat the whole string as a note.
+    expect(parseShiftWindows('10:30-15:30, lunch break')).toEqual({
+      windows: [],
+      note: '10:30-15:30, lunch break',
+    });
+  });
+
+  it('tolerates whitespace around the dash', () => {
+    expect(parseShiftWindows('9:00 - 17:00')).toEqual({
+      windows: [{ from: '9:00', to: '17:00' }],
+      note: '',
+    });
+  });
+});
+
+describe('formatShiftWindows', () => {
+  it('joins windows with an en-dash and comma', () => {
+    expect(formatShiftWindows([{ from: '10:30', to: '15:30' }, { from: '16:30', to: '18:30' }]))
+      .toBe('10:30–15:30, 16:30–18:30');
+  });
+
+  it('returns empty string for no windows', () => {
+    expect(formatShiftWindows([])).toBe('');
+    expect(formatShiftWindows(undefined)).toBe('');
+  });
+});
+
+describe('shiftWindowsLabel', () => {
+  it('turns a notes string straight into a display label', () => {
+    expect(shiftWindowsLabel('10:30-15:30, 16:30-18:30 | note')).toBe('10:30–15:30, 16:30–18:30');
+  });
+
+  it('returns empty when there are no windows', () => {
+    expect(shiftWindowsLabel('Sick day')).toBe('');
+    expect(shiftWindowsLabel('')).toBe('');
+  });
+});

--- a/packages/shared/utils/parseShiftWindows.js
+++ b/packages/shared/utils/parseShiftWindows.js
@@ -1,0 +1,43 @@
+// parseShiftWindows — recover a florist's worked time windows from an hours entry.
+//
+// When a florist logs hours (apps/florist FloristHoursForm), the FROM→TO windows
+// they enter are persisted as the FIRST segment of the entry's Notes string and
+// the total Hours is derived from them at log time, e.g.
+//     "10:30-15:30, 16:30-18:30 | covered for Anya"
+// The windows themselves were never displayed back — the owner only saw the total.
+// This util extracts them so the owner can see WHEN someone worked on a given day,
+// not just the absolute hours.
+
+// A single "HH:MM-HH:MM" window (whitespace around the dash tolerated).
+const WINDOW_RE = /^(\d{1,2}:\d{2})\s*-\s*(\d{1,2}:\d{2})$/;
+
+// Parse an hours-entry Notes string into { windows: [{ from, to }], note }.
+// The leading "|"-segment is treated as windows only when EVERY comma-separated
+// token in it is a valid window — otherwise the whole string is returned as note
+// (covers manually-entered notes that never had windows). The note keeps any
+// pipes beyond the first segment.
+export function parseShiftWindows(notes) {
+  const raw = (notes || '').trim();
+  if (!raw) return { windows: [], note: '' };
+
+  const segments = raw.split('|').map((s) => s.trim());
+  const tokens = segments[0].split(',').map((s) => s.trim()).filter(Boolean);
+
+  const matches = tokens.map((tok) => tok.match(WINDOW_RE));
+  const allWindows = matches.length > 0 && matches.every(Boolean);
+
+  if (!allWindows) return { windows: [], note: raw };
+
+  const windows = matches.map((m) => ({ from: m[1], to: m[2] }));
+  return { windows, note: segments.slice(1).join(' | ').trim() };
+}
+
+// Format parsed windows for display: "10:30–15:30, 16:30–18:30" (en-dash). Empty → ''.
+export function formatShiftWindows(windows) {
+  return (windows || []).map((w) => `${w.from}–${w.to}`).join(', ');
+}
+
+// Convenience: a raw Notes string → its display window label (or '' when none).
+export function shiftWindowsLabel(notes) {
+  return formatShiftWindows(parseShiftWindows(notes).windows);
+}


### PR DESCRIPTION
## What

Follow-up to #378/#379. Florists log work as FROM→TO time **windows** (e.g. `10:30–15:30, 16:30–18:30`), but those windows were collapsed into a daily total and persisted only as a string inside the entry's `Notes`. The owner could see *how many* hours someone worked on a day — never *when*. This surfaces the actual worked windows per day in the owner-facing payroll views.

## How

Pure frontend display change — the windows are already on the wire (`GET /florist-hours/payroll` returns each day's `notes` via `floristHoursService.buildPayroll`).

- **New shared util** `packages/shared/utils/parseShiftWindows.js` (+ `test/parseShiftWindows.test.js`, 12 cases):
  - `parseShiftWindows(notes)` → `{ windows: [{from,to}], note }`
  - `formatShiftWindows(windows)` → `"10:30–15:30, 16:30–18:30"` (en-dash)
  - `shiftWindowsLabel(notes)` — convenience: raw Notes → display label
  - Treats the leading `|`-segment as windows **only when every** comma token is a valid `HH:MM-HH:MM`, so manually-entered notes with no windows pass straight through as the note. Matches exactly the format `FloristHoursForm` writes (`[windowsToString(windows), notes].join(' | ')`).
- **Render (cross-app parity):** the per-day payroll table shows the windows as a secondary line under each date in:
  - `apps/florist/src/pages/FloristHoursPage.jsx` (owner mode)
  - `apps/dashboard/src/components/FinancialTab.jsx`

## Scope notes
- **No schema / migration / env / backend change.** No new translation keys — windows are bare times.
- Parity: delivery app has no hours surface; florist + dashboard both updated.

## Verification (pre-PR matrix)
- `packages/shared` tests: **354 pass** (342 baseline + 12 new) via backend vitest binary
- Builds clean: **florist ✓ · dashboard ✓ · delivery ✓**
- No `backend/` or `lab/` changes → backend Vitest / E2E / lab suites N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)