### PR TITLE
fix(stock): pending-PO auto-create carries Variety attrs under Y-model (C3)

### DIFF
--- a/backend/src/__tests__/stock.pendingPoAutoCreate.integration.test.js
+++ b/backend/src/__tests__/stock.pendingPoAutoCreate.integration.test.js
@@ -1,0 +1,115 @@
+// Integration tests for GET /stock/pending-po auto-create — C3 (ultracode audit).
+//
+// What we're proving:
+//   - When a pending PO has an unlinked Y-model line (Type/Colour/Size/Cultivar
+//     set, no Stock Item link), the auto-created stock card carries those
+//     Variety attrs. Without them the card has type_name = NULL and is invisible
+//     in listGroupedByVariety — the incoming flowers "disappear" from the
+//     grouped Stock view (same failure class as #327 / #323).
+//   - A legacy line (Flower Name only, no Variety attrs) still auto-creates an
+//     attr-less card — no regression to the pre-Y-model flow.
+//
+// Auth pattern + db/configService mocks mirror stock.groupedRoute.test.js.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express from 'express';
+import supertest from 'supertest';
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import { stock, stockOrders, stockOrderLines } from '../db/schema.js';
+import { eq } from 'drizzle-orm';
+
+const dbHolder = { db: null };
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  isPostgresConfigured: true,
+  pool: null,
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+let yModelEnabled = true;
+vi.mock('../services/configService.js', () => ({
+  getStockYModelEnabled: () => yModelEnabled,
+  getConfig: () => undefined,
+  getActiveSeasonalCategory: () => null,
+  generateOrderId: async () => 'TEST-001',
+}));
+
+import stockRouter from '../routes/stock.js';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    req.role = req.headers['x-test-role'] || 'owner';
+    next();
+  });
+  app.use('/stock', stockRouter);
+  app.use((err, _req, res, _next) => {
+    res.status(err.statusCode || 500).json({ error: err.message });
+  });
+  return app;
+}
+
+let harness, app;
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+  yModelEnabled = true;
+  app = buildApp();
+});
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+async function seedPendingPo() {
+  const [po] = await harness.db.insert(stockOrders).values({
+    poNumber: 'PO-20260622-1', status: 'Sent', createdDate: '2026-06-22',
+  }).returning();
+  return po;
+}
+
+describe('GET /stock/pending-po auto-create — Variety attrs (C3)', () => {
+  it('carries Type/Colour/Size/Cultivar from a Y-model PO line onto the auto-created card', async () => {
+    const po = await seedPendingPo();
+    await harness.db.insert(stockOrderLines).values({
+      poId: po.id,
+      flowerName: 'Peony Pink 60cm Sarah',
+      quantityNeeded: 30,
+      costPrice: '8', sellPrice: '24',
+      typeName: 'Peony', colour: 'Pink', sizeCm: 60, cultivar: 'Sarah',
+    });
+
+    const res = await supertest(app).get('/stock/pending-po');
+    expect(res.status).toBe(200);
+
+    const created = await harness.db.select().from(stock)
+      .where(eq(stock.displayName, 'Peony Pink 60cm Sarah')).then(r => r[0]);
+    expect(created).toBeTruthy();
+    expect(created.typeName).toBe('Peony');
+    expect(created.colour).toBe('Pink');
+    expect(created.sizeCm).toBe(60);
+    expect(created.cultivar).toBe('Sarah');
+  });
+
+  it('leaves a legacy (Flower-Name-only) line attr-less — no regression', async () => {
+    const po = await seedPendingPo();
+    await harness.db.insert(stockOrderLines).values({
+      poId: po.id,
+      flowerName: 'Mystery Bloom',
+      quantityNeeded: 10,
+      costPrice: '5', sellPrice: '15',
+      // no Variety attrs
+    });
+
+    const res = await supertest(app).get('/stock/pending-po');
+    expect(res.status).toBe(200);
+
+    const created = await harness.db.select().from(stock)
+      .where(eq(stock.displayName, 'Mystery Bloom')).then(r => r[0]);
+    expect(created).toBeTruthy();
+    expect(created.typeName).toBe(null);
+    expect(created.colour).toBe(null);
+  });
+});

