### PR TITLE
fix(customers): validate important-date input — 400 not 500 on bad format (#334)

### DIFF
--- a/apps/dashboard/src/components/KeyPersonChips.jsx
+++ b/apps/dashboard/src/components/KeyPersonChips.jsx
@@ -99,10 +99,14 @@ function KeyPersonSlot({ slot, cust, onPatch, autoFocus, onDone }) {
       </div>
       <div className="mt-1">
         <p className="text-[10px] text-ios-tertiary mb-0.5">{t.importantDate}</p>
-        <InlineEdit
-          value={date || ''}
-          onSave={v => onPatch(slot.dateField, v || null)}
-          placeholder="—"
+        {/* Use a native date input so the browser enforces YYYY-MM-DD — prevents
+            free-text reaching the Postgres `date` column and causing a 500. */}
+        <input
+          type="date"
+          defaultValue={date || ''}
+          onBlur={e => onPatch(slot.dateField, e.target.value || null)}
+          className="w-full text-sm text-ios-label bg-transparent border-b border-dashed border-gray-300
+            focus:border-brand-500 focus:outline-none py-0.5 cursor-pointer"
         />
       </div>
     </div>

--- a/apps/florist/src/components/KeyPersonChips.jsx
+++ b/apps/florist/src/components/KeyPersonChips.jsx
@@ -132,10 +132,14 @@ function KeyPersonSlot({ slot, cust, onPatch, canEdit, autoFocus, onDone }) {
       </div>
       <div className="mt-1">
         <p className="text-[10px] text-ios-tertiary mb-0.5">{t.importantDate || 'Important date'}</p>
-        <InlineEdit
-          value={date || ''}
-          onSave={v => onPatch(slot.dateField, v || null)}
-          placeholder="—"
+        {/* Use a native date input so the browser enforces YYYY-MM-DD — prevents
+            free-text reaching the Postgres `date` column and causing a 500. */}
+        <input
+          type="date"
+          defaultValue={date || ''}
+          onBlur={e => onPatch(slot.dateField, e.target.value || null)}
+          className="w-full text-sm text-ios-label bg-transparent border-b border-dashed border-gray-300
+            focus:border-brand-500 focus:outline-none py-0.5 cursor-pointer"
         />
       </div>
     </div>

--- a/backend/src/__tests__/customerRepo.test.js
+++ b/backend/src/__tests__/customerRepo.test.js
@@ -250,6 +250,58 @@ describe('repo.update', () => {
   });
 });
 
+// ── update — importantDate validation (#334) ──
+describe('repo.update — importantDate validation', () => {
+  it('throws 400 when Key person 1 important DATE is a non-ISO string', async () => {
+    await expect(
+      repo.update('uuid-cust-1', { 'Key person 1 (important DATE)': '15.03' }),
+    ).rejects.toMatchObject({ statusCode: 400, message: expect.stringContaining('YYYY-MM-DD') });
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('throws 400 when Key person 2 important DATE is a freeform string', async () => {
+    await expect(
+      repo.update('uuid-cust-1', { 'Key person 2 (important DATE)': 'March 15' }),
+    ).rejects.toMatchObject({ statusCode: 400, message: expect.stringContaining('YYYY-MM-DD') });
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid ISO date (YYYY-MM-DD) without throwing', async () => {
+    const kpRow = { id: 'kp-1', name: 'Bob', importantDate: null, deletedAt: null, createdAt: new Date() };
+    const kpRowUpdated = { ...kpRow, importantDate: '1990-03-15' };
+    // db.select calls: (1) customer row fetch, (2) existing KP fetch, (3) final KP fetch
+    db.select
+      .mockReturnValueOnce(makeChain([makeRow()]))    // customer fetch (no colValues path)
+      .mockReturnValueOnce(makeChain([kpRow]))        // existing KP rows
+      .mockReturnValueOnce(makeChain([kpRowUpdated])); // final KP rows
+    // db.update for the KP row
+    const returning = vi.fn().mockResolvedValue([]);
+    const where     = vi.fn().mockReturnValue({ returning });
+    const set       = vi.fn().mockReturnValue({ where });
+    db.update.mockReturnValue({ set });
+    // Should not throw
+    await expect(
+      repo.update('uuid-cust-1', { 'Key person 1 (important DATE)': '1990-03-15' }),
+    ).resolves.toBeDefined();
+  });
+
+  it('accepts null (clearing the date) without throwing', async () => {
+    const kpRow = { id: 'kp-1', name: 'Bob', importantDate: '1990-03-15', deletedAt: null, createdAt: new Date() };
+    const kpRowCleared = { ...kpRow, importantDate: null };
+    db.select
+      .mockReturnValueOnce(makeChain([makeRow()]))    // customer fetch
+      .mockReturnValueOnce(makeChain([kpRow]))        // existing KP rows
+      .mockReturnValueOnce(makeChain([kpRowCleared])); // final KP rows
+    const returning = vi.fn().mockResolvedValue([]);
+    const where     = vi.fn().mockReturnValue({ returning });
+    const set       = vi.fn().mockReturnValue({ where });
+    db.update.mockReturnValue({ set });
+    await expect(
+      repo.update('uuid-cust-1', { 'Key person 1 (important DATE)': null }),
+    ).resolves.toBeDefined();
+  });
+});
+
 // ── listOrders ──
 describe('repo.listOrders', () => {
   it('merges legacy + app orders, sorts date-desc, nulls last', async () => {

--- a/backend/src/repos/customerRepo.js
+++ b/backend/src/repos/customerRepo.js
@@ -255,6 +255,9 @@ export async function create(fields) {
   return _pgCustomerToResponse(inserted, kps);
 }
 
+// ISO-8601 date format (YYYY-MM-DD) — what Postgres `date` columns accept.
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
 export async function update(id, fields) {
   const colValues = {};
   const kpChanges = {};
@@ -265,6 +268,19 @@ export async function update(id, fields) {
     } else if (field in KP_PATCH_MAP) {
       const { slot, prop } = KP_PATCH_MAP[field];
       if (!kpChanges[slot]) kpChanges[slot] = {};
+
+      // Validate important-date values — Postgres date columns require ISO-8601
+      // (YYYY-MM-DD). Reject anything else with a 400 to avoid a 500 from PG.
+      if (prop === 'importantDate' && value != null && value !== '') {
+        if (!ISO_DATE_RE.test(value)) {
+          const err = new Error(
+            `important_date must be in YYYY-MM-DD format (received: "${value}").`,
+          );
+          err.statusCode = 400;
+          throw err;
+        }
+      }
+
       kpChanges[slot][prop] = value ?? null;
     }
   }


### PR DESCRIPTION
## Problem

Entering a free-text date like `15.03` or `March 15` in the Key Person important-date field caused Postgres to throw `invalid input syntax for type date`, which Express forwarded as an unhandled 500.

## Fix

**Backend (`backend/src/repos/customerRepo.js`)**
Added an ISO-8601 regex guard (`/^\d{4}-\d{2}-\d{2}$/`) in `customerRepo.update()`. Any `importantDate` value that is non-null and doesn't match YYYY-MM-DD is now rejected with a clear 400 error before it reaches Postgres. Empty / null (clearing the date) continues to be accepted.

**Frontend — both apps (cross-app parity)**
Replaced the plain `InlineEdit` on the important-date field in:
- `apps/florist/src/components/KeyPersonChips.jsx`
- `apps/dashboard/src/components/KeyPersonChips.jsx`

…with `<input type="date">`. The browser now enforces YYYY-MM-DD at the point of entry — the 400 guard is a backend safety net, not the primary defence.

## Verification

### Backend tests (`backend/src/__tests__/customerRepo.test.js`)

4 new test cases added to the `repo.update — importantDate validation` describe block:

```
✓ throws 400 when Key person 1 important DATE is a non-ISO string
✓ throws 400 when Key person 2 important DATE is a freeform string
✓ accepts a valid ISO date (YYYY-MM-DD) without throwing
✓ accepts null (clearing the date) without throwing
```

Full run:
```
✓ backend/src/__tests__/customerRepo.test.js (24 tests) 75ms
Test Files  1 passed (1)
Tests  24 passed (24)
```

All 18 non-integration backend test files pass (integration tests fail in the worktree due to a missing `drizzle-orm/node-postgres` package — pre-existing, unrelated to this change).

### Frontend builds

```
apps/florist  → ✓ built in 21.31s
apps/dashboard → ✓ built in 2.04s
```

## Parity note

Both `KeyPersonChips.jsx` files (florist + dashboard) receive identical changes — required by the cross-app parity rule.

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAwbjGui2tRuDXuvHW2pxS