### PR TITLE
fix(stock): DE-family lifecycle — release/soft-delete/route demand correctly (C5/C19/C25/C4)

### DIFF
--- a/backend/src/__tests__/orderRepo.deFamily.integration.test.js
+++ b/backend/src/__tests__/orderRepo.deFamily.integration.test.js
@@ -1,0 +1,264 @@
+// orderRepo DE-family lifecycle tests — A1 (overnight ultracode audit).
+//
+// Invariant: a Demand Entry's quantity is the single source of truth for unmet
+// demand. Every lifecycle op must apply a line's demand exactly once and reverse
+// it exactly once, through the correct path. These tests pin the four findings:
+//
+//   C5  — cancel / delete of a DE-bound line releases the demand (+qty toward 0)
+//         and SOFT-DELETES the DE when it reaches 0, so it never becomes a
+//         phantom 0-qty FEFO candidate (FEFO selects currentQuantity >= 0).
+//   C19 — write-off of a DE-bound removed line RELEASES the demand (a DE is
+//         future demand, not physical stems — nothing to lose). Previously the
+//         write-off branch only logged a loss and the demand leaked forever.
+//   C25 — edit add-line against a DE routes the demand to the canonical dated DE
+//         for THIS order's Required By (via getOrCreateDemandEntry), not a raw
+//         adjustQuantity on whatever (possibly wrong-dated) DE id was passed.
+//   C4  — clearing Required By de-schedules the DE in place (date → NULL),
+//         conserving the demand quantity (no split on a clear).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import { stock, orders, orderLines } from '../db/schema.js';
+import { eq, and, isNull } from 'drizzle-orm';
+import { ORDER_STATUS } from '../constants/statuses.js';
+
+const dbHolder = { db: null };
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  isPostgresConfigured: true,
+  pool: null,
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+const yModelFlag = { enabled: true };
+vi.mock('../services/configService.js', () => ({
+  getStockYModelEnabled: () => yModelFlag.enabled,
+  getStockXModelEnabled: () => false,
+  getConfig: vi.fn(),
+  updateConfig: vi.fn(),
+  generateOrderId: vi.fn(),
+  getDriverOfDay: vi.fn(),
+  isPastCutoff: vi.fn(),
+  getActiveSeasonalCategory: vi.fn(),
+  loadConfig: vi.fn(),
+  saveConfig: vi.fn(),
+}));
+
+import * as orderRepo from '../repos/orderRepo.js';
+
+const actor = { actor: { actorRole: 'florist', actorPinLabel: null } };
+
+let harness;
+let seq = 0;
+
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+  yModelFlag.enabled = true;
+  seq = 0;
+});
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+// Seed a Demand Entry + an order whose single line points straight at it, with
+// the DE magnitude under our exact control (bypasses createOrder's deepen so we
+// can drive the DE to a known value).
+async function seedDeBoundOrder({ deQty, lineQty, requiredBy = '2026-07-01', variety = { typeName: 'Tulip' }, status = ORDER_STATUS.NEW }) {
+  const [de] = await harness.db.insert(stock).values({
+    displayName:     `${variety.typeName} (${requiredBy})`,
+    typeName:        variety.typeName,
+    colour:          variety.colour ?? null,
+    sizeCm:          variety.sizeCm ?? null,
+    cultivar:        variety.cultivar ?? null,
+    currentQuantity: deQty,
+    date:            requiredBy,
+    active:          true,
+  }).returning();
+  const [order] = await harness.db.insert(orders).values({
+    appOrderId:    `BLO-DE-${++seq}`,
+    customerId:    'recCust1',
+    deliveryType:  'Pickup',
+    requiredBy,
+    status,
+    paymentStatus: 'Unpaid',
+  }).returning();
+  const [line] = await harness.db.insert(orderLines).values({
+    orderId:     order.id,
+    stockItemId: de.id,
+    flowerName:  variety.typeName,
+    quantity:    lineQty,
+  }).returning();
+  return { de, order, line };
+}
+
+const liveDe = (id) => harness.db.select().from(stock)
+  .where(and(eq(stock.id, id), isNull(stock.deletedAt))).then(r => r[0] ?? null);
+const anyDe = (id) => harness.db.select().from(stock).where(eq(stock.id, id)).then(r => r[0]);
+
+describe('(C5) cancel / delete release DE demand + soft-delete at zero', () => {
+  it('cancel: sole-consumer DE released to 0 → soft-deleted (no phantom)', async () => {
+    const { de, order } = await seedDeBoundOrder({ deQty: -5, lineQty: 5 });
+
+    await orderRepo.cancelWithStockReturn(order.id, actor);
+
+    const row = await anyDe(de.id);
+    expect(row.currentQuantity).toBe(0);  // demand released
+    expect(row.deletedAt).not.toBeNull(); // soft-deleted → invisible to FEFO + grouping
+  });
+
+  it('cancel: partial release leaves DE negative and LIVE', async () => {
+    const { de, order } = await seedDeBoundOrder({ deQty: -10, lineQty: 4 });
+
+    await orderRepo.cancelWithStockReturn(order.id, actor);
+
+    const row = await liveDe(de.id);
+    expect(row).not.toBeNull();
+    expect(row.currentQuantity).toBe(-6); // -10 + 4
+  });
+
+  it('delete: sole-consumer DE released to 0 → soft-deleted', async () => {
+    const { de, order } = await seedDeBoundOrder({ deQty: -3, lineQty: 3 });
+
+    await orderRepo.deleteOrder(order.id, actor);
+
+    const row = await anyDe(de.id);
+    expect(row.currentQuantity).toBe(0);
+    expect(row.deletedAt).not.toBeNull();
+  });
+
+  it('shared DE: cancelling one consumer keeps it live; the last consumer soft-deletes it', async () => {
+    // One DE (-8) shared by two orders (5 + 3). Releasing one leaves the DE
+    // negative + live; only the LAST consumer's release drives it to 0 →
+    // soft-delete. Proves the multi-consumer path never soft-deletes early and
+    // never strands live demand (refutes the multi-consumer phantom RISK).
+    const d = '2026-07-01';
+    const [de] = await harness.db.insert(stock).values({
+      displayName: `Tulip (${d})`, typeName: 'Tulip', currentQuantity: -8, date: d, active: true,
+    }).returning();
+    const mkOrder = async (qty) => {
+      const [o] = await harness.db.insert(orders).values({
+        appOrderId: `BLO-DE-${++seq}`, customerId: 'recCust1', deliveryType: 'Pickup',
+        requiredBy: d, status: ORDER_STATUS.NEW, paymentStatus: 'Unpaid',
+      }).returning();
+      await harness.db.insert(orderLines).values({
+        orderId: o.id, stockItemId: de.id, flowerName: 'Tulip', quantity: qty,
+      });
+      return o;
+    };
+    const o1 = await mkOrder(5);
+    const o2 = await mkOrder(3);
+
+    await orderRepo.cancelWithStockReturn(o1.id, actor);
+    let row = await anyDe(de.id);
+    expect(row.currentQuantity).toBe(-3); // -8 + 5
+    expect(row.deletedAt).toBeNull();     // still owed to o2 — live
+
+    await orderRepo.cancelWithStockReturn(o2.id, actor);
+    row = await anyDe(de.id);
+    expect(row.currentQuantity).toBe(0);  // -3 + 3
+    expect(row.deletedAt).not.toBeNull(); // last consumer released → soft-deleted
+  });
+});
+
+describe('(C19) write-off of a DE-bound removed line releases the demand', () => {
+  it('write-off releases the DE instead of leaking it forever', async () => {
+    const { de, order, line } = await seedDeBoundOrder({ deQty: -5, lineQty: 5 });
+
+    await orderRepo.editBouquetLines(order.id, {
+      lines: [],
+      removedLines: [{ lineId: line.id, stockItemId: de.id, quantity: 5, action: 'writeoff' }],
+    }, true, actor);
+
+    const row = await anyDe(de.id);
+    expect(row.currentQuantity).toBe(0);  // released (was: stayed -5, demand leaked)
+    expect(row.deletedAt).not.toBeNull(); // soft-deleted at zero
+  });
+});
+
+describe('(C25) edit add-line routes demand to the canonical dated DE', () => {
+  it('binds the new line to the order Required-By DE, not the passed wrong-dated DE', async () => {
+    const d1 = '2026-07-01';
+    const d2 = '2026-08-01';
+    // A DE for d1 exists; the new order is for d2 and the picker passes the d1 DE id.
+    const [deD1] = await harness.db.insert(stock).values({
+      displayName: `Tulip (${d1})`, typeName: 'Tulip', currentQuantity: -5, date: d1, active: true,
+    }).returning();
+    const [order] = await harness.db.insert(orders).values({
+      appOrderId: `BLO-DE-X`, customerId: 'recCust1', deliveryType: 'Pickup',
+      requiredBy: d2, status: ORDER_STATUS.NEW, paymentStatus: 'Unpaid',
+    }).returning();
+
+    await orderRepo.editBouquetLines(order.id, {
+      lines: [{ stockItemId: deD1.id, flowerName: 'Tulip', quantity: 3, sellPricePerUnit: 4, costPricePerUnit: 1 }],
+      removedLines: [],
+    }, true, actor);
+
+    // d1 DE untouched; demand routed to a NEW d2 DE at exactly -3 (applied once).
+    const d1After = await anyDe(deD1.id);
+    expect(d1After.currentQuantity).toBe(-5);
+
+    const d2Rows = await harness.db.select().from(stock)
+      .where(and(eq(stock.typeName, 'Tulip'), eq(stock.date, d2), isNull(stock.deletedAt)));
+    expect(d2Rows).toHaveLength(1);
+    expect(d2Rows[0].currentQuantity).toBe(-3);
+
+    // The new order line points at the d2 DE.
+    const lines = await harness.db.select().from(orderLines)
+      .where(and(eq(orderLines.orderId, order.id), isNull(orderLines.deletedAt)));
+    expect(lines).toHaveLength(1);
+    expect(lines[0].stockItemId).toBe(d2Rows[0].id);
+  });
+});
+
+describe('(C4) clearing Required By de-schedules the DE in place', () => {
+  it('clear → DE date NULL, demand quantity conserved', async () => {
+    const { de, order } = await seedDeBoundOrder({ deQty: -5, lineQty: 5, requiredBy: '2026-07-01' });
+
+    await orderRepo.updateOrder(order.id, { 'Required By': null }, actor);
+
+    const row = await liveDe(de.id);
+    expect(row.date).toBeNull();          // de-scheduled in place (was: stayed pinned)
+    expect(row.currentQuantity).toBe(-5); // demand preserved
+  });
+
+  it('re-date to a real date still updates the sole-owner DE in place', async () => {
+    const { de, order } = await seedDeBoundOrder({ deQty: -5, lineQty: 5, requiredBy: '2026-07-01' });
+
+    await orderRepo.updateOrder(order.id, { 'Required By': '2026-07-15' }, actor);
+
+    const row = await liveDe(de.id);
+    expect(row.date).toBe('2026-07-15');
+    expect(row.currentQuantity).toBe(-5);
+  });
+
+  it('clearing on a SHARED DE de-schedules it in place (no split), demand conserved', async () => {
+    // Documented decision: clearing one order's Required By on a shared DE sets
+    // the DE date to NULL in place for all co-owners — splitting needs a target
+    // date, and a clear is a de-scheduling, not a re-dating. Demand is conserved.
+    const d = '2026-07-01';
+    const [de] = await harness.db.insert(stock).values({
+      displayName: `Tulip (${d})`, typeName: 'Tulip', currentQuantity: -8, date: d, active: true,
+    }).returning();
+    const mkOrder = async (qty) => {
+      const [o] = await harness.db.insert(orders).values({
+        appOrderId: `BLO-DE-${++seq}`, customerId: 'recCust1', deliveryType: 'Pickup',
+        requiredBy: d, status: ORDER_STATUS.NEW, paymentStatus: 'Unpaid',
+      }).returning();
+      await harness.db.insert(orderLines).values({
+        orderId: o.id, stockItemId: de.id, flowerName: 'Tulip', quantity: qty,
+      });
+      return o;
+    };
+    const o1 = await mkOrder(5);
+    await mkOrder(3);
+
+    await orderRepo.updateOrder(o1.id, { 'Required By': null }, actor);
+
+    const row = await liveDe(de.id);
+    expect(row.date).toBeNull();          // de-scheduled in place
+    expect(row.currentQuantity).toBe(-8); // full demand conserved (no split)
+  });
+});