--- a/backend/src/routes/stock.js
+++ b/backend/src/routes/stock.js
@@ -296,7 +296,15 @@ router.get('/pending-po', async (req, res, next) => {
             }
           } else {
             // Auto-create stock item so the flower shows up in pickers.
+            // C3: carry the PO line's Variety identity (Type/Colour/Size/Cultivar,
+            // issue #304) onto the new card. Without it the card has
+            // type_name = NULL and is invisible in listGroupedByVariety, so the
+            // incoming flowers "disappear" from the grouped Stock view under the
+            // Y-model — same failure class as #327. Attrs are written only when
+            // the line carries them, so legacy (Flower-Name-only) lines are
+            // unchanged. Mirrors the evaluate-route auto-create discipline.
             const samplePoLine = unlinked.find(x => x.line['Flower Name']?.trim() === name)?.line;
+            const sizeNum = Number(samplePoLine?.['Size']);
             const created = await stockRepo.create({
               'Display Name':       name,
               'Purchase Name':      name,
@@ -306,6 +314,10 @@ router.get('/pending-po', async (req, res, next) => {
               Supplier:             samplePoLine?.Supplier || '',
               Category:             'Other',
               Active:               true,
+              ...(samplePoLine?.Type     ? { Type:     String(samplePoLine.Type).trim() }     : {}),
+              ...(samplePoLine?.Colour   ? { Colour:   String(samplePoLine.Colour).trim() }   : {}),
+              ...(Number.isFinite(sizeNum) && sizeNum > 0 ? { Size: sizeNum } : {}),
+              ...(samplePoLine?.Cultivar ? { Cultivar: String(samplePoLine.Cultivar).trim() } : {}),
             }, { actor: actorFromReq(req) });
             nameToId[name] = created.id;
             console.log(`[STOCK] Auto-created "${name}" (${created.id}) from pending PO line`);


### PR DESCRIPTION
## Slice B (part 1) — C3: attr-less invisible auto-created cards

`GET /stock/pending-po` auto-creates a stock card for any pending-PO line with **no Stock Item link but a Flower Name** (so the flower shows in pickers). Under **STOCK_Y_MODEL**, that card was created **without** Type/Colour/Size/Cultivar → `type_name = NULL` → invisible in `stockRepo.listGroupedByVariety`. The incoming flowers **disappear** from the grouped Stock view — the same failure class as #327.

### Fix
Copy `Type/Colour/Size/Cultivar` from the originating PO line onto the new card **when the line carries them** (PO lines gained these attrs in #304; `stockOrderRepo.lineToWire` surfaces them). Written only when present → legacy Flower-Name-only lines auto-create an attr-less card exactly as before. Mirrors the evaluate-route auto-create + the `receiveIntoStock` #327 discipline.

## Verification
- New integration test `stock.pendingPoAutoCreate.integration.test.js` — TDD red→green:
  - Y-model line → auto-created card carries attrs ✅
  - legacy line → stays attr-less (no regression) ✅
- Full backend suite **568 passed**; E2E **220 passed** (0 failed).

Backend-only. Behaviour change is gated on the PO line carrying attrs, so flag-off / legacy POs are untouched.

> **Note — sibling C13 deferred:** the substitute-stock path (`findOrCreateSubstituteStock` / substitute `receiveIntoStock`) also creates attr-less cards, but a substitute is a *different* free-text flower (Alt Flower Name) whose structured Variety is genuinely unknown — backfilling the original line's attrs would mislabel it. That needs an owner decision (capture substitute Variety in the eval UI vs. leave ungrouped) and is intentionally **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)