### PR TITLE
fix(stock): null-safe date sort guard across Y-model comparators (CR-02)

### DIFF
--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -51,6 +51,7 @@ utils/
   bouquetVisibility.js        → shouldShowBouquetSection({hasLines, isTerminal, isOwner}) — single gate for whether an order's bouquet-composition section renders. Shows when the order has lines OR is still editable (non-terminal / owner), so an emptied order keeps its "Edit bouquet" entry point (Pitfall #4). Consumed by florist OrderCard / OrderDetailPage / OrderCardExpanded(→BouquetEditor) and dashboard OrderDetailPanel / BouquetSection.
   orderStatusOptions.js       → getStatusOptions({role, currentStatus, previousStatuses}) — single source of truth for which status pills a user may pick. Owner = any→any; florist/driver = forward map ∪ previously-held statuses (revert). Mirrors backend orderRepo.transitionStatus.
   stockAllocationEngine.js    → stockAllocationEngine(rows, reservations, requiredBy, qty) — Y-model ranked allocation options for one order line (issue #287, PRD #283)
+  sortByDate.js               → byDateAsc / byDateDesc — null-safe date comparators for rows shaped { date: string|null }; undated rows sort LAST (CR-02)
   varietyKey.js               → 4-tuple identity helpers — `varietyKey`, `groupByVariety`, `varietyDisplayName`. NULL-aware per ADR-0006.
   timeSlots.js                → Time slot generation with lead-time filtering
   customerFilters.js          → Customer search + filter predicates (matchesSearch/Filters, EMPTY_FILTERS)

--- a/packages/shared/components/BatchArrivalList.jsx
+++ b/packages/shared/components/BatchArrivalList.jsx
@@ -18,6 +18,7 @@
  *   today       — optional ISO date override
  */
 import { useMemo, useState } from 'react';
+import { byDateDesc } from '../utils/sortByDate.js';
 
 // Variety identity gets the widest range so long cultivar names (e.g. "Hawaiian
 // Coral", "Sarah Bernhardt") render in full; long names wrap a second line
@@ -224,12 +225,7 @@ function BatchRow({ b, t, onRowClick, onPatchPriceBulk, traceNode }) {
 
 function ExpandedDetails({ underlying, t }) {
   const sorted = useMemo(
-    () => [...underlying].sort((a, b) => {
-      if (!a.date && !b.date) return 0;
-      if (!a.date) return 1;
-      if (!b.date) return -1;
-      return b.date.localeCompare(a.date); // newest first
-    }),
+    () => [...underlying].sort(byDateDesc),
     [underlying],
   );
 

--- a/packages/shared/components/BatchTracePanel.jsx
+++ b/packages/shared/components/BatchTracePanel.jsx
@@ -1,4 +1,5 @@
 import { formatDateDMY } from '../utils/formatDate.js';
+import { byDateAsc } from '../utils/sortByDate.js';
 
 /**
  * BatchTracePanel — presentational component rendering the per-batch usage trail.
@@ -28,7 +29,7 @@ export default function BatchTracePanel({ trail = [], t }) {
     if (e.type === 'premade' || !e.date) reserved.push(e);
     else dated.push(e);
   }
-  dated.sort((a, b) => a.date.localeCompare(b.date));
+  dated.sort(byDateAsc);
 
   let balance = 0;
   const withBalance = dated.map((entry) => {

--- a/packages/shared/components/PendingArrivalsPanel.jsx
+++ b/packages/shared/components/PendingArrivalsPanel.jsx
@@ -18,6 +18,7 @@
  */
 import { useMemo, useState } from 'react';
 import DateTag from './DateTag.jsx';
+import { byDateAsc } from '../utils/sortByDate.js';
 
 /** Bucket every pending PO line by its arrival date, then by Variety within a date. */
 function bucketByDate(pendingPO, stockById) {
@@ -53,12 +54,7 @@ function bucketByDate(pendingPO, stockById) {
 
   return [...byDate.values()]
     .map(sec => ({ ...sec, flowers: [...sec.flowers.values()] }))
-    .sort((a, b) => {
-      if (!a.date && !b.date) return 0;
-      if (!a.date) return 1;   // undated last
-      if (!b.date) return -1;
-      return a.date.localeCompare(b.date); // earliest first
-    });
+    .sort(byDateAsc);
 }
 
 export default function PendingArrivalsPanel({ pendingPO = {}, stock = [], t = {} }) {

--- a/packages/shared/components/VarietyAllocationPicker.jsx
+++ b/packages/shared/components/VarietyAllocationPicker.jsx
@@ -3,6 +3,7 @@ import { groupByVariety, varietyDisplayName } from '../utils/varietyKey.js';
 import { stockAllocationEngine } from '../utils/stockAllocationEngine.js';
 import { getVarietyAvailability, arrivalsForVariety } from '../utils/stockMath.js';
 import { formatDateDMY } from '../utils/formatDate.js';
+import { byDateAsc } from '../utils/sortByDate.js';
 import VarietyIdentity from './VarietyIdentity.jsx';
 import VarietyAvailabilityLine from './VarietyAvailabilityLine.jsx';
 
@@ -459,12 +460,7 @@ export function collapseBatchTiers(options, stockById, qty, t) {
 
   for (const m of tiers.values()) {
     const pairs = m.stockIds.map((id, i) => ({ id, date: m.stockIdDates[i] }));
-    pairs.sort((a, b) => {
-      if (!a.date && !b.date) return 0;
-      if (!a.date) return 1;
-      if (!b.date) return -1;
-      return a.date.localeCompare(b.date);
-    });
+    pairs.sort(byDateAsc);
     m.stockIds = pairs.map((p) => p.id);
     delete m.stockIdDates;
     m.sufficient = m.freeQty > 0 && m.freeQty >= qty;

--- a/packages/shared/components/VarietyTracePanel.jsx
+++ b/packages/shared/components/VarietyTracePanel.jsx
@@ -1,4 +1,5 @@
 import { formatDateDMY } from '../utils/formatDate.js';
+import { byDateAsc } from '../utils/sortByDate.js';
 
 /**
  * VarietyTracePanel — presentational per-Variety usage trail (PRD #324 T5).
@@ -22,14 +23,7 @@ import { formatDateDMY } from '../utils/formatDate.js';
 export default function VarietyTracePanel({ events = [], unaccountedStems = 0, t }) {
   const hasEvents = events && events.length > 0;
 
-  const sorted = hasEvents
-    ? [...events].sort((a, b) => {
-        if (!a.date && !b.date) return 0;
-        if (!a.date) return 1;
-        if (!b.date) return -1;
-        return a.date.localeCompare(b.date);
-      })
-    : [];
+  const sorted = hasEvents ? [...events].sort(byDateAsc) : [];
 
   return (
     <div>

--- a/packages/shared/components/WriteOffBatchPicker.jsx
+++ b/packages/shared/components/WriteOffBatchPicker.jsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { byDateAsc } from '../utils/sortByDate.js';
 
 /**
  * WriteOffBatchPicker — form-card for writing off stems from a Variety's
@@ -39,12 +40,7 @@ export default function WriteOffBatchPicker({ variety, reasons, t, onConfirm, on
     }
     // FEFO-sort rows inside each tier; sort tiers by sell asc.
     for (const m of byTier.values()) {
-      m.rows.sort((a, b) => {
-        if (!a.date && !b.date) return 0;
-        if (!a.date) return 1;
-        if (!b.date) return -1;
-        return a.date.localeCompare(b.date);
-      });
+      m.rows.sort(byDateAsc);
     }
     return [...byTier.values()].sort((a, b) => (a.sell ?? 0) - (b.sell ?? 0));
   }, [variety]);

--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -72,6 +72,9 @@ export { default as FeedbackModal } from './components/FeedbackModal.jsx';
 export { default as useOrderTerminationFlow } from './hooks/useOrderTerminationFlow.js';
 export { default as OrderTerminationConfirm } from './components/OrderTerminationConfirm.jsx';
 
+// Null-safe date comparators (CR-02 — never dereference null.localeCompare)
+export { byDateAsc, byDateDesc } from './utils/sortByDate.js';
+
 // Stock Y-model allocation engine (issue #287, PRD #283)
 export { stockAllocationEngine } from './utils/stockAllocationEngine.js';
 

--- a/packages/shared/test/sortByDate.test.js
+++ b/packages/shared/test/sortByDate.test.js
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { byDateAsc, byDateDesc } from '../utils/sortByDate.js';
+
+describe('byDateAsc', () => {
+  it('sorts dated rows earliest-first', () => {
+    const rows = [
+      { date: '2026-06-20' },
+      { date: '2026-06-09' },
+      { date: '2026-06-15' },
+    ];
+    const sorted = [...rows].sort(byDateAsc);
+    expect(sorted.map((r) => r.date)).toEqual(['2026-06-09', '2026-06-15', '2026-06-20']);
+  });
+
+  it('null date sorts LAST', () => {
+    const rows = [
+      { date: null },
+      { date: '2026-06-09' },
+      { date: '2026-06-20' },
+    ];
+    const sorted = [...rows].sort(byDateAsc);
+    expect(sorted.map((r) => r.date)).toEqual(['2026-06-09', '2026-06-20', null]);
+  });
+
+  it('both null → returns 0 (equal)', () => {
+    expect(byDateAsc({ date: null }, { date: null })).toBe(0);
+  });
+
+  it('null a sorts after non-null b', () => {
+    expect(byDateAsc({ date: null }, { date: '2026-06-09' })).toBeGreaterThan(0);
+  });
+
+  it('non-null a sorts before null b', () => {
+    expect(byDateAsc({ date: '2026-06-09' }, { date: null })).toBeLessThan(0);
+  });
+});
+
+describe('byDateDesc', () => {
+  it('sorts dated rows latest-first', () => {
+    const rows = [
+      { date: '2026-06-09' },
+      { date: '2026-06-20' },
+      { date: '2026-06-15' },
+    ];
+    const sorted = [...rows].sort(byDateDesc);
+    expect(sorted.map((r) => r.date)).toEqual(['2026-06-20', '2026-06-15', '2026-06-09']);
+  });
+
+  it('null date sorts LAST (even in desc)', () => {
+    const rows = [
+      { date: null },
+      { date: '2026-06-20' },
+      { date: '2026-06-09' },
+    ];
+    const sorted = [...rows].sort(byDateDesc);
+    expect(sorted.map((r) => r.date)).toEqual(['2026-06-20', '2026-06-09', null]);
+  });
+
+  it('both null → returns 0 (equal)', () => {
+    expect(byDateDesc({ date: null }, { date: null })).toBe(0);
+  });
+
+  it('null a sorts after non-null b', () => {
+    expect(byDateDesc({ date: null }, { date: '2026-06-09' })).toBeGreaterThan(0);
+  });
+
+  it('non-null a sorts before null b', () => {
+    expect(byDateDesc({ date: '2026-06-09' }, { date: null })).toBeLessThan(0);
+  });
+});

--- a/packages/shared/test/stockAllocationEngine.test.js
+++ b/packages/shared/test/stockAllocationEngine.test.js
@@ -337,3 +337,36 @@ describe('stockAllocationEngine — fixture 1: no rows', () => {
     expect(def.kind).toBe('fresh');
   });
 });
+
+// ─── Fixture 9: undated rows (null date) must not crash the FIFO sort ─────────
+// Regression: an undated orig Stock Item / undated Demand Entry (date == null)
+// previously crashed the comparator with `null.localeCompare` — the picker
+// threw "undefined is not an object (evaluating 'a.date.localeCompare')" and the
+// whole bouquet editor went to the error boundary. Undated rows must sort safely
+// (last) instead of throwing.
+describe('stockAllocationEngine — fixture 9: null-date rows', () => {
+  it('does not throw when a Batch has a null date', () => {
+    const rows = [batch('b-null', 15, null), batch('b1', 10, '2026-06-09')];
+    expect(() => stockAllocationEngine(rows, new Map(), '2026-06-21', 8)).not.toThrow();
+    const options = stockAllocationEngine(rows, new Map(), '2026-06-21', 8);
+    expect(options.filter((o) => o.kind === 'batch')).toHaveLength(2);
+  });
+
+  it('does not throw when a Demand Entry has a null date', () => {
+    const rows = [demandEntry('d-null', -5, null), demandEntry('d1', -2, '2026-06-17')];
+    expect(() => stockAllocationEngine(rows, new Map(), '2026-06-21', 8)).not.toThrow();
+    const options = stockAllocationEngine(rows, new Map(), '2026-06-21', 8);
+    expect(options.filter((o) => o.kind === 'merge')).toHaveLength(2);
+  });
+
+  it('sorts undated rows last so dated rows keep chronological order', () => {
+    const rows = [
+      batch('b-null', 15, null),
+      batch('b-late', 10, '2026-06-20'),
+      batch('b-early', 10, '2026-06-09'),
+    ];
+    const options = stockAllocationEngine(rows, new Map(), '2026-06-21', 8);
+    const batchIds = options.filter((o) => o.kind === 'batch').map((o) => o.stockId);
+    expect(batchIds).toEqual(['b-early', 'b-late', 'b-null']);
+  });
+});

--- a/packages/shared/utils/sortByDate.js
+++ b/packages/shared/utils/sortByDate.js
@@ -1,0 +1,15 @@
+// Null-safe date comparators for rows shaped { date: string|null }.
+// Undated rows (legacy/orig Stock Items, dateless DEs) sort LAST so dated
+// rows keep chronological order — never dereference null.localeCompare.
+export function byDateAsc(a, b) {
+  if (!a.date && !b.date) return 0;
+  if (!a.date) return 1;
+  if (!b.date) return -1;
+  return a.date.localeCompare(b.date);
+}
+export function byDateDesc(a, b) {
+  if (!a.date && !b.date) return 0;
+  if (!a.date) return 1;
+  if (!b.date) return -1;
+  return b.date.localeCompare(a.date);
+}

--- a/packages/shared/utils/stockAllocationEngine.js
+++ b/packages/shared/utils/stockAllocationEngine.js
@@ -48,13 +48,15 @@
  * Past-date merges (date < requiredBy) are NEVER the default — flagged
  * with isPastDate: true so the UI can grey them.
  */
+import { byDateAsc } from './sortByDate.js';
+
 export function stockAllocationEngine(rows, reservations, requiredBy, qty) {
   const batches = rows.filter((r) => !r.isDemandEntry);
   const demands = rows.filter((r) => r.isDemandEntry);
 
   // ── Batch options ────────────────────────────────────────────────────────
   // Sort FIFO (oldest first)
-  const sortedBatches = [...batches].sort((a, b) => a.date.localeCompare(b.date));
+  const sortedBatches = [...batches].sort(byDateAsc);
 
   const batchOptions = sortedBatches.map((row) => {
     const reservedQty = reservations.get(row.id) ?? 0;
@@ -76,7 +78,7 @@ export function stockAllocationEngine(rows, reservations, requiredBy, qty) {
 
   // ── Demand Entry (merge) options ─────────────────────────────────────────
   // Sort by date ascending so UI sees them in chronological order
-  const sortedDemands = [...demands].sort((a, b) => a.date.localeCompare(b.date));
+  const sortedDemands = [...demands].sort(byDateAsc);
 
   const mergeOptions = sortedDemands.map((row) => ({
     kind: 'merge',


### PR DESCRIPTION
## What

Re-lands the CR-02 crash fix from the 2026-06-21 Y-model owner test session (it lived only on a throwaway lab branch) and hardens the whole comparator class.

An undated row (`date == null` — a legacy/orig Stock Item or a dateless Demand Entry) crashed `a.date.localeCompare(b.date)` → *"undefined is not an object (evaluating 'a.date.localeCompare')"* → the entire bouquet editor hit the error boundary.

## Change

- **New shared util** `packages/shared/utils/sortByDate.js` — `byDateAsc` / `byDateDesc`, undated rows sort **last**, never dereference null. 10 unit tests.
- `stockAllocationEngine.js` — both FIFO sorts route through `byDateAsc`; regression fixture re-landed (3 tests).
- **De-duped 6 sibling comparators** onto the one util: `BatchArrivalList`, `BatchTracePanel`, `PendingArrivalsPanel`, `VarietyAllocationPicker`, `VarietyTracePanel`, `WriteOffBatchPicker`. `BatchTracePanel` was the only remaining naked crash; the other five had ad-hoc inline guards (partial prior landing) now collapsed to the shared impl. `VarietyAllocationPicker:466` was a plan addendum — same crash class, directly in the picker hot path.

`VarietyListItem` (`?? ''`) and `stockMath.js` (`String(...)`) already guarded — left untouched.

Flag-agnostic: pure null-safety, no behavior change for dated rows.

## Verification
- `packages/shared` Vitest — **419 pass** (incl. 10 new `sortByDate` + 3 engine fixture tests)
- `vite build` — florist / dashboard / delivery all green (shared changed → all three built)

Slice **S0** of `docs/superpowers/plans/2026-06-21-ymodel-session2-fixes-plan.md`. CR context: `docs/superpowers/plans/2026-06-21-ymodel-test-session-2-crs.md` (CR-02).

🤖 Generated with [Claude Code](https://claude.com/claude-code)