### PR TITLE
fix(dashboard): filter orders by delivery date, not submission date (#337)

### DIFF
--- a/apps/dashboard/src/components/OrdersTab.jsx
+++ b/apps/dashboard/src/components/OrdersTab.jsx
@@ -109,8 +109,11 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
       if (upcomingMode) {
         params.upcoming = '1';
       } else {
-        if (dateFrom) params.dateFrom = dateFrom;
-        if (dateTo) params.dateTo = dateTo;
+        // Filter by delivery/pickup date (Required By), not submission date.
+        // The owner thinks in terms of "when does this order go out",
+        // not "when was it placed" — #337.
+        if (dateFrom) params.requiredByFrom = dateFrom;
+        if (dateTo) params.requiredByTo = dateTo;
       }
       if (unpaidOnly) params.paymentStatus = 'Unpaid';
       if (paidOnly) params.paymentStatus = 'Paid';

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -35,7 +35,7 @@ const ORDERS_PATCH_ALLOWED = [
 // activeOnly: returns all non-terminal orders (excludes Delivered, Picked Up, Cancelled), sorted by Required By asc.
 router.get('/', async (req, res, next) => {
   try {
-    const { status, dateFrom, dateTo, forDate, source, deliveryType, paymentStatus, paymentMethod, excludeCancelled, upcoming, activeOnly, completedOnly } = req.query;
+    const { status, dateFrom, dateTo, requiredByFrom, requiredByTo, forDate, source, deliveryType, paymentStatus, paymentMethod, excludeCancelled, upcoming, activeOnly, completedOnly } = req.query;
     const filters = [];
 
     if (status)           filters.push(`{Status} = '${sanitizeFormulaValue(status)}'`);
@@ -135,6 +135,10 @@ router.get('/', async (req, res, next) => {
     } else {
       if (dateFrom) pgFilter.dateFrom = dateFrom;
       if (dateTo)   pgFilter.dateTo = dateTo;
+      // Delivery/pickup date range — sent by dashboard's Orders tab so the owner
+      // sees orders by when they go out, not when they were placed (#337).
+      if (requiredByFrom) pgFilter.requiredByFrom = requiredByFrom;
+      if (requiredByTo)   pgFilter.requiredByTo = requiredByTo;
     }
 
     const orders = await orderRepo.list({


### PR DESCRIPTION
## Summary

- The date-range picker in the Orders tab (Dashboard) was sending `dateFrom`/`dateTo`, which the backend mapped to `orders.order_date` (when the order was placed). The owner expected the range to filter by **delivery/pickup date** — "show me orders going out this month."
- Fix: frontend now sends `requiredByFrom`/`requiredByTo`; backend route destructures and forwards to `pgFilter`, which `orderRepo.js` already handles at lines 259–260 (filters on `orders.required_by`). Two files changed, zero new imports.

## Verification

- **Backend tests:** 220 passed, 0 new failures (42 test-file failures are pre-existing in this worktree due to `drizzle-orm/node-postgres` not installed — confirmed identical baseline before and after the change via `git stash`)
- **Diff review:** purely a param-name rename on the frontend fetch + one destructure + two `pgFilter` assignments on the backend. No new imports, no new dependencies.
- The `orderRepo.js` `requiredByFrom`/`requiredByTo` path was already exercised by other callers — this PR only wires the dashboard UI to use it.

## Parity note

The florist app's `OrderListPage.jsx` does **not** have a `dateFrom`/`dateTo` range filter — its Completed view uses a single-day `forDate` picker. That picker already routes through `pgFilter.forDate`, which filters `requiredBy OR orderDate` (correct semantics for "show all orders relevant to a specific day"). No florist-app change is needed for #337.

## Issue #390 / #247 overlap

- **#390** ("delivery date filter shows orders instead of deliveries"): operates through the florist's `forDate` path (OR logic — show orders placed on OR due on that day). That is a separate control and a separate design question about OR vs. strict-delivery-only. This PR does not touch that path — #390 is NOT the same code path and will not auto-resolve.
- **#247** (sort by delivery/pickup date): a sort feature request, no overlap with this date-range filter fix.

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAwbjGui2tRuDXuvHW2pxS