### PR TITLE
fix(stock): Y-model quick wins — owner financials, desktop PO coverage, Type-only PO save

### DIFF
--- a/apps/dashboard/src/components/StockOrderPanel.jsx
+++ b/apps/dashboard/src/components/StockOrderPanel.jsx
@@ -667,9 +667,14 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
           </div>
 
           <div className="flex gap-2">
+            {/* PG-6: a Y-model line may be Type-only (no Flower Name) — the
+                submit filter already accepts `l.flowerName || l.type`, so the
+                guard must mirror it. Inert under STOCK_Y_MODEL off (the Type
+                input is flag-gated, so l.type stays '' → collapses to the
+                legacy !l.flowerName check). */}
             <button
               onClick={createPO}
-              disabled={submitting || formLines.every(l => !l.flowerName)}
+              disabled={submitting || formLines.every(l => !l.flowerName && !l.type)}
               className="px-4 py-2 rounded-xl bg-brand-600 text-white text-sm font-semibold disabled:opacity-50"
             >
               {submitting ? t.saving : t.save}

--- a/apps/dashboard/src/components/StockTab.jsx
+++ b/apps/dashboard/src/components/StockTab.jsx
@@ -843,6 +843,7 @@ export default function StockTab({ initialFilter, onNavigate, isActive = true })
             <ShortfallSummary
               groups={filteredGroups}
               reservations={reservationsMap}
