### PR TITLE
fix(delivery): accept comma decimal separators in stock price entry (#333)

### DIFF
--- a/apps/delivery/src/pages/StockPickupPage.jsx
+++ b/apps/delivery/src/pages/StockPickupPage.jsx
@@ -90,7 +90,9 @@ export default function StockPickupPage() {
       if (o.id !== orderId) return o;
       let payments = {};
       try { payments = JSON.parse(o['Supplier Payments'] || '{}'); } catch {}
-      payments[supplier] = amount === '' ? '' : Number(amount) || 0;
+      // Normalize comma decimal separator (mobile numeric keyboards may insert ',')
+      const normalized = String(amount).replace(',', '.');
+      payments[supplier] = normalized === '' ? '' : Number(normalized) || 0;
       return { ...o, 'Supplier Payments': JSON.stringify(payments) };
     }));
   }
@@ -208,7 +210,8 @@ export default function StockPickupPage() {
                         {t.totalPaidAt} {supplier}:
                       </span>
                       <input
-                        type="number"
+                        type="text"
+                        inputMode="decimal"
                         value={payments[supplier] ?? ''}
                         onChange={e => setLocalPayment(order.id, supplier, e.target.value)}
                         onBlur={() => saveSupplierPayment(order.id, supplier)}


### PR DESCRIPTION
## Summary

- **Root cause:** The supplier payment input in `StockPickupPage.jsx` used `type="number"`, which on iOS/Android native keyboards hides the comma key and causes the browser to reject comma input entirely. Drivers couldn't enter prices like `12,50 zł`.
- **Fix:** Changed the input to `type="text" inputMode="decimal"` — this surfaces the native decimal keyboard on mobile (with comma) while allowing both `,` and `.` as decimal separators on all platforms.
- **Normalization:** Added `String(amount).replace(',', '.')` in `setLocalPayment` before `Number()` parse, so comma-separated input is stored correctly. Existing dot-decimal entry is unaffected. Empty string continues to clear the field.

## Files changed

- `apps/delivery/src/pages/StockPickupPage.jsx` — 2 targeted changes: input `type` attribute + normalization in `setLocalPayment`

## Verification

**Build:** `vite build` on the delivery app succeeded — 157 modules transformed, no errors, no warnings from the changed code.

**Manual logic trace:**
- `"12,50"` → `replace(',', '.')` → `"12.50"` → `Number("12.50")` = `12.5` ✓
- `"12.50"` → `replace(',', '.')` → `"12.50"` → `Number("12.50")` = `12.5` ✓
- `"15"` → `replace(',', '.')` → `"15"` → `Number("15")` = `15` ✓
- `""` → normalized `""` → stored as `''` (cleared) ✓

**Scope:** Delivery app only. Integer quantity inputs (`type="number"`) on the same page are not touched — only the decimal price/payment input is changed. No florist/dashboard parity needed (driver-only page).

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAwbjGui2tRuDXuvHW2pxS