### PR TITLE
feat(po): planned date as a coloured arriving chip (CR-3, S4)

### DIFF
--- a/apps/dashboard/src/components/StockOrderPanel.jsx
+++ b/apps/dashboard/src/components/StockOrderPanel.jsx
@@ -6,7 +6,7 @@ import client from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import t from '../translations.js';
 import useConfigLists from '../hooks/useConfigLists.js';
-import { useStockYModelFlag } from '@flower-studio/shared';
+import { useStockYModelFlag, DateTag } from '@flower-studio/shared';
 
 const STATUS_COLORS = {
   Draft:        'bg-gray-100 text-gray-700',
@@ -722,8 +722,9 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
                     <span className="text-xs text-ios-secondary">{order['Assigned Driver']}</span>
                   )}
                   {order['Planned Date'] && (
-                    <span className="text-xs text-blue-600 font-medium">
-                      {t.plannedDate || 'Planned'}: {order['Planned Date']}
+                    <span className="inline-flex items-center gap-1 text-xs text-ios-secondary">
+                      {t.plannedDate || 'Planned'}:
+                      <DateTag date={order['Planned Date']} kind="arriving" t={t} />
                     </span>
                   )}
                 </div>

--- a/apps/florist/src/pages/PurchaseOrderPage.jsx
+++ b/apps/florist/src/pages/PurchaseOrderPage.jsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import client from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import useConfigLists from '../hooks/useConfigLists.js';
-import { useStockYModelFlag } from '@flower-studio/shared';
+import { useStockYModelFlag, DateTag } from '@flower-studio/shared';
 import t from '../translations.js';
 
 const STATUS_COLORS = {
@@ -630,7 +630,7 @@ export default function PurchaseOrderPage() {
                       <span className="text-xs text-ios-secondary">{order['Assigned Driver']}</span>
                     )}
                     {order['Planned Date'] && (
-                      <span className="text-xs text-blue-600 font-medium">{order['Planned Date']}</span>
+                      <DateTag date={order['Planned Date']} kind="arriving" t={t} />
                     )}
                   </div>
                 </button>


### PR DESCRIPTION
First S4 increment. The read-only **Planned Date** on the PO list now renders as the shared \`<DateTag kind="arriving">\` (blue, DD.MM.YYYY) instead of raw ISO text — consistent with the date chips introduced in S1/S3 across the stock surfaces.

- Dashboard \`StockOrderPanel.jsx\` + florist \`PurchaseOrderPage.jsx\` (parity).
- The native date \`<input>\` used to *edit* the planned date is unchanged.

florist + dashboard build green. No shared/backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)