### PR TITLE
feat(florist): delivery-method selector incl. assign-to-florist (#388)

### DIFF
--- a/apps/florist/src/components/OrderCard.jsx
+++ b/apps/florist/src/components/OrderCard.jsx
@@ -1166,7 +1166,11 @@ function OrderCard({
                 </div>
               )}
 
-              {/* ── Driver assignment ──
+              {/* ── Delivery method + driver assignment ──
+                  Parity with dashboard OrderDetailPanel and OrderDetailPage.
+                  Method pill (Driver/Taxi/Florist) always shows for delivery orders.
+                  Driver picker only renders when method is Driver.
+                  When method switches to Florist/Taxi, Assigned Driver is cleared.
                   Gate on `isDelivery && drivers.length` only: do NOT require
                   `detail?.delivery` here. For fresh Delivery orders the
                   Airtable back-link from Deliveries → Orders can take a
@@ -1176,26 +1180,59 @@ function OrderCard({
                   /convert-to-delivery when one is missing, so the picker
                   can work even when `detail.delivery` is undefined. */}
               {isDelivery && drivers.length > 0 && (
-                <div>
-                  <p className="text-xs font-semibold text-ios-tertiary uppercase tracking-wide mb-1">{t.assignedDriver}</p>
-                  <div className="flex flex-wrap gap-1.5">
-                    {drivers.map(driver => (
-                      <button
-                        key={driver}
-                        onClick={() => patchDelivery({ 'Assigned Driver': detail?.delivery?.['Assigned Driver'] === driver ? '' : driver })}
-                        disabled={saving}
-                        className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-colors active-scale disabled:opacity-40 ${
-                          detail?.delivery?.['Assigned Driver'] === driver
-                            ? 'bg-brand-600 text-white border-brand-600 shadow-sm'
-                            : 'bg-gray-100 dark:bg-gray-700 text-ios-secondary dark:text-gray-300 border-gray-200 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600'
-                        }`}
-                      >
-                        {driver}
-                      </button>
-                    ))}
+                <div className="space-y-2">
+                  {/* Delivery method selector */}
+                  <div>
+                    <p className="text-xs font-semibold text-ios-tertiary uppercase tracking-wide mb-1">{t.deliveryMethod}</p>
+                    <Pills
+                      options={[
+                        { value: 'Driver',  label: t.deliveryMethodDriver },
+                        { value: 'Taxi',    label: t.deliveryMethodTaxi },
+                        { value: 'Florist', label: t.deliveryMethodFlorist },
+                      ]}
+                      value={detail?.delivery?.['Delivery Method'] || 'Driver'}
+                      onChange={v => {
+                        const methodPatch = { 'Delivery Method': v };
+                        if (v === 'Taxi') {
+                          methodPatch['Assigned Driver'] = '';
+                          methodPatch['Driver Payout'] = 0;
+                        } else if (v === 'Florist') {
+                          methodPatch['Assigned Driver'] = '';
+                          methodPatch['Driver Payout'] = 0;
+                          methodPatch['Taxi Cost'] = 0;
+                        } else {
+                          methodPatch['Taxi Cost'] = 0;
+                        }
+                        patchDelivery(methodPatch);
+                      }}
+                      disabled={saving}
+                    />
                   </div>
-                  {!detail?.delivery?.['Assigned Driver'] && (
-                    <p className="text-xs text-ios-tertiary mt-1">{t.noDriver}</p>
+
+                  {/* Driver picker — only when method is Driver */}
+                  {(detail?.delivery?.['Delivery Method'] || 'Driver') === 'Driver' && (
+                    <div>
+                      <p className="text-xs font-semibold text-ios-tertiary uppercase tracking-wide mb-1">{t.assignedDriver}</p>
+                      <div className="flex flex-wrap gap-1.5">
+                        {drivers.map(driver => (
+                          <button
+                            key={driver}
+                            onClick={() => patchDelivery({ 'Assigned Driver': detail?.delivery?.['Assigned Driver'] === driver ? '' : driver })}
+                            disabled={saving}
+                            className={`px-3 py-1.5 rounded-full text-sm font-medium border transition-colors active-scale disabled:opacity-40 ${
+                              detail?.delivery?.['Assigned Driver'] === driver
+                                ? 'bg-brand-600 text-white border-brand-600 shadow-sm'
+                                : 'bg-gray-100 dark:bg-gray-700 text-ios-secondary dark:text-gray-300 border-gray-200 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600'
+                            }`}
+                          >
+                            {driver}
+                          </button>
+                        ))}
+                      </div>
+                      {!detail?.delivery?.['Assigned Driver'] && (
+                        <p className="text-xs text-ios-tertiary mt-1">{t.noDriver}</p>
+                      )}
+                    </div>
                   )}
                 </div>
               )}

--- a/apps/florist/src/pages/OrderDetailPage.jsx
+++ b/apps/florist/src/pages/OrderDetailPage.jsx
@@ -567,37 +567,75 @@ export default function OrderDetailPage() {
               </div>
             )}
 
-            {/* Driver assignment — same picker as the expanded OrderCard.
+            {/* Delivery method + driver assignment — parity with dashboard OrderDetailPanel.
+                Method pill (Driver/Taxi/Florist) always shows for delivery orders.
+                Driver picker only renders when method is Driver.
+                When method switches to Florist/Taxi, Assigned Driver is cleared.
                 Gate on `isDelivery && drivers.length` only. Do NOT require
                 `order.delivery` — patchDelivery auto-heals a missing
                 delivery record via /convert-to-delivery. See OrderCard.jsx
                 for the full rationale. */}
             {isDelivery && drivers.length > 0 && (
-              <div>
-                <p className="ios-label">{t.assignedDriver}</p>
-                <div className="ios-card p-4">
-                  <div className="flex flex-wrap gap-1.5">
-                    {drivers.map(driver => (
-                      <button
-                        key={driver}
-                        onClick={() => patchDelivery({
-                          'Assigned Driver': order.delivery?.['Assigned Driver'] === driver ? '' : driver,
-                        })}
-                        disabled={saving}
-                        className={`px-3.5 py-1.5 rounded-full text-sm font-medium border transition-colors active-scale disabled:opacity-40 ${
-                          order.delivery?.['Assigned Driver'] === driver
-                            ? 'bg-brand-600 text-white border-brand-600 shadow-sm'
-                            : 'bg-gray-100 dark:bg-gray-700 text-ios-secondary dark:text-gray-300 border-gray-200 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600'
-                        }`}
-                      >
-                        {driver}
-                      </button>
-                    ))}
+              <div className="space-y-3">
+                {/* Delivery method selector */}
+                <div>
+                  <p className="ios-label">{t.deliveryMethod}</p>
+                  <div className="ios-card p-4">
+                    <Pills
+                      options={[
+                        { value: 'Driver',  label: t.deliveryMethodDriver },
+                        { value: 'Taxi',    label: t.deliveryMethodTaxi },
+                        { value: 'Florist', label: t.deliveryMethodFlorist },
+                      ]}
+                      value={order.delivery?.['Delivery Method'] || 'Driver'}
+                      onChange={v => {
+                        const methodPatch = { 'Delivery Method': v };
+                        if (v === 'Taxi') {
+                          methodPatch['Assigned Driver'] = '';
+                          methodPatch['Driver Payout'] = 0;
+                        } else if (v === 'Florist') {
+                          methodPatch['Assigned Driver'] = '';
+                          methodPatch['Driver Payout'] = 0;
+                          methodPatch['Taxi Cost'] = 0;
+                        } else {
+                          methodPatch['Taxi Cost'] = 0;
+                        }
+                        patchDelivery(methodPatch);
+                      }}
+                      disabled={saving}
+                    />
                   </div>
-                  {!order.delivery?.['Assigned Driver'] && (
-                    <p className="text-xs text-ios-tertiary mt-2">{t.noDriver}</p>
-                  )}
                 </div>
+
+                {/* Driver picker — only when method is Driver */}
+                {(order.delivery?.['Delivery Method'] || 'Driver') === 'Driver' && (
+                  <div>
+                    <p className="ios-label">{t.assignedDriver}</p>
+                    <div className="ios-card p-4">
+                      <div className="flex flex-wrap gap-1.5">
+                        {drivers.map(driver => (
+                          <button
+                            key={driver}
+                            onClick={() => patchDelivery({
+                              'Assigned Driver': order.delivery?.['Assigned Driver'] === driver ? '' : driver,
+                            })}
+                            disabled={saving}
+                            className={`px-3.5 py-1.5 rounded-full text-sm font-medium border transition-colors active-scale disabled:opacity-40 ${
+                              order.delivery?.['Assigned Driver'] === driver
+                                ? 'bg-brand-600 text-white border-brand-600 shadow-sm'
+                                : 'bg-gray-100 dark:bg-gray-700 text-ios-secondary dark:text-gray-300 border-gray-200 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600'
+                            }`}
+                          >
+                            {driver}
+                          </button>
+                        ))}
+                      </div>
+                      {!order.delivery?.['Assigned Driver'] && (
+                        <p className="text-xs text-ios-tertiary mt-2">{t.noDriver}</p>
+                      )}
+                    </div>
+                  </div>
+                )}
               </div>
             )}
 


### PR DESCRIPTION
## Summary

- Both `OrderDetailPage.jsx` and `OrderCard.jsx` previously showed only a driver picker for delivery orders — no way to select Taxi or Florist delivery method on mobile/florist app.
- Ported the three-option Delivery Method pill selector (Driver / Taxi / Florist) from `dashboard/OrderDetailPanel.jsx:951–975` into both florist order surfaces.
- Both surfaces updated — parity within the florist app is maintained (OrderCard = expanded inline card in the list, OrderDetailPage = full-page view).

## Verification

- **Build:** `cd apps/florist && ./node_modules/.bin/vite build` — clean build, zero errors. `OrderDetailPage` chunk grew from 22.67 kB → 23.36 kB; `OrderListPage` (includes OrderCard) grew from 68.36 kB → 69.09 kB — consistent with the added UI.
- **Code trace:** When method changes to Florist, `patchDelivery({ 'Delivery Method': 'Florist', 'Assigned Driver': '', 'Driver Payout': 0, 'Taxi Cost': 0 })` is called — exact same cascade as the dashboard. Driver picker is hidden when method is not `'Driver'`. No new API endpoints needed.
- **Translations:** All required keys (`deliveryMethod`, `deliveryMethodDriver`, `deliveryMethodTaxi`, `deliveryMethodFlorist`) were already present in `apps/florist/src/translations.js` in both EN and RU — zero new keys added.
- **No shared/backend changes:** Pure frontend parity fix; shared package and backend are untouched, so no additional build checks apply per CLAUDE.md check matrix.

## Files changed

- `apps/florist/src/pages/OrderDetailPage.jsx` — added method pill section, driver picker now conditional on method=Driver
- `apps/florist/src/components/OrderCard.jsx` — same change in the expanded card surface

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAwbjGui2tRuDXuvHW2pxS