+              pendingPO={pendingPO}
               t={t}
               onVarietyClick={(key) => setExpandedKey(k => k === key ? null : key)}
               fetchUsage={async (stockId) => {

--- a/apps/florist/src/pages/PurchaseOrderPage.jsx
+++ b/apps/florist/src/pages/PurchaseOrderPage.jsx
@@ -573,8 +573,13 @@ export default function PurchaseOrderPage() {
 
             {/* Actions */}
             <div className="flex gap-2">
+              {/* PG-6: a Y-model line may be Type-only (no Flower Name) — the
+                  submit filter already accepts `l.flowerName || l.type`, so the
+                  guard must mirror it. Inert under STOCK_Y_MODEL off (the Type
+                  input is flag-gated, so l.type stays '' → collapses to the
+                  legacy !l.flowerName check). */}
               <button onClick={createPO}
-                disabled={submitting || formLines.every(l => !l.flowerName)}
+                disabled={submitting || formLines.every(l => !l.flowerName && !l.type)}
                 className="flex-1 py-3 rounded-2xl bg-brand-600 text-white text-sm font-semibold disabled:opacity-50 active-scale">
                 {submitting ? (t.saving || 'Saving...') : (t.save || 'Save')}
               </button>

--- a/packages/shared/components/VarietyListItem.jsx
+++ b/packages/shared/components/VarietyListItem.jsx
@@ -26,6 +26,7 @@
  */
 import { useState } from 'react';
 import { getVarietyTotals, getVarietyAvailability, arrivalsForVariety } from '../utils/stockMath.js';
+import { varietyFinancials } from '../utils/varietyFinancials.js';
 import { formatDateDMY } from '../utils/formatDate.js';
 import VarietyIdentity from './VarietyIdentity.jsx';
 import DateTag from './DateTag.jsx';
@@ -208,11 +209,17 @@ export default function VarietyListItem({
         // Sell label is informative only when more than one Batch tier exists —
         // a single tier is redundant noise next to the Batch chip.
         const multiTier = expansionRows.filter((r) => r.kind === 'batch').length > 1;
-        // CR-36: owner-only financials, representative from the primary Batch.
-        const cost = Number(primaryRow?.current_cost_price) || 0;
-        const sell = Number(primaryRow?.current_sell_price) || 0;
-        const supplier = primaryRow?.supplier || primaryRow?.Supplier || null;
-        const markup = cost > 0 ? (sell / cost).toFixed(1) : null;
+        // CR-36 + C26: owner-only financials via the canonical varietyFinancials
+        // helper. It dual-reads PascalCase (what the grouped /stock API emits
+        // through pgToResponse) ?? snake_case, and mirrors the Flat table's
+        // newest-positive-batch rule. The old inline read used snake_case keys
+        // (current_cost_price/current_sell_price) the API never sends, so the
+        // owner saw 0.00 / 0.00 in production (C26).
+        const fin = varietyFinancials(variety.rows);
+        const cost = fin.cost ?? 0;
+        const sell = fin.sell ?? 0;
+        const supplier = fin.supplier;
+        const markup = fin.markup != null ? fin.markup.toFixed(1) : null;
         return (
         <ul className="bg-gray-50 border-t border-gray-100">
           {isOwner && (sell > 0 || cost > 0 || supplier) && (

--- a/packages/shared/test/VarietyListItem.test.jsx
+++ b/packages/shared/test/VarietyListItem.test.jsx
@@ -314,6 +314,26 @@ describe('VarietyListItem owner financials on expand (CR-36)', () => {
     expect(fin).toHaveTextContent('Stojek'); // supplier
   });
 
+  // C26: the grouped /stock API emits PascalCase fields via pgToResponse
+  // ('Current Cost Price' / 'Current Sell Price' / 'Supplier'), NOT the
+  // snake_case current_cost_price/current_sell_price keys the component used to
+  // read. Reading only snake_case rendered 0.00 for the owner in production.
+  // The snake_case test above stays green (varietyFinancials dual-reads).
+  it('reads PascalCase API fields, not just snake_case (C26)', () => {
+    const vPascal = {
+      key: 'Peony|Pink|60|', type_name: 'Peony', colour: 'Pink', size_cm: 60, cultivar: 'Sarah Bernhardt',
+      rows: [{ id: 'b1', current_quantity: 25, date: '2026-06-10',
+               'Current Cost Price': 12, 'Current Sell Price': 42, Supplier: 'Stojek' }],
+    };
+    render(<VarietyListItem variety={vPascal} reservations={new Map()} t={t}
+      hideType={true} expanded={true} isOwner={true} onToggle={() => {}} />);
+    const fin = screen.getByTestId('variety-owner-financials');
+    expect(fin).toHaveTextContent('12.00'); // cost — rendered 0.00 before the fix
+    expect(fin).toHaveTextContent('42.00'); // sell — rendered 0.00 before the fix
+    expect(fin).toHaveTextContent('3.5');   // markup 42/12
+    expect(fin).toHaveTextContent('Stojek'); // supplier
+  });
+
   it('hides owner financials for non-owner', () => {
     render(<VarietyListItem variety={v} reservations={new Map()} t={t}
       hideType={true} expanded={true} isOwner={false} onToggle={() => {}} />);


### PR DESCRIPTION
## Slice D — Y-model quick wins (overnight ultracode audit)

Three small, owner-visible **STOCK_Y_MODEL** fixes. Each is **inert under the flag-off (current prod) path**.

### C26 — owner financials showed 0.00 / 0.00
`VarietyListItem` expand body read snake_case `current_cost_price` / `current_sell_price`, but the grouped `/stock` API emits **PascalCase** (`Current Cost Price` / `Current Sell Price`) via `pgToResponse` (`stockRepo.listGroupedByVariety` ~L1061). Switched to the canonical `varietyFinancials()` helper — dual-reads PascalCase ?? snake_case and mirrors the Flat table's newest-positive-batch rule.
- The **existing** test fed snake_case (the casing the API never sends) → it was green *through* the bug. Added a regression test feeding **PascalCase** rows.

### P1 — desktop shortfalls ignored incoming PO coverage
Dashboard `ShortfallSummary` omitted `pendingPO`; the florist app already passes it (`StockPanelPage.jsx:549`). Added `pendingPO={pendingPO}` → desktop shortfalls net against in-flight purchases + the late-PO badge lights up. Restores florist↔dashboard parity.

### PG-6 — Type-only PO line could not be saved
`createPO` disabled guard was `every(l => !l.flowerName)` while the submit filter already accepted `(l.flowerName || l.type)`. Guard now mirrors the filter in **both** PO forms (`PurchaseOrderPage.jsx`, `StockOrderPanel.jsx`).

## Verification
- `packages/shared` vitest: **459 passed** (incl. new C26 PascalCase test; red→green confirmed).
- All three apps build clean (florist / dashboard / delivery).
- Adversarial verification workflow (4 agents vs `master`): C26 **SOUND**, P1 **SOUND**, PG-6 logic **SOUND** + backend Type-only acceptance + parity confirmed. The one RISK flagged is non-blocking (guard is inert under flag-off; only activates the intended Y-model flow when the flag flips).

**Frontend-only** (shared component + util-wiring + two app forms). No schema/API change. Y-model surfaces only.

Follow-up (non-blocking, before the flag flips on prod): an end-to-end test for "flag ON → Type-only PO line saves end-to-end" to lock the guard's flag-coupled behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)