### PR TITLE
feat(stock): S1 — Y-model date chips + date-grouped arrivals + layout (CR-32/33/34/11)

### DIFF
--- a/apps/delivery/src/pages/StockPickupPage.jsx
+++ b/apps/delivery/src/pages/StockPickupPage.jsx
@@ -345,7 +345,11 @@ function PickupLineItem({ line, orderId, onUpdate, isSaving, flowers = [], suppl
       <div className="flex items-center justify-between mb-2">
         <div className="flex items-center gap-2">
           <div className={`w-2.5 h-2.5 rounded-full ${statusColor}`} />
-          <span className="text-base font-medium text-ios-label">{line['Flower Name']}</span>
+          {/* CR-11: the driver doesn't need the needed-by date — strip the
+              trailing "(YYYY-MM-DD)" / "(DD.Mon.)" suffix, keep the identity. */}
+          <span className="text-base font-medium text-ios-label">
+            {String(line['Flower Name'] || '').replace(/\s*\([^)]*\)\s*$/, '').trim() || line['Flower Name']}
+          </span>
         </div>
         {isSaving && (
           <div className="w-4 h-4 border border-brand-300 border-t-brand-600 rounded-full animate-spin" />

--- a/apps/florist/src/pages/StockPanelPage.jsx
+++ b/apps/florist/src/pages/StockPanelPage.jsx
@@ -428,23 +428,16 @@ export default function StockPanelPage() {
           </button>
         )}
 
-        {/* Pending arrivals — Y-native (Variety-grouped) when flag on,
-            legacy per-stockId table when flag off. */}
-        {yEnabled
-          ? <PendingArrivalsPanel
-              pendingPO={pendingPO}
-              stock={(groups || []).flatMap(g => (g.rows || []).map(r => ({
-                ...r,
-                Type: g.type_name, Colour: g.colour, Size: g.size_cm, Cultivar: g.cultivar,
-              })))}
-              t={t}
-            />
-          : <PendingArrivalsSection
-              stock={stock}
-              committedMap={committedMap}
-              onOrderClick={(id) => navigate(`/orders/${id}`)}
-            />
-        }
+        {/* Legacy per-stockId pending table (flag off). Under Y-model the
+            date-grouped PendingArrivalsPanel renders directly above the
+            ShortfallSummary instead — see below (CR-34). */}
+        {!yEnabled && (
+          <PendingArrivalsSection
+            stock={stock}
+            committedMap={committedMap}
+            onOrderClick={(id) => navigate(`/orders/${id}`)}
+          />
+        )}
 
         {/* Receive stock */}
         <button
@@ -547,6 +540,16 @@ export default function StockPanelPage() {
             <p className="text-ios-tertiary text-sm text-center py-12">{t.noStockFound || 'No items found'}</p>
           ) : (
             <>
+              {/* Pending arrivals stacked directly above shortfalls — the two
+                  "coming / missing" signal panels read together (CR-34). */}
+              <PendingArrivalsPanel
+                pendingPO={pendingPO}
+                stock={(groups || []).flatMap(g => (g.rows || []).map(r => ({
+                  ...r,
+                  Type: g.type_name, Colour: g.colour, Size: g.size_cm, Cultivar: g.cultivar,
+                })))}
+                t={t}
+              />
               <ShortfallSummary
                 groups={filteredGroups}
                 reservations={reservationsMap}

--- a/packages/shared/components/DateTag.jsx
+++ b/packages/shared/components/DateTag.jsx
@@ -1,0 +1,43 @@
+import { formatDateDMY } from '../utils/formatDate.js';
+
+/**
+ * DateTag — the single coloured date chip used across every Y-model stock
+ * surface (decision D6, 2026-06-12). One component so a date never renders
+ * as a raw ISO string or a relative "+Nd" again.
+ *
+ * Props:
+ *   date    — ISO 'YYYY-MM-DD' (or null/'' → undated marker)
+ *   kind    — 'arrived' | 'needed' | 'arriving' (drives the colour)
+ *   compact — true → DD.MM (drop the year) for tight inline chips;
+ *             default → DD.MM.YYYY
+ *   t       — strings ({ undatedShort })
+ *
+ * Colour legend (D6): arrived = grey (batch), needed = red (demand),
+ * arriving = blue (incoming PO).
+ */
+const KIND_CLASS = {
+  arrived:  'bg-gray-100 text-gray-600',
+  needed:   'bg-red-100 text-red-700',
+  arriving: 'bg-blue-100 text-blue-700',
+};
+
+export default function DateTag({ date, kind = 'arrived', compact = false, t = {} }) {
+  const full = formatDateDMY(date); // '' when no/invalid date
+  const label = !full
+    ? (t.undatedShort ?? '—')
+    : compact
+      ? full.slice(0, 5) // 'DD.MM'
+      : full;            // 'DD.MM.YYYY'
+
+  const colour = KIND_CLASS[kind] ?? KIND_CLASS.arrived;
+
+  return (
+    <span
+      data-testid="date-tag"
+      data-kind={kind}
+      className={`inline-flex items-baseline px-1.5 py-0.5 rounded text-[11px] font-medium tabular-nums ${colour}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/packages/shared/components/PendingArrivalsPanel.jsx
+++ b/packages/shared/components/PendingArrivalsPanel.jsx
@@ -1,49 +1,28 @@
 /**
- * PendingArrivalsPanel — Y-model incoming arrivals grouped by Variety.
+ * PendingArrivalsPanel — Y-model incoming arrivals grouped by ARRIVAL DATE.
  *
  * Reads /stock/pending-po (keyed by stockId), joins each entry to its Stock
- * row's Variety attrs (type_name/colour/size_cm/cultivar), buckets by the
- * 4-tuple, then renders one row per Variety with a date strip showing
- * "+N stems → DD.Mon." for each planned arrival.
+ * row's Variety attrs, then buckets every PO line by its planned arrival date.
+ * Each date is headed by a DateTag (kind="arriving") and lists the flowers
+ * landing that day with their incoming quantity. (CR-33, decision D6.)
+ *
+ * Mirrors ShortfallSummary's date-grouped layout so "what's coming" and
+ * "what's missing" read the same way.
  *
  * Props:
  *   pendingPO  — { [stockId]: { ordered, plannedDate, pos[], flowerName } }
  *                 from GET /stock/pending-po
  *   stock      — full /stock list (Y-model rows carry Type/Colour/Size/Cultivar)
  *   t          — translations
- *   today      — optional ISO date override
+ *   today      — optional ISO date override (unused now; kept for API stability)
  */
 import { useMemo, useState } from 'react';
+import DateTag from './DateTag.jsx';
 
-const MONTHS_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+/** Bucket every pending PO line by its arrival date, then by Variety within a date. */
+function bucketByDate(pendingPO, stockById) {
+  const byDate = new Map(); // dateKey → { date, total, flowers: Map<varietyKey, row> }
 
-function dateTag(iso) {
-  if (!iso) return null;
-  const m = String(iso).match(/^(\d{4})-(\d{2})-(\d{2})/);
-  if (!m) return null;
-  const day = Number(m[3]);
-  const month = MONTHS_SHORT[Number(m[2]) - 1] || m[2];
-  return `${day}.${month}.`;
-}
-
-function diffDays(iso, today) {
-  if (!iso) return null;
-  const a = Date.parse(today);
-  const b = Date.parse(iso);
-  if (isNaN(a) || isNaN(b)) return null;
-  return Math.round((b - a) / 86400000);
-}
-
-function ageCls(days) {
-  if (days == null) return 'bg-gray-100 text-gray-500';
-  if (days <= 2)  return 'bg-emerald-100 text-emerald-800';
-  if (days <= 7)  return 'bg-amber-100 text-amber-800';
-  return 'bg-gray-100 text-gray-700';
-}
-
-/** Bucket pendingPO entries by Variety 4-tuple. */
-function bucketByVariety(pendingPO, stockById) {
-  const map = new Map();
   for (const [stockId, po] of Object.entries(pendingPO || {})) {
     const stockRow = stockById.get(stockId);
     if (!stockRow) continue;
@@ -51,58 +30,38 @@ function bucketByVariety(pendingPO, stockById) {
     const colour = stockRow.Colour ?? stockRow.colour ?? null;
     const size = stockRow.Size ?? stockRow.size_cm ?? null;
     const cultivar = stockRow.Cultivar ?? stockRow.cultivar ?? null;
-    // Stock row without Type — surface under a generic bucket using its name
-    // so legacy stock items don't disappear from the panel.
     const key = type
       ? [type, colour ?? '', size ?? '', cultivar ?? ''].join('|')
       : `__legacy__|${po.flowerName || stockRow['Display Name'] || stockId}`;
-    if (!map.has(key)) {
-      map.set(key, {
-        key,
-        type,
-        colour,
-        size,
-        cultivar,
-        fallbackName: type ? null : (po.flowerName || stockRow['Display Name'] || '—'),
-        totalOrdered: 0,
-        // arrivals: array of { date: ISO, qty }
-        arrivals: [],
-        // pos: dedup by id so duplicate rows under the same Variety merge
-        poIds: new Set(),
-        pos: [],
-      });
-    }
-    const g = map.get(key);
-    g.totalOrdered += Number(po.ordered) || 0;
+    const fallbackName = type ? null : (po.flowerName || stockRow['Display Name'] || '—');
+
     for (const p of po.pos || []) {
-      const arrival = {
-        date: p.plannedDate || po.plannedDate || null,
-        qty: Number(p.quantity) || 0,
-        poNumber: p.number || `PO-${String(p.id || '').slice(-4)}`,
-      };
-      if (arrival.qty > 0) g.arrivals.push(arrival);
-      if (p.id && !g.poIds.has(p.id)) { g.poIds.add(p.id); g.pos.push(p); }
+      const qty = Number(p.quantity) || 0;
+      if (qty <= 0) continue;
+      const date = p.plannedDate || po.plannedDate || null;
+      const dKey = date ?? '__undated__';
+
+      if (!byDate.has(dKey)) byDate.set(dKey, { date, total: 0, flowers: new Map() });
+      const sec = byDate.get(dKey);
+      sec.total += qty;
+
+      const f = sec.flowers.get(key) ?? { key, type, colour, size, cultivar, fallbackName, qty: 0 };
+      f.qty += qty;
+      sec.flowers.set(key, f);
     }
   }
-  // Sort each group's arrivals by date (undated last)
-  for (const g of map.values()) {
-    g.arrivals.sort((a, b) => {
+
+  return [...byDate.values()]
+    .map(sec => ({ ...sec, flowers: [...sec.flowers.values()] }))
+    .sort((a, b) => {
       if (!a.date && !b.date) return 0;
-      if (!a.date) return 1;
+      if (!a.date) return 1;   // undated last
       if (!b.date) return -1;
-      return a.date.localeCompare(b.date);
+      return a.date.localeCompare(b.date); // earliest first
     });
-  }
-  // Sort groups by earliest arrival date (most urgent first)
-  return [...map.values()].sort((a, b) => {
-    const ad = a.arrivals[0]?.date ?? '9999';
-    const bd = b.arrivals[0]?.date ?? '9999';
-    return ad.localeCompare(bd);
-  });
 }
 
-export default function PendingArrivalsPanel({ pendingPO = {}, stock = [], t = {}, today }) {
-  const today_ = today ?? new Date().toISOString().slice(0, 10);
+export default function PendingArrivalsPanel({ pendingPO = {}, stock = [], t = {} }) {
   const [collapsed, setCollapsed] = useState(false);
 
   const stockById = useMemo(() => {
@@ -111,14 +70,9 @@ export default function PendingArrivalsPanel({ pendingPO = {}, stock = [], t = {
     return m;
   }, [stock]);
 
-  const groups = useMemo(
-    () => bucketByVariety(pendingPO, stockById),
-    [pendingPO, stockById],
-  );
+  const byDate = useMemo(() => bucketByDate(pendingPO, stockById), [pendingPO, stockById]);
 
-  if (groups.length === 0) return null;
-
-  const totalStems = groups.reduce((s, g) => s + g.totalOrdered, 0);
+  if (byDate.length === 0) return null;
 
   return (
     <section
@@ -137,67 +91,48 @@ export default function PendingArrivalsPanel({ pendingPO = {}, stock = [], t = {
             {t.pendingArrivals ?? 'Incoming'}
           </span>
         </div>
-        <div className="flex items-center gap-3">
-          <div className="text-xs text-indigo-700">
-            <span data-testid="pending-arrivals-varieties" className="font-semibold tabular-nums">{groups.length}</span>
-            <span className="mx-1">{t.pendingArrivalsVarieties ?? t.shortfallsVarieties ?? 'varieties'}</span>
-            <span className="mx-1">·</span>
-            <span data-testid="pending-arrivals-stems" className="font-semibold tabular-nums">{totalStems}</span>
-            <span className="ml-1">{t.pendingArrivalsStems ?? 'stems incoming'}</span>
-          </div>
-          <span
-            data-testid="pending-arrivals-chevron"
-            data-collapsed={String(collapsed)}
-            className={`text-indigo-500 text-xs transition-transform ${collapsed ? '' : 'rotate-180'}`}
-          >
-            ▾
-          </span>
-        </div>
+        <span
+          data-testid="pending-arrivals-chevron"
+          data-collapsed={String(collapsed)}
+          className={`text-indigo-500 text-xs transition-transform ${collapsed ? '' : 'rotate-180'}`}
+        >
+          ▾
+        </span>
       </button>
 
       {!collapsed && (
         <ul className="divide-y divide-indigo-100">
-          {groups.map(g => (
-            <li key={g.key} data-testid="pending-arrivals-row" className="px-4 py-2">
-              <div className="flex items-baseline justify-between gap-2 mb-1">
-                <div className="flex items-baseline gap-2 truncate min-w-0">
-                  {g.type
-                    ? <>
-                        <span className="text-sm font-semibold text-gray-900 shrink-0">{g.type}</span>
-                        {g.colour && <span className="text-sm font-semibold text-gray-900">{g.colour}</span>}
-                        {g.size != null && <span className="text-xs text-gray-600 tabular-nums">{g.size}cm</span>}
-                        {g.cultivar && <span className="text-xs text-gray-400 italic truncate">{g.cultivar}</span>}
-                      </>
-                    : <span className="font-medium text-gray-700 truncate">{g.fallbackName}</span>}
-                </div>
-                <span className="text-sm text-indigo-700 font-semibold tabular-nums shrink-0">
-                  +{g.totalOrdered} {t.stems ?? 'stems'}
+          {byDate.map(sec => (
+            <li key={sec.date ?? 'undated'} data-testid={`pending-arrival-date-${sec.date ?? 'undated'}`} className="px-4 py-2">
+              <div className="flex items-baseline justify-between mb-1">
+                <DateTag date={sec.date} kind="arriving" t={t} />
+                <span className="text-[10px] text-indigo-500 tabular-nums">
+                  +{sec.total} {t.stems ?? 'stems'}
                 </span>
               </div>
-              <div className="flex flex-wrap gap-1.5">
-                {g.arrivals.map((a, i) => {
-                  const tag = dateTag(a.date) ?? (t.undatedShort ?? '—');
-                  const days = diffDays(a.date, today_);
-                  const friendly = days == null
-                    ? tag
-                    : days === 0 ? (t.today ?? 'Today')
-                    : days === 1 ? (t.tomorrow ?? 'Tomorrow')
-                    : days > 0 ? `+${days}${t.daysSuffix ?? 'd'}`
-                    : `${days}${t.daysSuffix ?? 'd'}`;
-                  return (
-                    <span
-                      key={i}
-                      data-testid="pending-arrivals-arrival"
-                      title={a.date ?? ''}
-                      className={`inline-flex items-baseline gap-1 px-2 py-0.5 rounded text-[11px] font-medium tabular-nums ${ageCls(days)}`}
-                    >
-                      <span>+{a.qty}</span>
-                      <span className="opacity-70">·</span>
-                      <span>{friendly}</span>
+              <ul className="space-y-1">
+                {sec.flowers.map(f => (
+                  <li
+                    key={f.key}
+                    data-testid="pending-arrival-row"
+                    className="flex items-baseline justify-between text-sm px-2 py-1"
+                  >
+                    <span className="flex items-baseline gap-2 truncate min-w-0">
+                      {f.type
+                        ? <>
+                            <span className="font-semibold text-gray-900 shrink-0">{f.type}</span>
+                            {f.colour && <span className="font-semibold text-gray-900">{f.colour}</span>}
+                            {f.size != null && <span className="text-xs text-gray-600 tabular-nums">{f.size}cm</span>}
+                            {f.cultivar && <span className="text-xs text-gray-400 italic truncate">{f.cultivar}</span>}
+                          </>
+                        : <span className="font-medium text-gray-700 truncate">{f.fallbackName}</span>}
                     </span>
-                  );
-                })}
-              </div>
+                    <span className="text-sm text-indigo-700 font-semibold tabular-nums shrink-0 ml-2">
+                      +{f.qty}
+                    </span>
+                  </li>
+                ))}
+              </ul>
             </li>
           ))}
         </ul>

--- a/packages/shared/components/ShortfallSummary.jsx
+++ b/packages/shared/components/ShortfallSummary.jsx
@@ -18,6 +18,7 @@
  */
 import { useMemo, useState } from 'react';
 import { getVarietyTotals } from '../utils/stockMath.js';
+import DateTag from './DateTag.jsx';
 
 export default function ShortfallSummary({
   groups,
@@ -98,7 +99,6 @@ export default function ShortfallSummary({
             <li key={date} data-testid={`shortfall-date-${date}`}>
               <DateRow
                 date={date}
-                today={today_}
                 rows={rows}
                 t={t}
                 openRow={openRow}
@@ -115,14 +115,13 @@ export default function ShortfallSummary({
   );
 }
 
-function DateRow({ date, today, rows, t, openRow, trails, loadingId, onToggleRow, onVarietyClick }) {
-  const friendly = friendlyDate(date, today, t);
+function DateRow({ date, rows, t, openRow, trails, loadingId, onToggleRow, onVarietyClick }) {
   const total = rows.reduce((s, r) => s + r.qty, 0);
 
   return (
     <div className="px-4 py-2">
       <div className="flex items-baseline justify-between mb-1">
-        <span className="text-xs font-semibold text-red-700 tabular-nums">{friendly}</span>
+        <DateTag date={date} kind="needed" t={t} />
         <span className="text-[10px] text-red-500 tabular-nums">
           {total} {t.stems}
         </span>
@@ -231,15 +230,3 @@ function bucket(groups, reservations, today) {
   return { byDate, totalStems, varietyCount: varietyKeys.size };
 }
 
-// Owner ask 2026-05-31: drop the parenthetical absolute date when the
-// relative label is already shown — "+3d (2026-06-03)" reads doubled-up.
-// Within 7 days = relative only ("Today", "Tomorrow", "+3d"). Beyond
-// that window the absolute date is more useful than counting days.
-function friendlyDate(date, today, t) {
-  if (date === today) return t.today ?? 'Today';
-  const diffDays = Math.round((Date.parse(date) - Date.parse(today)) / 86400000);
-  if (diffDays === 1) return t.tomorrow ?? 'Tomorrow';
-  if (diffDays > 1 && diffDays <= 7) return `+${diffDays}${t.daysSuffix ?? 'd'}`;
-  if (diffDays < 0 && diffDays >= -7) return `${diffDays}${t.daysSuffix ?? 'd'}`;
-  return date;
-}

--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -86,6 +86,9 @@ export { default as VarietyIdentity } from './components/VarietyIdentity.jsx';
 // Type group sticky collapsible header for Y-model Stock list (issue #289)
 export { default as TypeGroupHeader } from './components/TypeGroupHeader.jsx';
 
+// Single coloured date chip for every Y-model stock surface (decision D6, 2026-06-12)
+export { default as DateTag } from './components/DateTag.jsx';
+
 // Variety row with 4-bucket header for Y-model Stock list (issue #289, pitfall #8)
 export { default as VarietyListItem } from './components/VarietyListItem.jsx';
 

--- a/packages/shared/test/DateTag.test.jsx
+++ b/packages/shared/test/DateTag.test.jsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import DateTag from '../components/DateTag.jsx';
+
+const t = { undatedShort: '—' };
+
+describe('DateTag', () => {
+  it('renders the date as DD.MM.YYYY by default', () => {
+    render(<DateTag date="2026-06-15" kind="needed" t={t} />);
+    expect(screen.getByTestId('date-tag')).toHaveTextContent('15.06.2026');
+  });
+
+  it('renders DD.MM (no year) in compact mode', () => {
+    render(<DateTag date="2026-06-15" kind="needed" compact t={t} />);
+    const tag = screen.getByTestId('date-tag');
+    expect(tag).toHaveTextContent('15.06');
+    expect(tag).not.toHaveTextContent('2026');
+  });
+
+  it('tags the kind via data-kind for styling/queries', () => {
+    render(<DateTag date="2026-06-15" kind="arriving" t={t} />);
+    expect(screen.getByTestId('date-tag')).toHaveAttribute('data-kind', 'arriving');
+  });
+
+  it('colours by kind: arrived=grey, needed=red, arriving=blue', () => {
+    const { rerender } = render(<DateTag date="2026-06-15" kind="arrived" t={t} />);
+    expect(screen.getByTestId('date-tag').className).toMatch(/gray/);
+    rerender(<DateTag date="2026-06-15" kind="needed" t={t} />);
+    expect(screen.getByTestId('date-tag').className).toMatch(/red/);
+    rerender(<DateTag date="2026-06-15" kind="arriving" t={t} />);
+    expect(screen.getByTestId('date-tag').className).toMatch(/blue/);
+  });
+
+  it('shows the undated marker when no date is given', () => {
+    render(<DateTag date={null} kind="arrived" t={t} />);
+    expect(screen.getByTestId('date-tag')).toHaveTextContent('—');
+  });
+
+  it('never shows a raw ISO date or a relative "+Nd" label', () => {
+    render(<DateTag date="2026-06-20" kind="needed" t={t} />);
+    const text = screen.getByTestId('date-tag').textContent;
+    expect(text).not.toMatch(/\d{4}-\d{2}-\d{2}/); // no ISO
+    expect(text).not.toMatch(/\+\d+d/);            // no "+3d"
+  });
+});

--- a/packages/shared/test/PendingArrivalsPanel.test.jsx
+++ b/packages/shared/test/PendingArrivalsPanel.test.jsx
@@ -1,112 +1,95 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import PendingArrivalsPanel from '../components/PendingArrivalsPanel.jsx';
 
-const t = {
-  pendingArrivals: 'Incoming',
-  shortfallsVarieties: 'varieties',
-  shortfallsStems: 'stems',
-  stems: 'stems',
-  today: 'Today',
-  tomorrow: 'Tomorrow',
-  daysSuffix: 'd',
-};
-
-const TODAY = '2026-05-11';
+// CR-33: pending arrivals are grouped BY ARRIVAL DATE (mirrors ShortfallSummary),
+// each date headed by a DateTag (kind=arriving); no "+Nd" chip, no "N varieties /
+// N stems incoming" summary.
+const t = { pendingArrivals: 'Incoming', stems: 'stems', undatedShort: '—' };
+const TODAY = '2026-06-12';
 
 function setup(pendingPO, stock) {
   return render(<PendingArrivalsPanel pendingPO={pendingPO} stock={stock} t={t} today={TODAY} />);
 }
 
-describe('PendingArrivalsPanel', () => {
+describe('PendingArrivalsPanel (date-grouped, CR-33)', () => {
   it('renders nothing when no pending PO', () => {
     const { container } = setup({}, []);
     expect(container.firstChild).toBeNull();
   });
 
-  it('groups multiple stockIds by Variety 4-tuple', () => {
+  it('groups arrivals by date — different flowers on the same date share one section', () => {
     const stock = [
-      { id: 's1', Type: 'Peony', Colour: 'Pink', Size: 50, Cultivar: null },
-      { id: 's2', Type: 'Peony', Colour: 'Pink', Size: 50, Cultivar: null },
-      { id: 's3', Type: 'Rose',  Colour: 'Red',  Size: 60, Cultivar: 'Naomi' },
+      { id: 's1', Type: 'Peony',      Colour: 'Pink',  Size: 50, Cultivar: null },
+      { id: 's2', Type: 'Lisianthus', Colour: 'White', Size: 50, Cultivar: null },
     ];
     const pendingPO = {
-      s1: { ordered: 10, plannedDate: '2026-05-13', pos: [{ id: 'p1', number: 'PO-1', quantity: 10, plannedDate: '2026-05-13' }] },
-      s2: { ordered: 5,  plannedDate: '2026-05-15', pos: [{ id: 'p2', number: 'PO-2', quantity: 5,  plannedDate: '2026-05-15' }] },
-      s3: { ordered: 20, plannedDate: '2026-05-12', pos: [{ id: 'p3', number: 'PO-3', quantity: 20, plannedDate: '2026-05-12' }] },
+      s1: { ordered: 7,  plannedDate: '2026-06-16', pos: [{ id: 'p1', quantity: 7,  plannedDate: '2026-06-16' }] },
+      s2: { ordered: 20, plannedDate: '2026-06-16', pos: [{ id: 'p2', quantity: 20, plannedDate: '2026-06-16' }] },
     };
     setup(pendingPO, stock);
-    const rows = screen.getAllByTestId('pending-arrivals-row');
-    expect(rows).toHaveLength(2); // Two unique Varieties
+    expect(screen.getAllByTestId(/^pending-arrival-date-/)).toHaveLength(1);
+    const section = screen.getByTestId('pending-arrival-date-2026-06-16');
+    expect(within(section).getAllByTestId('pending-arrival-row')).toHaveLength(2);
   });
 
-  it('sums quantities across stockIds of the same Variety', () => {
-    const stock = [
-      { id: 's1', Type: 'Peony', Colour: 'Pink', Size: 50, Cultivar: null },
-      { id: 's2', Type: 'Peony', Colour: 'Pink', Size: 50, Cultivar: null },
-    ];
-    const pendingPO = {
-      s1: { ordered: 10, plannedDate: '2026-05-13', pos: [{ id: 'p1', quantity: 10, plannedDate: '2026-05-13' }] },
-      s2: { ordered: 7,  plannedDate: '2026-05-15', pos: [{ id: 'p2', quantity: 7,  plannedDate: '2026-05-15' }] },
-    };
-    setup(pendingPO, stock);
-    expect(screen.getByText('+17 stems')).toBeInTheDocument();
-  });
-
-  it('renders arrival pills with relative date labels', () => {
+  it('heads each date with a DateTag (kind=arriving, DD.MM.YYYY)', () => {
     const stock = [{ id: 's1', Type: 'Peony', Colour: 'Pink', Size: 50, Cultivar: null }];
-    const pendingPO = {
-      s1: {
-        ordered: 15,
-        plannedDate: '2026-05-12',
-        pos: [
-          { id: 'p1', quantity: 10, plannedDate: '2026-05-12' }, // +1d → Tomorrow
-          { id: 'p2', quantity: 5,  plannedDate: '2026-05-18' }, // +7d
-        ],
-      },
-    };
+    const pendingPO = { s1: { ordered: 7, plannedDate: '2026-06-16', pos: [{ id: 'p1', quantity: 7, plannedDate: '2026-06-16' }] } };
     setup(pendingPO, stock);
-    const arrivals = screen.getAllByTestId('pending-arrivals-arrival');
-    expect(arrivals).toHaveLength(2);
-    expect(arrivals[0].textContent).toContain('+10');
-    expect(arrivals[0].textContent).toContain('Tomorrow');
-    expect(arrivals[1].textContent).toContain('+5');
-    expect(arrivals[1].textContent).toContain('+7d');
+    const tag = within(screen.getByTestId('pending-arrival-date-2026-06-16')).getByTestId('date-tag');
+    expect(tag).toHaveTextContent('16.06.2026');
+    expect(tag).toHaveAttribute('data-kind', 'arriving');
   });
 
-  it('falls back to flower name when stock row has no Type (legacy item)', () => {
-    const stock = [{ id: 's1', 'Display Name': 'Custom Bouquet Filler', Type: null, Colour: null, Size: null, Cultivar: null }];
-    const pendingPO = {
-      s1: { ordered: 3, plannedDate: '2026-05-13', flowerName: 'Custom Bouquet Filler',
-            pos: [{ id: 'p1', quantity: 3, plannedDate: '2026-05-13' }] },
-    };
-    setup(pendingPO, stock);
-    expect(screen.getByText('Custom Bouquet Filler')).toBeInTheDocument();
-  });
-
-  it('collapse toggles row visibility', () => {
+  it('lists each flower with its incoming qty under the date', () => {
     const stock = [{ id: 's1', Type: 'Peony', Colour: 'Pink', Size: 50, Cultivar: null }];
-    const pendingPO = { s1: { ordered: 5, plannedDate: '2026-05-13', pos: [{ id: 'p1', quantity: 5, plannedDate: '2026-05-13' }] } };
+    const pendingPO = { s1: { ordered: 7, plannedDate: '2026-06-16', pos: [{ id: 'p1', quantity: 7, plannedDate: '2026-06-16' }] } };
     setup(pendingPO, stock);
-    expect(screen.getAllByTestId('pending-arrivals-row')).toHaveLength(1);
-    fireEvent.click(screen.getByTestId('pending-arrivals-header'));
-    expect(screen.queryByTestId('pending-arrivals-row')).toBeNull();
+    const row = screen.getByTestId('pending-arrival-row');
+    expect(row.textContent).toContain('Peony');
+    expect(row.textContent).toContain('+7');
   });
 
-  it('orders groups by earliest arrival date (most urgent first)', () => {
+  it('separate dates → separate sections, earliest first', () => {
     const stock = [
       { id: 's1', Type: 'Peony', Colour: 'Pink', Size: 50, Cultivar: null },
       { id: 's2', Type: 'Rose',  Colour: 'Red',  Size: 60, Cultivar: 'Naomi' },
     ];
     const pendingPO = {
-      s1: { ordered: 5, plannedDate: '2026-05-20', pos: [{ id: 'p1', quantity: 5, plannedDate: '2026-05-20' }] },
-      s2: { ordered: 3, plannedDate: '2026-05-12', pos: [{ id: 'p2', quantity: 3, plannedDate: '2026-05-12' }] },
+      s1: { ordered: 5, plannedDate: '2026-06-20', pos: [{ id: 'p1', quantity: 5, plannedDate: '2026-06-20' }] },
+      s2: { ordered: 3, plannedDate: '2026-06-14', pos: [{ id: 'p2', quantity: 3, plannedDate: '2026-06-14' }] },
     };
     setup(pendingPO, stock);
-    const rows = screen.getAllByTestId('pending-arrivals-row');
-    // First row should be Rose (earlier arrival)
-    expect(rows[0].textContent).toContain('Rose');
-    expect(rows[1].textContent).toContain('Peony');
+    const dates = screen.getAllByTestId(/^pending-arrival-date-/);
+    expect(dates).toHaveLength(2);
+    expect(dates[0]).toHaveAttribute('data-testid', 'pending-arrival-date-2026-06-14');
+  });
+
+  it('shows no relative "+Nd" label and no "stems incoming" summary', () => {
+    const stock = [{ id: 's1', Type: 'Peony', Colour: 'Pink', Size: 50, Cultivar: null }];
+    const pendingPO = { s1: { ordered: 7, plannedDate: '2026-06-16', pos: [{ id: 'p1', quantity: 7, plannedDate: '2026-06-16' }] } };
+    const { container } = setup(pendingPO, stock);
+    expect(screen.queryByTestId('pending-arrivals-stems')).toBeNull();
+    expect(screen.queryByTestId('pending-arrivals-varieties')).toBeNull();
+    expect(container.textContent).not.toMatch(/\+\d+d\b/);
+  });
+
+  it('falls back to the flower name for a legacy (typeless) stock row', () => {
+    const stock = [{ id: 's1', 'Display Name': 'Custom Bouquet Filler', Type: null }];
+    const pendingPO = { s1: { ordered: 3, plannedDate: '2026-06-13', flowerName: 'Custom Bouquet Filler',
+                              pos: [{ id: 'p1', quantity: 3, plannedDate: '2026-06-13' }] } };
+    setup(pendingPO, stock);
+    expect(screen.getByText('Custom Bouquet Filler')).toBeInTheDocument();
+  });
+
+  it('collapse toggles the date sections', () => {
+    const stock = [{ id: 's1', Type: 'Peony', Colour: 'Pink', Size: 50, Cultivar: null }];
+    const pendingPO = { s1: { ordered: 5, plannedDate: '2026-06-13', pos: [{ id: 'p1', quantity: 5, plannedDate: '2026-06-13' }] } };
+    setup(pendingPO, stock);
+    expect(screen.getAllByTestId(/^pending-arrival-date-/)).toHaveLength(1);
+    fireEvent.click(screen.getByTestId('pending-arrivals-header'));
+    expect(screen.queryByTestId(/^pending-arrival-date-/)).toBeNull();
   });
 });

--- a/packages/shared/test/ShortfallSummary.test.jsx
+++ b/packages/shared/test/ShortfallSummary.test.jsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import ShortfallSummary from '../components/ShortfallSummary.jsx';
+
+const t = { stems: 'stems', undatedShort: '—' };
+
+// One short Variety (net < 0) with a dated Demand Entry.
+const groups = [{
+  key: 'Peony|Pink|50|', type_name: 'Peony', colour: 'Pink', size_cm: 50, cultivar: null,
+  rows: [{ id: 'd1', current_quantity: -7, date: '2026-06-20' }],
+}];
+
+describe('ShortfallSummary date header (CR-32)', () => {
+  it('renders the needed-by date as a DateTag (DD.MM.YYYY), not a relative "+Nd"', () => {
+    render(<ShortfallSummary groups={groups} t={t} today="2026-06-12" />);
+    const section = screen.getByTestId('shortfall-date-2026-06-20');
+    const tag = within(section).getByTestId('date-tag');
+    expect(tag).toHaveTextContent('20.06.2026');
+    expect(tag).toHaveAttribute('data-kind', 'needed');
+  });
+
+  it('never shows a raw ISO date or a "+Nd" label in the header', () => {
+    render(<ShortfallSummary groups={groups} t={t} today="2026-06-12" />);
+    const header = screen.getByTestId('shortfall-date-2026-06-20')
+      .querySelector('[data-testid="date-tag"]').textContent;
+    expect(header).not.toMatch(/\d{4}-\d{2}-\d{2}/);
+    expect(header).not.toMatch(/\+\d+d/);
+  });
+});


### PR DESCRIPTION
First slice of the Y-model CR plan (`docs/superpowers/plans/2026-06-12-ymodel-cr-implementation-plan.md`). Unblocked, low-risk; fixes the date-format complaints from the live test sessions.

## What changed
- **New `<DateTag>`** (shared) — one coloured date chip per kind (grey=arrived · red=needed · blue=arriving), `DD.MM.YYYY` (compact `DD.MM`). Never relative `+Nd`, never raw ISO (decision **D6**). 6 unit tests.
- **CR-32 ShortfallSummary** — date headers render `DateTag(needed)`; removed the 7-day relative cliff that produced the inconsistent `+3d / +6d / 2026-06-20`.
- **CR-33 PendingArrivalsPanel** — **regrouped by arrival date** (mirrors ShortfallSummary), `DateTag(arriving)` header; dropped the `+qty · +Nd` chip and the `N varieties · N stems incoming` summary. Test rewritten for date-grouping.
- **CR-34 StockPanelPage** — pending arrivals now stack **directly above** shortfalls (Receive + search no longer in between).
- **CR-11 StockPickupPage** — driver line label strips the trailing needed-by date.

## Verification
- TDD red→green throughout. Full shared suite **370 passing**; florist + dashboard + delivery all build clean.
- Rehearsed live on the `y-model-guide` lab scenario.

## Re-slice note
CR-3 (PO planned-date) + CR-4 (qty "050") moved to **S4** (they live in the PO editors S4 consolidates); CR-30 (bouquet cart date) moved to **S3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)