### PR TITLE
fix(premade): atomic Y-model match + edit — no bouquet loss / leaked deletes (C2, C10)

### DIFF
--- a/backend/src/__tests__/premadeBouquetService.integration.test.js
+++ b/backend/src/__tests__/premadeBouquetService.integration.test.js
@@ -301,6 +301,29 @@ describe('createPremadeBouquet flag-on (STOCK_Y_MODEL=true) — issue #285', () 
     const [after] = await harness.db.select().from(stock).where(eq(stock.id, rose.id));
     expect(after.currentQuantity).toBe(5);
   });
+
+  it('(C2) preserves the bouquet when createOrder fails — no delete-before-create loss', async () => {
+    const [rose] = await harness.db.insert(stock).values({
+      displayName: 'Rose', currentQuantity: 10, typeName: 'Rose',
+    }).returning();
+    const built = await createPremadeBouquet({
+      name: 'Fragile',
+      lines: [{ stockItemId: rose.id, flowerName: 'Rose', quantity: 4, costPricePerUnit: 1, sellPricePerUnit: 5 }],
+      createdBy: 'F',
+    });
+    // The sale throws mid-createOrder (e.g. bad delivery data). The bouquet must
+    // survive — a failed sale must never destroy the bouquet (delete-before-create).
+    createOrder.mockImplementationOnce(async () => { throw new Error('boom'); });
+
+    await expect(matchPremadeBouquetToOrder(built.id, {
+      customerName: 'Test', deliveryType: 'pickup', orderDate: '2026-05-10',
+    }, defaultConfig)).rejects.toThrow('boom');
+
+    const bouquetsAfter = await harness.db.select().from(premadeBouquets);
+    expect(bouquetsAfter).toHaveLength(1);
+    const linesAfter = await harness.db.select().from(premadeBouquetLines);
+    expect(linesAfter).toHaveLength(1);
+  });
 });
 
 // ── #330: editPremadeBouquetLines under flag-on must NOT touch Batch qty ──
@@ -391,5 +414,21 @@ describe('editPremadeBouquetLines flag-on (STOCK_Y_MODEL=true) — issue #330', 
     expect(after.currentQuantity).toBe(5);
     const [unchanged] = await harness.db.select().from(premadeBouquetLines).where(eq(premadeBouquetLines.id, line.id));
     expect(unchanged.quantity).toBe(4);
+  });
+
+  it('(C10) rolls back a removed-line deletion when a new line fails validation', async () => {
+    const [rose] = await harness.db.insert(stock).values({ displayName: 'Rose', currentQuantity: 5, typeName: 'Rose' }).returning();
+    const { bouquet, line } = await seedBouquetWithLine(rose.id, 4); // reserves 4 of 5
+    // Remove the existing line (frees 4) AND add a new line that still exceeds
+    // free qty (6 > 5) → validateFreeQty throws inside the tx. The removed-line
+    // deletion must roll back with the failed tx, not commit on its own.
+    await expect(editPremadeBouquetLines(bouquet.id, {
+      removedLines: [{ lineId: line.id, stockItemId: rose.id, quantity: 4 }],
+      lines: [{ stockItemId: rose.id, flowerName: 'Rose', quantity: 6, costPricePerUnit: 1, sellPricePerUnit: 5 }],
+    })).rejects.toThrow(/Insufficient free stems/);
+
+    const lines = await harness.db.select().from(premadeBouquetLines).where(eq(premadeBouquetLines.bouquetId, bouquet.id));
+    expect(lines).toHaveLength(1);
+    expect(lines[0].id).toBe(line.id);
   });
 });