--- a/backend/src/repos/orderRepo.js
+++ b/backend/src/repos/orderRepo.js
@@ -932,7 +932,9 @@ export async function cancelWithStockReturn(orderId, opts = {}) {
     const returnedItems = [];
     for (const line of lineRows) {
       if (line.stockItemId && line.quantity > 0) {
-        const result = await stockRepo.adjustQuantity(line.stockItemId, line.quantity, { tx, actor });
+        // C5: DE-bound lines release demand (+qty) and soft-delete the DE at 0;
+        // Batch/legacy lines return stems. reverseLineStockEffect picks correctly.
+        const result = await stockRepo.reverseLineStockEffect(line.stockItemId, line.quantity, 'return', tx, actor);
         returnedItems.push({
           stockId:         result.stockId,
           flowerName:      line.flowerName || '?',
@@ -997,7 +999,9 @@ export async function deleteOrder(orderId, opts = {}) {
         .where(and(eq(orderLines.orderId, before.id), isNull(orderLines.deletedAt)));
       for (const line of lineRows) {
         if (line.stockItemId && line.quantity > 0) {
-          const result = await stockRepo.adjustQuantity(line.stockItemId, line.quantity, { tx, actor });
+          // C5: same DE-aware reversal as cancel — release demand + soft-delete
+          // a DE that hits 0; return stems for Batch/legacy lines.
+          const result = await stockRepo.reverseLineStockEffect(line.stockItemId, line.quantity, 'return', tx, actor);
           returnedItems.push({
             stockId: result.stockId,
             flowerName: line.flowerName,
@@ -1044,22 +1048,23 @@ export async function editBouquetLines(orderId, { lines = [], removedLines = [] 
     const writeoffsToLog = [];
     for (const rem of removedLines) {
       if (rem.stockItemId && rem.quantity > 0) {
-        if (rem.action === 'writeoff') {
-          // Buffer Stock Loss Log writes and run OUTSIDE the PG transaction so
-          // a loss-log failure doesn't roll back the order edit. Loss is
-          // non-critical reporting; order/line/stock updates are the business state.
+        const mode = rem.action === 'writeoff' ? 'writeoff' : 'return';
+        // Reverse the line's stock effect. For a Batch/legacy line: 'return'
+        // adds stems back; 'writeoff' leaves qty decremented (logged below).
+        // For a DE-bound line BOTH modes release the demand and soft-delete the
+        // DE at 0 — a DE is future demand, not physical stems, so a write-off
+        // has nothing to lose and must not leak the demand forever (C19/C5).
+        // A missing/unknown action falls through to 'return' so stems are never
+        // silently dropped on the floor (Pitfall #5).
+        const result = await stockRepo.reverseLineStockEffect(rem.stockItemId, rem.quantity, mode, tx, actor);
+        // Only a Batch/legacy write-off records a physical stock loss; a DE
+        // write-off released demand (result.kind === 'de') — nothing lost.
+        if (mode === 'writeoff' && result.kind !== 'de') {
           writeoffsToLog.push({
             stockItemId: rem.stockItemId,
             quantity:    rem.quantity,
             reason:      rem.reason || 'Bouquet edit',
           });
-        } else {
-          // Default = RETURN the stems to inventory. Only an explicit 'writeoff'
-          // loses stock; a missing/unknown action MUST NOT silently delete the
-          // line and drop the stems on the floor (Pitfall #5). This guards the
-          // leak class where a UI path removed a line without tagging the action
-          // — the stock would vanish with no audit. Returning is the safe default.
-          await stockRepo.adjustQuantity(rem.stockItemId, rem.quantity, { tx, actor });
         }
       }
       if (rem.lineId) {
@@ -1148,6 +1153,27 @@ export async function editBouquetLines(orderId, { lines = [], removedLines = [] 
             if (targetId && targetId !== line.stockItemId) {
               line.stockItemId = targetId;
             }
+          } else if (stockRow?.typeName && Number(stockRow.currentQuantity) < 0) {
+            // C25: the new line points at a DE. Route its demand to the canonical
+            // dated DE for THIS order's Required By (mirrors createOrder step 3b),
+            // not whatever — possibly wrong-dated — DE id the picker passed. The
+            // raw adjustQuantity below is skipped because getOrCreateDemandEntry
+            // already deepened the demand exactly once (_deApplied).
+            const demandDate = computeDemandDate({
+              requiredBy: order.requiredBy || null,
+              orderDate:  new Date().toISOString().split('T')[0],
+            });
+            const de = await getOrCreateDemandEntry(
+              {
+                typeName: stockRow.typeName,
+                colour:   stockRow.colour,
+                sizeCm:   stockRow.sizeCm,
+                cultivar: stockRow.cultivar,
+              },
+              demandDate, Number(line.quantity), tx, actor,
+            );
+            line.stockItemId = de._pgId;
+            line._deApplied = true;
           }
         }
 
@@ -1161,7 +1187,7 @@ export async function editBouquetLines(orderId, { lines = [], removedLines = [] 
           stockDeferred:    line.stockDeferred === true,
         }).returning();
         createdLines.push(created);
-        if (line.stockItemId && !line.stockDeferred) {
+        if (line.stockItemId && !line.stockDeferred && !line._deApplied) {
           await stockRepo.adjustQuantity(line.stockItemId, -line.quantity, { tx, actor });
         }
       }
@@ -1235,8 +1261,13 @@ export async function updateOrder(id, fields, opts = {}) {
     }
 
     // Flag-on Required By cascade → Demand Entry date update.
-    if (getStockYModelEnabled() && 'Required By' in fields && fields['Required By']) {
-      const newDate = fields['Required By'];
+    // C4: gate on PRESENCE, not truthiness — clearing Required By (null/'')
+    // must still cascade so the linked DEs de-schedule (updateDemandEntryDate
+    // handles a null newDate by clearing the DE date in place). The old
+    // `&& fields['Required By']` skipped clears and left DEs pinned to the
+    // stale date.
+    if (getStockYModelEnabled() && 'Required By' in fields) {
+      const newDate = fields['Required By'] || null;
       // Fetch all order_lines for this order
       const orderLineRows = await tx.select({
         id:          orderLines.id,

--- a/backend/src/repos/stockRepo.js
+++ b/backend/src/repos/stockRepo.js
@@ -157,6 +157,22 @@ export async function updateDemandEntryDate(orderLineId, newDate, tx, actor = { 
     .limit(1);
   if (!de) return null; // linked stock is a Batch (qty >= 0), not a DE — nothing to cascade
 
+  // C4: a cleared Required By (newDate == null) is a de-scheduling, not a
+  // re-dating. Splitting needs a target date, so on a clear we set the DE's
+  // date to NULL in place (even when shared) — the demand quantity is
+  // conserved; only the date pin is removed (decision: no split on a clear).
+  if (newDate == null) {
+    const [after] = await tx.update(stock)
+      .set({ date: null, updatedAt: new Date() })
+      .where(eq(stock.id, de.id))
+      .returning();
+    await tryAudit(tx, {
+      entityType: 'stock', entityId: after.id, action: 'update',
+      before: { date: de.date }, after: { date: null }, ...actor,
+    });
+    return { demandEntryId: after.id, action: 'cleared-in-place' };
+  }
+
   // 3. Count other order_lines pointing at the same DE
   const sharingLines = await tx.select({ id: orderLines.id }).from(orderLines)
     .where(and(
@@ -250,6 +266,74 @@ export async function resolveBatchByFEFO(varietyKey, lineQty, tx) {
 
   const fullCover = candidates.find(c => Number(c.currentQuantity) >= Number(lineQty));
   return (fullCover ?? candidates[0]).id;
+}
+
+/**
+ * Reverse an order line's stock effect when the line goes away
+ * (cancel / delete / bouquet-edit remove). Y-model aware:
+ *
+ *  - DE-bound line (linked stock row has typeName set AND currentQuantity < 0):
+ *    the line represented future DEMAND, not physical stems. BOTH 'return' and
+ *    'writeoff' release that demand (+qty toward zero) — there are no stems to
+ *    lose (C19). If the DE reaches >= 0 it is SOFT-DELETED so it can never
+ *    become a phantom 0-qty FEFO candidate (C5; FEFO selects currentQuantity >= 0
+ *    and would otherwise treat a depleted DE as an empty Batch).
+ *
+ *  - Batch / legacy line: 'return' adds the qty back to stock; 'writeoff' leaves
+ *    the quantity decremented (the caller logs the physical loss) — unchanged.
+ *
+ * Must run inside the caller's db.transaction (tx required).
+ *
+ * @param {string} stockItemId
+ * @param {number} quantity  - positive line quantity being reversed
+ * @param {'return'|'writeoff'} mode
+ * @param {object} tx        - Drizzle transaction handle (required)
+ * @param {object} [actor]
+ * @returns {Promise<{ kind: 'de'|'batch', stockId: string, newQty: number, released: boolean }>}
+ */
+export async function reverseLineStockEffect(stockItemId, quantity, mode, tx, actor = { actorRole: 'system', actorPinLabel: null }) {
+  const qty = Number(quantity) || 0;
+  // Resolve recXXX (legacy Airtable) OR uuid the same way adjustQuantity does —
+  // a raw eq(stock.id, recXXX) errors against the uuid column.
+  const row = await findPgByAirtableOrUuid(stockItemId, tx);
+
+  const isDe = !!row && !!row.typeName && Number(row.currentQuantity) < 0;
+
+  if (isDe) {
+    // Release the demand regardless of mode — a DE has no physical stems.
+    const [after] = await tx.update(stock)
+      .set({ currentQuantity: sql`${stock.currentQuantity} + ${qty}`, updatedAt: new Date() })
+      .where(eq(stock.id, row.id))
+      .returning();
+    await tryAudit(tx, {
+      entityType: 'stock', entityId: after.id, action: 'update',
+      before: { 'Current Quantity': row.currentQuantity },
+      after:  { 'Current Quantity': after.currentQuantity }, ...actor,
+    });
+    const newQty = Number(after.currentQuantity);
+    if (newQty >= 0) {
+      // Demand fully satisfied/released — drop the row so it is never a phantom
+      // 0-qty FEFO candidate.
+      await tx.update(stock)
+        .set({ deletedAt: new Date(), updatedAt: new Date() })
+        .where(eq(stock.id, row.id));
+      await tryAudit(tx, {
+        entityType: 'stock', entityId: after.id, action: 'delete',
+        before: { 'Current Quantity': after.currentQuantity }, after: null, ...actor,
+      });
+    }
+    return { kind: 'de', stockId: after.airtableId || after.id, newQty, released: true };
+  }
+
+  // Batch / legacy row.
+  if (mode === 'writeoff') {
+    // Leave qty decremented — the caller logs the physical loss. No lookup throw
+    // even if the row is missing (matches the prior write-off-then-log path).
+    return { kind: 'batch', stockId: row?.airtableId || row?.id || stockItemId, newQty: row ? Number(row.currentQuantity) : 0, released: false };
+  }
+  // Return path: delegate to adjustQuantity — it handles dual id-lookup + 404.
+  const result = await adjustQuantity(stockItemId, qty, { tx, actor });
+  return { kind: 'batch', stockId: result.stockId, newQty: result.newQty, released: true };
 }
 
 // ── Backend mode stub ──


### PR DESCRIPTION
## A1 — DE-family lifecycle (overnight ultracode audit)

The Y-model Demand Entry (DE) path was retrofitted per-op and applied inconsistently. This enforces the invariant: **a line's demand is applied exactly once and reversed exactly once, through the correct path.** Four findings, all in the order/stock lifecycle.

| Finding | Before | After |
|---|---|---|
| **C5** cancel/delete | `adjustQuantity(+qty)` drove a DE to 0 → phantom 0-qty FEFO candidate | `reverseLineStockEffect` releases demand + **soft-deletes** the DE at `>= 0` |
| **C19** edit write-off | only logged a loss → demand **leaked forever** | DE write-off **releases** the demand (no physical stems to lose), logs no loss |
| **C25** edit add-line | raw `adjustQuantity` on the picker-passed (maybe wrong-dated) DE | routes to the **canonical dated DE** for the order's Required By via `getOrCreateDemandEntry`; `_deApplied` skips the double-decrement |
| **C4** clear Required By | truthy guard skipped clears → DEs pinned to stale date | presence-gate fires; `updateDemandEntryDate` **de-schedules in place** (date → NULL, demand conserved, no split) |

### New seam: `stockRepo.reverseLineStockEffect(stockItemId, qty, mode, tx, actor)`
Wired into `cancelWithStockReturn`, `deleteOrder`, and `editBouquetLines` (remove). DE-aware: a DE-bound line releases demand (both `return` and `writeoff`) and soft-deletes at 0; a Batch/legacy line returns stems (`return`) or leaves qty decremented (`writeoff`, caller logs loss). Resolves recXXX ids via `findPgByAirtableOrUuid` and delegates Batch-return to `adjustQuantity` — **flag-off / legacy behavior unchanged** (`isDe` requires `typeName` set).

## Verification
- `orderRepo.deFamily.integration.test.js` — **9 tests**, TDD red→green for all four findings + two edge locks: multi-consumer release (only the *last* consumer soft-deletes) and shared-DE clear (de-schedule in place, demand conserved).
- Full backend suite **580 passed**; E2E **220 passed** (0 failed).
- Adversarially verified (5 agents vs `master`): all 11 critical paths **SOUND**; the lone BROKEN verdict was **refuted** — it misread `adjustQuantity` as decrementing, but it does `+= delta` (`stockRepo.js:644/671`), so the existing-line qty-change branch already handles DEs correctly (reduce 5→3 → delta +2 → DE −10+2 = −8 ✓).

Backend-only. Builds on #412 (the C1 `_deApplied` guard in `createOrder`, now merged).

### Non-blocking notes (documented, demand always conserved)
- C25 add-line on an already-de-scheduled order (`requiredBy == null`) routes to a today-dated DE (mirrors `createOrder` step 3b). Edge flow.
- Shared-DE clear de-schedules co-owners in place — the accepted decision (a clear is a de-scheduling, not a re-dating; splitting needs a target date).

🤖 Generated with [Claude Code](https://claude.com/claude-code)