### PR TITLE
fix(stock): bouquet line removal must never silently lose stock

### DIFF
--- a/backend/src/__tests__/orderRepo.integration.test.js
+++ b/backend/src/__tests__/orderRepo.integration.test.js
@@ -480,6 +480,47 @@ describe('editBouquetLines', () => {
     expect(await harness.db.select().from(orderLines)).toHaveLength(0);
   });
 
+  it('removing a line WITHOUT an explicit action still returns stock (never silently lose stems)', async () => {
+    // Regression: a removedLine with lineId+stockItemId+quantity but no/unknown
+    // `action` used to delete the line while crediting nothing back — a silent
+    // stock leak. The safe default is RETURN; only an explicit 'writeoff' loses
+    // the stems. (Pitfall #5: silent state changes.)
+    const { order, orderLines: lines } = await orderRepo.createOrder({
+      customer: 'recCust1', customerRequest: 'X', deliveryType: 'Pickup',
+      orderLines: [{ stockItemId: stockId1, flowerName: 'Red Rose', quantity: 8 }],
+      paymentStatus: 'Paid', paymentMethod: 'Cash', createdBy: 'florist',
+    }, config);
+
+    await orderRepo.editBouquetLines(order.id, {
+      lines: [],
+      removedLines: [
+        { lineId: lines[0]._pgId, stockItemId: stockId1, quantity: 8 },  // NO action
+      ],
+    }, true);
+
+    const [s1] = await harness.db.select().from(stock).where(eq(stock.id, stockId1));
+    expect(s1.currentQuantity).toBe(100);  // 92 + 8 returned, not leaked
+    expect(await harness.db.select().from(orderLines)).toHaveLength(0);
+  });
+
+  it('removing a line with action=writeoff does NOT return stock (explicit loss)', async () => {
+    const { order, orderLines: lines } = await orderRepo.createOrder({
+      customer: 'recCust1', customerRequest: 'X', deliveryType: 'Pickup',
+      orderLines: [{ stockItemId: stockId1, flowerName: 'Red Rose', quantity: 8 }],
+      paymentStatus: 'Paid', paymentMethod: 'Cash', createdBy: 'florist',
+    }, config);
+
+    await orderRepo.editBouquetLines(order.id, {
+      lines: [],
+      removedLines: [
+        { lineId: lines[0]._pgId, stockItemId: stockId1, quantity: 8, action: 'writeoff' },
+      ],
+    }, true);
+
+    const [s1] = await harness.db.select().from(stock).where(eq(stock.id, stockId1));
+    expect(s1.currentQuantity).toBe(92);  // 100 - 8, stems written off (not returned)
+  });
+
   it('updating quantity adjusts stock by the delta', async () => {
     const { order, orderLines: lines } = await orderRepo.createOrder({
       customer: 'recCust1', customerRequest: 'X', deliveryType: 'Pickup',

--- a/backend/src/repos/orderRepo.js
+++ b/backend/src/repos/orderRepo.js
@@ -1037,9 +1037,7 @@ export async function editBouquetLines(orderId, { lines = [], removedLines = [] 
     const writeoffsToLog = [];
     for (const rem of removedLines) {
       if (rem.stockItemId && rem.quantity > 0) {
-        if (rem.action === 'return') {
-          await stockRepo.adjustQuantity(rem.stockItemId, rem.quantity, { tx, actor });
-        } else if (rem.action === 'writeoff') {
+        if (rem.action === 'writeoff') {
           // Buffer Stock Loss Log writes and run OUTSIDE the PG transaction so
           // a loss-log failure doesn't roll back the order edit. Loss is
           // non-critical reporting; order/line/stock updates are the business state.
@@ -1048,6 +1046,13 @@ export async function editBouquetLines(orderId, { lines = [], removedLines = [] 
             quantity:    rem.quantity,
             reason:      rem.reason || 'Bouquet edit',
           });
+        } else {
+          // Default = RETURN the stems to inventory. Only an explicit 'writeoff'
+          // loses stock; a missing/unknown action MUST NOT silently delete the
+          // line and drop the stems on the floor (Pitfall #5). This guards the
+          // leak class where a UI path removed a line without tagging the action
+          // — the stock would vanish with no audit. Returning is the safe default.
+          await stockRepo.adjustQuantity(rem.stockItemId, rem.quantity, { tx, actor });
         }
       }
       if (rem.lineId) {


### PR DESCRIPTION
## Problem

`editBouquetLines` returned stock **only** when a removed line's `action` was exactly `'return'`. Any missing or unknown action **deleted the line and credited nothing back** — a silent stock leak (root CLAUDE.md **Pitfall #5**). A bouquet built and then stripped could leave its batches understated, with no audit row and no Stock Loss Log entry.

Surfaced while diagnosing an owner report (order 202606-022): an order built as a large mixed bouquet was stripped back; on teardown only one batch (peony) was credited while other batches stayed decremented.

## Fix

Flip the default in the removed-lines loop: only an explicit **`'writeoff'`** loses stock; **every other case (including a missing action) RETURNS** the stems to inventory. Stock can still go negative by design (PO demand signal) — it just can't *vanish*.

```diff
- if (rem.action === 'return')   { adjust(+qty) }
- else if (rem.action === 'writeoff') { writeoff }
- // else: nothing → line deleted, stock lost
+ if (rem.action === 'writeoff') { writeoff }
+ else { adjust(+qty) }   // default = return; never silently lose stock
```

## Tests

New regression tests in `orderRepo.integration.test.js`:
- removing a line **without an explicit action** returns stock (was the leak; now green)
- removing a line with `action: 'writeoff'` does **not** return stock (explicit loss preserved)

## Verification (pre-PR matrix)
- `orderRepo.integration.test.js`: **36 passed** (incl. 2 new). Order/stock integration set (4 files): **63 passed**.
- E2E harness: **220 passed, 0 failed** — incl. §9 "Bouquet edit — remove line (return + writeoff)".
- Note: the *full* `npx vitest run` (60 files) hit local resource contention in `setupPgHarness` (pglite WASM instance exhaustion on my machine); targeted runs are green and CI runs on a clean runner (same path #402 passed). Lab `lab-api` runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)