--- a/backend/src/services/premadeBouquetService.js
+++ b/backend/src/services/premadeBouquetService.js
@@ -226,16 +226,6 @@ export async function editPremadeBouquetLines(id, payload) {
 async function _editPremadeBouquetLinesYModel(id, { lines = [], removedLines = [] }) {
   const bouquet = await premadeBouquetRepo.getById(id);
 
-  // Removed lines: drop the row only. No credit to Batch qty (nothing was
-  // deducted at build time under the reservation model).
-  for (const rem of removedLines) {
-    if (rem.lineId) {
-      await premadeBouquetRepo.deleteLineById(rem.lineId).catch(err =>
-        console.error(`[PREMADE] Failed to delete removed line ${rem.lineId}:`, err.message),
-      );
-    }
-  }
-
   const newUnmatched = lines.filter(l => !l.id && !l.stockItemId && l.flowerName);
   if (newUnmatched.length > 0) await autoMatchStock(newUnmatched);
 
@@ -256,6 +246,15 @@ async function _editPremadeBouquetLinesYModel(id, { lines = [], removedLines = [
   // deadlock against this open tx in pglite).
   const createdLines = [];
   await db.transaction(async (tx) => {
+    // Removed lines first — drop the reservation row inside the SAME tx so a
+    // later validateFreeQty failure rolls the deletion back (C10). No credit to
+    // Batch qty (nothing was deducted at build time under the reservation model).
+    for (const rem of removedLines) {
+      if (rem.lineId) {
+        await tx.delete(premadeBouquetLines).where(eq(premadeBouquetLines.id, rem.lineId));
+      }
+    }
+
     for (const line of lines) {
       if (line.id) {
         if (line._originalQty != null && line.quantity !== line._originalQty) {
@@ -457,14 +456,22 @@ async function _matchPremadeYModel(id, orderData, config) {
     ? orderData.priceOverride
     : (premade['Price Override'] || null);
 
-  // Delete lines FIRST — frees the reservation before standard order deduction.
-  await premadeBouquetRepo.deleteById(premade._pgId);
-
-  // Standard createOrder — NO skipStockDeduction. Batch decremented now.
+  // Create the order FIRST (standard allocation — NO skipStockDeduction, Batch
+  // decremented now). Only once the sale is safely persisted do we delete the
+  // bouquet, which frees its reservation. If createOrder throws, the bouquet is
+  // left intact — a failed sale must never destroy it (C2). Mirrors the legacy
+  // sale-path ordering. The transient double-count (Batch decremented + premade
+  // reservation still present until the delete) is the same window legacy has.
   const result = await createOrder(
     { ...orderData, orderLines, priceOverride, notes: orderData.notes || premade.Notes || '' },
     config,
   );
+
+  try {
+    await premadeBouquetRepo.deleteById(premade._pgId);  // CASCADE removes lines
+  } catch (cleanupErr) {
+    console.error('[PREMADE] Cleanup after match failed:', cleanupErr.message);
+  }
 
   broadcast({ type: 'premade_bouquet_matched', bouquetId: id, orderId: result.order?.id || null });
   return { ...result, premadeBouquetId: id };


### PR DESCRIPTION
## Problem (audit findings C2 + C10, both 🟠 HIGH)

Two Y-model premade paths could lose data on a mid-operation failure:

- **C2** — `_matchPremadeYModel` deleted the bouquet (`premadeBouquetRepo.deleteById`, its own connection) **before** calling `createOrder`. If `createOrder` threw (bad delivery data, allocation error), the bouquet was already gone with no order created — **unrecoverable**. `premadeBouquetService.js:461`.
- **C10** — `_editPremadeBouquetLinesYModel` deleted removed lines via the repo's own connection **before** the validate/insert `db.transaction`. A later `validateFreeQty` failure rolled back the inserts but **not** the deletions → a removed line vanished even though the edit failed. `premadeBouquetService.js:231`.

## Fix

- **C2** — reorder to **create the order first, then delete** the bouquet (with a logged try/catch), mirroring the legacy sale path `_matchPremadeLegacy`. A failed sale now leaves the bouquet intact. The transient double-count window (Batch decremented + reservation still present until the delete) is identical to the one legacy already has, and resolves the instant the delete lands.
- **C10** — move the removed-line deletes **inside** the same `db.transaction` using `tx.delete` (the inserts already bypass the repo for the documented pglite-deadlock reason), so deletes + inserts commit or roll back together.

Flag-off legacy paths (`_matchPremadeLegacy`, `_editPremadeBouquetLinesLegacy`) are **byte-for-byte unchanged**.

## Verification path (per CLAUDE.md gate)

- **Regression locks** in `premadeBouquetService.integration.test.js`:
  - `(C2)` — `createOrder` mocked to throw; asserts the bouquet **and** its lines survive (pre-fix: `[]`).
  - `(C10)` — remove a line + add a new line that exceeds free qty (validate throws inside the tx); asserts the removed line still exists (pre-fix: gone).
- `cd backend && npx vitest run` → **568 passed, 1 todo, 0 failed**
- `npm run harness` + `npm run test:e2e` → **220 passed, 0 failed**

Part of the Y-model cutover-blocker sweep — see `docs/superpowers/reports/2026-06-21-overnight-ultracode/05-status-and-slice-plan-2026-06-22.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)