### PR TITLE
fix(orders): cancel linked delivery when order converts to pickup (#317)

### DIFF
--- a/backend/src/__tests__/orderRepo.integration.test.js
+++ b/backend/src/__tests__/orderRepo.integration.test.js
@@ -903,3 +903,127 @@ describe('updateOrder Required By cascade (STOCK_Y_MODEL)', () => {
     }
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────
+// updateOrder Delivery→Pickup cascade (#317)
+// ─────────────────────────────────────────────────────────────────────
+//
+// When an order's Delivery Type transitions Delivery → Pickup, the
+// linked delivery record must be cancelled inside the same transaction.
+// This prevents the driver app from showing a stale Pending delivery.
+
+describe('updateOrder Delivery→Pickup cancel cascade (#317)', () => {
+  it('cancels linked Pending delivery when order converts Delivery → Pickup', async () => {
+    // Create a delivery-type order with a linked delivery record.
+    const { order } = await orderRepo.createOrder({
+      customer: 'recCust1', customerRequest: 'Convert test',
+      deliveryType: 'Delivery',
+      requiredBy: '2026-06-20',
+      orderLines: [{ stockItemId: stockId1, flowerName: 'Red Rose', quantity: 3 }],
+      delivery: { address: 'ul. Floriańska 1', date: '2026-06-20', fee: 25, driver: 'Timur' },
+      paymentStatus: 'Unpaid', createdBy: 'florist',
+    }, config, { actor: { actorRole: 'florist' } });
+
+    // Sanity: delivery should exist and be Pending.
+    const before = await orderRepo.getById(order.id);
+    expect(before['Delivery Type']).toBe('Delivery');
+    expect(before._delivery).toBeTruthy();
+    expect(before._delivery['Status']).toBe(DELIVERY_STATUS.PENDING);
+    const deliveryId = before._delivery.id;
+
+    // Patch: flip Delivery Type to Pickup.
+    await orderRepo.updateOrder(order.id, { 'Delivery Type': 'Pickup' }, { actor: { actorRole: 'owner' } });
+
+    // The delivery record should now be Cancelled.
+    const [deliveryRow] = await harness.db.select().from(deliveries)
+      .where(eq(deliveries.id, deliveryId));
+    expect(deliveryRow.status).toBe(DELIVERY_STATUS.CANCELLED);
+
+    // listDeliveries with no filter returns all non-deleted rows —
+    // but the driver app only renders Pending/Out-for-Delivery/Delivered.
+    // Confirm the cancelled delivery would be excluded from those groups
+    // (i.e. its status is Cancelled, not Pending).
+    const allDeliveries = await orderRepo.listDeliveries({});
+    const found = allDeliveries.find(d => d.id === deliveryId);
+    expect(found?.Status).toBe(DELIVERY_STATUS.CANCELLED);
+
+    // Audit trail: a delivery update audit row should exist with Status=Cancelled.
+    // audit_log stores { before, after } in the jsonb `diff` column.
+    const auditRows = await harness.db.select().from(auditLog)
+      .where(eq(auditLog.entityType, 'delivery'));
+    const cancelAudit = auditRows.find(
+      a => a.entityId === deliveryId && a.action === 'update'
+        && a.diff?.after?.Status === DELIVERY_STATUS.CANCELLED
+    );
+    expect(cancelAudit).toBeTruthy();
+  });
+
+  it('does NOT cancel the delivery when patching unrelated fields (Delivery stays Pending)', async () => {
+    const { order } = await orderRepo.createOrder({
+      customer: 'recCust1', customerRequest: 'Unrelated patch',
+      deliveryType: 'Delivery',
+      requiredBy: '2026-06-20',
+      orderLines: [{ stockItemId: stockId1, flowerName: 'Red Rose', quantity: 2 }],
+      delivery: { address: 'ul. Test 2', date: '2026-06-20', fee: 25, driver: 'Timur' },
+      paymentStatus: 'Unpaid', createdBy: 'florist',
+    }, config, { actor: { actorRole: 'owner' } });
+
+    const before = await orderRepo.getById(order.id);
+    const deliveryId = before._delivery.id;
+
+    // Patch something unrelated — florist note.
+    await orderRepo.updateOrder(order.id, { 'Florist Note': 'Add ribbon' }, { actor: { actorRole: 'owner' } });
+
+    // Delivery must remain Pending.
+    const [deliveryRow] = await harness.db.select().from(deliveries)
+      .where(eq(deliveries.id, deliveryId));
+    expect(deliveryRow.status).toBe(DELIVERY_STATUS.PENDING);
+  });
+
+  it('does NOT re-cancel a delivery that is already Cancelled', async () => {
+    const { order } = await orderRepo.createOrder({
+      customer: 'recCust1', customerRequest: 'Already cancelled',
+      deliveryType: 'Delivery',
+      requiredBy: '2026-06-20',
+      orderLines: [{ stockItemId: stockId1, flowerName: 'Red Rose', quantity: 2 }],
+      delivery: { address: 'ul. Test 3', date: '2026-06-20', fee: 25, driver: 'Timur' },
+      paymentStatus: 'Unpaid', createdBy: 'florist',
+    }, config, { actor: { actorRole: 'florist' } });
+
+    const before = await orderRepo.getById(order.id);
+    const deliveryId = before._delivery.id;
+
+    // Manually cancel the delivery first.
+    await harness.db.update(deliveries)
+      .set({ status: DELIVERY_STATUS.CANCELLED, updatedAt: new Date() })
+      .where(eq(deliveries.id, deliveryId));
+
+    // Patch Delivery Type → Pickup (delivery already Cancelled).
+    await orderRepo.updateOrder(order.id, { 'Delivery Type': 'Pickup' }, { actor: { actorRole: 'owner' } });
+
+    // Should still be Cancelled — no extra audit rows for a no-op.
+    const [deliveryRow] = await harness.db.select().from(deliveries)
+      .where(eq(deliveries.id, deliveryId));
+    expect(deliveryRow.status).toBe(DELIVERY_STATUS.CANCELLED);
+  });
+
+  it('does NOT touch delivery when converting Pickup → Delivery (no linked delivery exists)', async () => {
+    // Pickup order — no delivery record.
+    const { order } = await orderRepo.createOrder({
+      customer: 'recCust1', customerRequest: 'Pickup order',
+      deliveryType: 'Pickup',
+      requiredBy: '2026-06-20',
+      orderLines: [{ stockItemId: stockId1, flowerName: 'Red Rose', quantity: 2 }],
+      paymentStatus: 'Unpaid', createdBy: 'florist',
+    }, config, { actor: { actorRole: 'florist' } });
+
+    // Patch Delivery Type → Delivery (the reverse path).
+    // convertToDelivery is the proper endpoint for this; updateOrder just stores the field.
+    // Either way no linked delivery exists, so nothing should blow up.
+    await orderRepo.updateOrder(order.id, { 'Delivery Type': 'Delivery' }, { actor: { actorRole: 'owner' } });
+
+    // No deliveries at all — confirm.
+    const allDeliveries = await harness.db.select().from(deliveries);
+    expect(allDeliveries).toHaveLength(0);
+  });
+});

--- a/backend/src/repos/orderRepo.js
+++ b/backend/src/repos/orderRepo.js
@@ -1222,6 +1222,25 @@ export async function updateOrder(id, fields, opts = {}) {
       }
     }
 
+    // Cascade: Delivery → Pickup conversion must cancel the linked delivery so
+    // the driver app stops showing it. Guard: only when the type genuinely
+    // transitions from Delivery to Pickup AND a non-cancelled delivery exists.
+    if (fields['Delivery Type'] === 'Pickup' && before.deliveryType === 'Delivery') {
+      const [delivery] = await tx.select().from(deliveries)
+        .where(and(eq(deliveries.orderId, after.id), isNull(deliveries.deletedAt)))
+        .limit(1);
+      if (delivery && delivery.status !== DELIVERY_STATUS.CANCELLED) {
+        await tx.update(deliveries)
+          .set({ status: DELIVERY_STATUS.CANCELLED, updatedAt: new Date() })
+          .where(eq(deliveries.id, delivery.id));
+        await tryAudit(tx, {
+          entityType: 'delivery', entityId: delivery.id, action: 'update',
+          before: { Status: delivery.status }, after: { Status: DELIVERY_STATUS.CANCELLED },
+          ...actor,
+        });
+      }
+    }
+
     // Flag-on Required By cascade → Demand Entry date update.
     if (getStockYModelEnabled() && 'Required By' in fields && fields['Required By']) {
       const newDate = fields['Required By'];


### PR DESCRIPTION
## Summary

- When an order's `Delivery Type` was patched from `Delivery → Pickup` via `updateOrder()` in `backend/src/repos/orderRepo.js`, the linked delivery record was left with `Pending` status — causing the driver app (`DeliveryListPage`) to keep showing it
- Fix: inside the same `db.transaction()` as the order update, detect the `Delivery → Pickup` transition and set the linked delivery's status to `DELIVERY_STATUS.CANCELLED`
- Guard: only fires when the before-state was `Delivery`, the new value is `Pickup`, and the linked delivery exists and is not already Cancelled — no-ops on unrelated patches

## Root cause

`updateOrder` (~line 1181 in `orderRepo.js`) already cascaded `Required By` and `Delivery Time` changes to the linked delivery row. It did not handle `Delivery Type` transitions. The delivery survived untouched; `listDeliveries` returned it; `DeliveryListPage` surfaced it in the `Pending` group.

## Implementation

Single block added to `orderRepo.updateOrder`, inside the existing `db.transaction()`, after the existing `hasCascade` block:

```js
if (fields['Delivery Type'] === 'Pickup' && before.deliveryType === 'Delivery') {
  const [delivery] = await tx.select()...
  if (delivery && delivery.status !== DELIVERY_STATUS.CANCELLED) {
    await tx.update(deliveries).set({ status: DELIVERY_STATUS.CANCELLED, ... })
    await tryAudit(...)
  }
}
```

Pattern mirrors the existing cancel cascade in `cancelWithStockReturn` (line ~952).

## Verification

New describe block `updateOrder Delivery→Pickup cancel cascade (#317)` added to `backend/src/__tests__/orderRepo.integration.test.js` with 4 tests:

```
✓ cancels linked Pending delivery when order converts Delivery → Pickup      584ms
✓ does NOT cancel the delivery when patching unrelated fields                 605ms
✓ does NOT re-cancel a delivery that is already Cancelled                     567ms
✓ does NOT touch delivery when converting Pickup → Delivery (no linked delivery exists)  561ms
```

Full suite run:
```
Test Files  1 passed (1)
Tests  38 passed (38)
Duration  23.72s
```

All 38 tests green (34 pre-existing + 4 new).

Closes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAwbjGui2tRuDXuvHW2pxS