### PR TITLE
fix(stock): Y-model order no longer double-decrements Demand Entries (C1 cutover blocker)

### DIFF
--- a/backend/src/__tests__/orderRepo.integration.test.js
+++ b/backend/src/__tests__/orderRepo.integration.test.js
@@ -14,7 +14,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
 import { stock, orders, orderLines, deliveries, auditLog } from '../db/schema.js';
-import { eq } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
 import { ORDER_STATUS, DELIVERY_STATUS } from '../constants/statuses.js';
 
 const dbHolder = { db: null };
@@ -239,6 +239,46 @@ describe('createOrder', () => {
     // (c) DE row's current_quantity is deepened by the ordered quantity
     const [deAfter] = await harness.db.select().from(stock).where(eq(stock.id, deId));
     expect(deAfter.currentQuantity).toBe(-3); // 0 - 3
+
+    yModelFlag.enabled = false;
+  });
+
+  it('(C1) deepens a pre-existing negative Demand Entry exactly ONCE — no double-decrement', async () => {
+    // Regression for C1. When an order line points at a DE that ALREADY holds
+    // demand (qty < 0) for the same Variety + date the order computes, step 3b
+    // (getOrCreateDemandEntry) deepens it AND step 4 (adjustQuantity) used to hit
+    // the same row again → 2× the line qty. This seed-row assertion is the blind
+    // spot the CR-08 test missed: it seeded qty 0, which step 3b skips (>= 0), so
+    // the line went through step 4 only and never exercised the double path.
+    yModelFlag.enabled = true;
+
+    const demandDate = '2026-07-01';
+    const [de] = await harness.db.insert(stock).values({
+      airtableId: 'recDEc1', displayName: `Tulip (${demandDate})`,
+      typeName: 'Tulip', currentQuantity: -20, date: demandDate, active: true,
+    }).returning();
+    const deId = de.id;
+
+    await orderRepo.createOrder({
+      customer: 'recCust1',
+      customerRequest: 'Tulip top-up',
+      deliveryType: 'Pickup',
+      requiredBy: demandDate,
+      orderLines: [
+        { stockItemId: deId, flowerName: 'Tulip', quantity: 5, sellPricePerUnit: 4, costPricePerUnit: 1 },
+      ],
+      paymentStatus: 'Unpaid',
+      createdBy: 'florist',
+    }, config, { actor: { actorRole: 'florist' } });
+
+    // Demand deepened by EXACTLY the line qty: -20 → -25 (not -30).
+    const [deAfter] = await harness.db.select().from(stock).where(eq(stock.id, deId));
+    expect(deAfter.currentQuantity).toBe(-25);
+
+    // And no duplicate DE row was spawned for the same Variety + date.
+    const sameVariety = await harness.db.select().from(stock)
+      .where(and(eq(stock.typeName, 'Tulip'), eq(stock.date, demandDate)));
+    expect(sameVariety).toHaveLength(1);
 
     yModelFlag.enabled = false;
   });

--- a/backend/src/repos/orderRepo.js
+++ b/backend/src/repos/orderRepo.js
@@ -691,6 +691,13 @@ export async function createOrder(params, config, opts = {}) {
             .where(eq(orderLines.id, createdLines[i].id));
           createdLines[i] = { ...createdLines[i], stockItemId: de._pgId };
         }
+
+        // C1: this line's stock effect is now fully applied via the DE path
+        // (getOrCreateDemandEntry deepened the demand above). Mark it so step 4
+        // does NOT decrement it a second time. Without this, every order against
+        // a demand-only Variety counted its demand twice (the seed DE went
+        // -20 → -25 here, then -30 in step 4).
+        line._deApplied = true;
       }
     }
 
@@ -698,7 +705,7 @@ export async function createOrder(params, config, opts = {}) {
     //    THIS transaction. Any throw rolls everything back.
     if (!skipStockDeduction) {
       for (const line of lines) {
-        if (line.stockItemId && !line.stockDeferred) {
+        if (line.stockItemId && !line.stockDeferred && !line._deApplied) {
           await stockRepo.adjustQuantity(line.stockItemId, -line.quantity, { tx, actor });
         }
       }


### PR DESCRIPTION
## Problem — 🔴 CRITICAL data integrity (cutover blocker for #291)

Under `STOCK_Y_MODEL=true`, `orderRepo.createOrder` applied an order line's stock effect **twice** when the line pointed at a **Demand Entry** (a stock row with `current_quantity < 0` representing unmet demand):

1. Step **3b** deepens the DE via `getOrCreateDemandEntry` (`currentQuantity - qty`).
2. Step **4** then ran `adjustQuantity(line.stockItemId, -qty)` on the **same row again** — its guard `line.stockItemId && !line.stockDeferred` still fired because 3b updates `createdLines[i]`, not `lines[i]`.

Net effect: every order against a demand-only Variety counted its demand **2×**, systematically inflating shortfall → PO over-ordering and inflated cost. Found in the 2026-06-21 overnight audit (finding **C1**), re-verified STILL_PRESENT on master.

## Fix

Mark every line routed through the DE path in step 3b (`line._deApplied = true`) and add `&& !line._deApplied` to step 4's guard, so a DE-backed line's demand is applied **exactly once**.

- **Flag-off is provably unchanged**: step 3b is flag-gated, so the marker is never set and step 4 runs identically to before.
- Batch and legacy lines are not marked (step-3b `continue` guards exclude `qty >= 0` / `typeName === null`), so step 4 still adjusts them once.
- The FK-repoint case (`de._pgId !== line.stockItemId`) is correct: the demand lands only on the canonical dated DE; the original picked row is no longer wrongly decremented.

Adversarially reviewed (7 risk checks: under-count, wrong-row, marker leakage, batch/legacy, FEFO interaction, test quality, skipStockDeduction) — no defects.

## Verification path (order/stock change — per CLAUDE.md verification gate)

- **Regression lock**: `backend/src/__tests__/orderRepo.integration.test.js` — new `(C1)` test seeds a DE at **-20**, orders qty 5 dated to match, asserts the seed row ends at **-25 (not -30)** and no duplicate DE row. Fails pre-fix (`-30`), passes post-fix. (This is the blind spot the existing CR-08 test missed — it seeded qty 0, which step 3b skips as a Batch.)
- `cd backend && npx vitest run` → **567 passed, 1 todo, 0 failed**
- `npm run harness` + `npm run test:e2e` → **220 passed, 0 failed** (incl. all order/stock sections 6–13)

## Scope

C1 only (the hotfix the audit sequenced first — "stop the bleeding"). The sibling DE-accounting holes **C4/C5/C19/C25** (clear-Required-By cascade, cancel/delete phantom DE, write-off demand leak, edit-add-line) are a follow-up slice via a shared `applyLineStockEffect` helper — see `docs/superpowers/reports/2026-06-21-overnight-ultracode/05-status-and-slice-plan-2026-06-22.md` and `06-design-forks.md` (Fork-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)