### PR TITLE
fix(dashboard): navigate to exact customer by id from TODAY order click (#335)

### DIFF
--- a/apps/dashboard/src/components/DayToDayTab.jsx
+++ b/apps/dashboard/src/components/DayToDayTab.jsx
@@ -462,7 +462,7 @@ export default function DayToDayTab({ onNavigate, isActive = true }) {
           <div className="bg-gray-50 rounded-xl overflow-hidden divide-y divide-gray-100">
             {data.keyDateReminders.map((r, i) => (
               <div key={i}
-                onClick={() => nav('customers', { search: r.customerName })}
+                onClick={() => nav('customers', { selectedId: r.customerId })}
                 className="flex items-center justify-between px-4 py-2.5 cursor-pointer hover:bg-gray-100 transition-colors">
                 <div>
                   <span className="text-sm font-medium text-ios-label">{r.customerName}</span>


### PR DESCRIPTION
## Summary

- `DayToDayTab.jsx` line 465: replace `nav('customers', { search: r.customerName })` with `nav('customers', { selectedId: r.customerId })` in the key-date reminders click handler
- Clicking a key-date reminder in the TODAY tab now opens the exact matching customer record instead of seeding a fuzzy name-text-search that could match multiple clients with similar names

## Root cause

`keyDateReminders` in `GET /dashboard` already returns `customerId` on every entry (see `backend/src/routes/dashboard.js:174`). `CustomersTab` already handles `f.selectedId` to pre-select a record on mount (see `CustomersTab.jsx:35`). The bug was purely at the call site — a name string was passed instead of the id.

## Verification

**Code trace:**
1. Backend: `keyDateReminders.push({ customerId: c.id, ... })` — `c.id` is the Postgres UUID primary key.
2. DashboardPage: passes `tabFilter` (which becomes `{ selectedId }`) as `initialFilter` to `CustomersTab`.
3. `CustomersTab`: `const [selectedId, setSelected] = useState(f.selectedId || null)` — seeds selection from the filter on mount.
4. Result: correct record opens immediately with no search involvement.

**Build:** `npm run --workspace=apps/dashboard build` — ✓ built in 4.41s, zero errors.

**Parity check (florist app):** The florist's `DaySummaryPage.jsx` fetches from the same `/dashboard` endpoint but does **not** render a key-date reminders widget and does not navigate to the customers screen from that surface. No parity bug exists in the florist app.

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAwbjGui2tRuDXuvHW2pxS