### PR TITLE
fix(stock): New-PO form proposes netted shortfalls, nets open POs (Y-model)

### DIFF
--- a/apps/dashboard/src/components/StockOrderPanel.jsx
+++ b/apps/dashboard/src/components/StockOrderPanel.jsx
@@ -18,7 +18,7 @@ const STATUS_COLORS = {
   Complete:     'bg-emerald-100 text-emerald-700',
 };
 
-export default function StockOrderPanel({ negativeStock, stock, autoCreate, onClose }) {
+export default function StockOrderPanel({ negativeStock, poSuggestions, stock, autoCreate, onClose }) {
   const { suppliers: SUPPLIERS, targetMarkup } = useConfigLists();
   const { showToast } = useToast();
   // Y-model new-Variety fields (#304) only show when the flag is on. Off in prod
@@ -90,18 +90,24 @@ export default function StockOrderPanel({ negativeStock, stock, autoCreate, onCl
   // Like a kanban card automatically moving to the next station — no extra click needed.
   const autoCreated = useRef(false);
   useEffect(() => {
-    if (autoCreate && !autoCreated.current && stock?.length > 0) {
+    // Y-model has no flat `stock` (grouped fetch) — fire on poSuggestions instead.
+    if (autoCreate && !autoCreated.current && (stock?.length > 0 || poSuggestions?.length > 0)) {
       autoCreated.current = true;
       startNewPO();
     }
-  }, [autoCreate, stock]);
+  }, [autoCreate, stock, poSuggestions]);
 
   // Pre-fill form from negative stock items.
   // Qty = raw stem demand (matches owner's reading). Pkgs stays 0 — owner
   // fills it if she wants to order whole batches; createPO then stores
   // Quantity Needed = pkgs * lotSize, else raw qty.
   function startNewPO() {
-    const lines = (negativeStock || []).map(item => {
+    // Y-model: netted per-Variety shortfall suggestions from the parent (drops
+    // Varieties covered by stock or an open PO, incl. late ones). Legacy: one
+    // line per negative stock row (unchanged).
+    const lines = (yModelOn && poSuggestions)
+      ? poSuggestions
+      : (negativeStock || []).map(item => {
       const si = (stock || []).find(s => s.id === item.id);
       const lotSize = Number(si?.['Lot Size']) || 0;
       const quantity = Math.abs(item.qty);

--- a/apps/dashboard/src/components/StockTab.jsx
+++ b/apps/dashboard/src/components/StockTab.jsx
@@ -17,6 +17,7 @@ import {
   BatchTracePanel,
   VarietyTracePanel,
   WriteOffBatchPicker,
+  buildPoSuggestions,
 } from '@flower-studio/shared';
 import StockReceiveForm from './StockReceiveForm.jsx';
 import StockOrderPanel from './StockOrderPanel.jsx';
@@ -564,6 +565,9 @@ export default function StockTab({ initialFilter, onNavigate, isActive = true })
             qty: s['Current Quantity'],
             supplier: s.Supplier,
           }))}
+          // Y-model: netted per-Variety shortfall suggestions (the legacy
+          // negativeStock list is empty under the flag — grouped fetch instead).
+          poSuggestions={stockYModelEnabled ? buildPoSuggestions(groups, pendingPO, premadeMap) : null}
           stock={stock}
           autoCreate={initialFilter?.action === 'createPO'}
           onClose={() => setShowPurchaseOrders(false)}

--- a/apps/florist/src/pages/PurchaseOrderPage.jsx
+++ b/apps/florist/src/pages/PurchaseOrderPage.jsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import client from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import useConfigLists from '../hooks/useConfigLists.js';
-import { useStockYModelFlag, DateTag } from '@flower-studio/shared';
+import { useStockYModelFlag, DateTag, buildPoSuggestions } from '@flower-studio/shared';
 import t from '../translations.js';
 
 const STATUS_COLORS = {
@@ -37,6 +37,12 @@ export default function PurchaseOrderPage() {
 
   const [orders, setOrders] = useState([]);
   const [stock, setStock] = useState([]);
+  // Y-model PO-suggestion inputs: grouped Varieties + pending POs + premade
+  // reservations, used by buildPoSuggestions to pre-fill the new-PO form with
+  // netted shortfalls instead of raw negative rows. Legacy path ignores these.
+  const [groups, setGroups] = useState([]);
+  const [pendingPO, setPendingPO] = useState({});
+  const [premadeMap, setPremadeMap] = useState({});
   const [loading, setLoading] = useState(true);
   const [expandedId, setExpandedId] = useState(null);
   const [expandedLines, setExpandedLines] = useState([]);
@@ -71,6 +77,21 @@ export default function PurchaseOrderPage() {
     client.get('/stock?includeEmpty=true').then(r => setStock(r.data)).catch(() => {});
     client.get('/settings').then(r => setDrivers(r.data.drivers || [])).catch(() => {});
   }, [fetchOrders]);
+
+  // Y-model only: grouped Varieties + pending POs + premade reservations feed
+  // buildPoSuggestions. Keyed on yModelOn so it runs once the flag resolves.
+  useEffect(() => {
+    if (!yModelOn) return;
+    Promise.all([
+      client.get('/stock?grouped=true').catch(() => ({ data: {} })),
+      client.get('/stock/pending-po').catch(() => ({ data: {} })),
+      client.get('/stock/premade-committed').catch(() => ({ data: {} })),
+    ]).then(([g, p, pm]) => {
+      setGroups(g.data.groups || []);
+      setPendingPO(p.data || {});
+      setPremadeMap(pm.data || {});
+    });
+  }, [yModelOn]);
 
   // Negative stock items for pre-filling new POs
   const negativeStock = stock.filter(s => (Number(s['Current Quantity']) || 0) < 0);
@@ -110,7 +131,12 @@ export default function PurchaseOrderPage() {
   // owner's demand reading). Pkgs stays 0 — owner decides how many lots she
   // actually wants to buy. Stored Quantity Needed = pkgs > 0 ? pkgs*lot : qty.
   function startNewPO() {
-    const lines = negativeStock.map(item => {
+    // Y-model: pre-fill from netted per-Variety shortfalls (drops Varieties
+    // covered by on-hand stock or already on an open PO, incl. late ones).
+    // Legacy: one line per negative stock row (unchanged).
+    const lines = yModelOn
+      ? buildPoSuggestions(groups, pendingPO, premadeMap)
+      : negativeStock.map(item => {
       const lotSize = Number(item['Lot Size']) || 0;
       const quantity = Math.abs(Number(item['Current Quantity']) || 0);
       const cost = Number(item['Current Cost Price']) || 0;

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -63,6 +63,7 @@ utils/
   phone.js                    → cleanPhone, telHref
   imageResize.js              → resizeImageBlob — canvas-based client-side downscale + JPEG re-encode for bouquet uploads
   varietyFinancials.js        → varietyFinancials(rows) — per-Variety Cost/Sell/Markup/Supplier derivation for stock cards (CR-05 follow-on). Mirrors BatchArrivalList.flatten's newest-positive-batch rule.
+  buildPoSuggestions.js       → buildPoSuggestions(groups, pendingPO, premadeMap) — Y-model New-PO-form pre-fill. One line per Variety still short after stock + ALL open POs (effective < 0, date-agnostic so even a late PO nets out — intentionally differs from the date-aware SHORTFALLS panel). qty = −effective; demand-driven (committed > 0 only); attaches to the undated orig row (else carries 4-tuple identity, #304). Consumed by PurchaseOrderPage (florist) + StockOrderPanel via StockTab (dashboard).
 ```
 
 ## Rules

--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -134,3 +134,5 @@ export { STOCK_GRID_FULL } from './components/stockRowGrid.js';
 
 // CR-05 follow-on: per-Variety financials for stock cards (Cost/Sell/Markup/Supplier).
 export { varietyFinancials } from './utils/varietyFinancials.js';
+// Y-model New-PO-form pre-fill: netted per-Variety shortfall suggestions (nets all open POs).
+export { buildPoSuggestions } from './utils/buildPoSuggestions.js';

--- a/packages/shared/test/buildPoSuggestions.test.js
+++ b/packages/shared/test/buildPoSuggestions.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { buildPoSuggestions } from '../utils/buildPoSuggestions.js';
+
+// Helpers to build grouped-endpoint-shaped fixtures (GET /stock?grouped=true).
+// Rows carry both PascalCase (pgToResponse) and snake_case (current_quantity, date)
+// exactly as listGroupedByVariety emits them.
+function orig(id, attrs = {}) {
+  return {
+    id, current_quantity: 0, 'Current Quantity': 0, date: null,
+    'Display Name': attrs.name || 'Orig', 'Current Cost Price': attrs.cost ?? null,
+    'Current Sell Price': attrs.sell ?? null, Supplier: attrs.supplier ?? '',
+    'Lot Size': attrs.lotSize ?? 0, Farmer: attrs.farmer ?? '',
+  };
+}
+function demand(id, qty, date) {
+  return { id, current_quantity: -Math.abs(qty), 'Current Quantity': -Math.abs(qty), date };
+}
+function batch(id, qty, date, attrs = {}) {
+  return {
+    id, current_quantity: qty, 'Current Quantity': qty, date,
+    'Current Cost Price': attrs.cost ?? null, 'Current Sell Price': attrs.sell ?? null,
+    Supplier: attrs.supplier ?? '', 'Lot Size': attrs.lotSize ?? 0,
+  };
+}
+function group(attrs, rows) {
+  return {
+    key: `${attrs.type_name || ''}|${attrs.colour || ''}|${attrs.size_cm ?? ''}|${attrs.cultivar || ''}`,
+    type_name: attrs.type_name ?? null, colour: attrs.colour ?? null,
+    size_cm: attrs.size_cm ?? null, cultivar: attrs.cultivar ?? null,
+    rows, reservedForPremades: attrs.reservedForPremades ?? 0,
+  };
+}
+
+describe('buildPoSuggestions', () => {
+  it('suggests a genuine shortfall, attaching to the undated orig row', () => {
+    const groups = [group(
+      { type_name: 'Ranunculus', colour: 'Orange', size_cm: 40 },
+      [orig('r-orig', { name: 'Ranunculus Orange 40cm', cost: 17.45, sell: 16 }),
+       demand('r-de', 5, '2026-06-20')],
+    )];
+    const out = buildPoSuggestions(groups, {}, {});
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      stockItemId: 'r-orig',          // attaches to the undated orig, not the DE
+      flowerName: 'Ranunculus Orange 40cm',
+      quantity: 5,                    // committed demand, nothing on hand
+      costPrice: '17.45',
+      sellPrice: '16',
+      sellPriceManual: true,
+      type: '', colour: '', size: '', cultivar: '', // identity omitted when linking to orig
+    });
+  });
+
+  it('excludes a Variety fully covered by on-hand stock (Bug A)', () => {
+    const groups = [group(
+      { type_name: 'Lisianthus', colour: 'White', size_cm: 50 },
+      [batch('l-b', 12, '2026-06-18', { cost: 18.26, sell: 14 }),
+       demand('l-de', 12, '2026-06-18')],
+    )];
+    expect(buildPoSuggestions(groups, {}, {})).toEqual([]);
+  });
+
+  it('excludes a Variety already covered by a pending PO — even a late one (Bug B)', () => {
+    const groups = [group(
+      { type_name: 'Peony', colour: 'Pink', size_cm: 50 },
+      [orig('p-orig', { name: 'Peony Pink 50cm' }), demand('p-de', 7, '2026-06-15')],
+    )];
+    // PO arrives 2026-06-16, AFTER the 2026-06-15 demand (late) — still nets in the form.
+    const pendingPO = { 'p-orig': { ordered: 7, plannedDate: '2026-06-16', pos: [{ quantity: 7, plannedDate: '2026-06-16' }] } };
+    expect(buildPoSuggestions(groups, pendingPO, {})).toEqual([]);
+  });
+
+  it('suggests only the residual when a pending PO partially covers the shortfall', () => {
+    const groups = [group(
+      { type_name: 'Peony', colour: 'Pink', size_cm: 50 },
+      [orig('p-orig', { name: 'Peony Pink 50cm' }), demand('p-de', 7, '2026-06-15')],
+    )];
+    const pendingPO = { 'p-orig': { ordered: 3, plannedDate: '2026-06-16', pos: [{ quantity: 3, plannedDate: '2026-06-16' }] } };
+    const out = buildPoSuggestions(groups, pendingPO, {});
+    expect(out).toHaveLength(1);
+    expect(out[0].quantity).toBe(4); // 7 demand − 3 incoming
+  });
+
+  it('carries Variety identity (no stockItemId) when the Variety has no undated orig', () => {
+    const groups = [group(
+      { type_name: 'Gypsophila', colour: 'White', size_cm: 60, cultivar: 'Xlence' },
+      [demand('g-de', 5, '2026-06-22')], // DE only, no undated orig card
+    )];
+    const out = buildPoSuggestions(groups, {}, {});
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      stockItemId: '',
+      flowerName: 'Gypsophila White 60cm Xlence',
+      quantity: 5,
+      type: 'Gypsophila', colour: 'White', size: '60', cultivar: 'Xlence',
+    });
+  });
+
+  it('does not suggest a Variety with no customer demand (premade-reservation only)', () => {
+    const groups = [group(
+      { type_name: 'Eucalyptus', colour: 'Green', size_cm: 50 },
+      [orig('e-orig', { name: 'Eucalyptus' })], // onHand 0, no DE
+    )];
+    const premadeMap = { 'e-orig': { qty: 3 } }; // 3 stems reserved, but zero customer demand
+    expect(buildPoSuggestions(groups, {}, premadeMap)).toEqual([]);
+  });
+
+  it('returns one line per short Variety and skips covered ones', () => {
+    const groups = [
+      group({ type_name: 'Ranunculus', colour: 'Orange', size_cm: 40 },
+        [orig('r-orig', { name: 'Ranunculus Orange 40cm' }), demand('r-de', 5, '2026-06-20')]),
+      group({ type_name: 'Lisianthus', colour: 'White', size_cm: 50 },
+        [batch('l-b', 12, '2026-06-18'), demand('l-de', 12, '2026-06-18')]), // covered
+      group({ type_name: 'Gypsophila', colour: 'White', size_cm: 60 },
+        [orig('gy-orig', { name: 'Gypsophila White 60cm' }), demand('gy-de', 5, '2026-06-22')]),
+    ];
+    const out = buildPoSuggestions(groups, {}, {});
+    expect(out.map(l => l.flowerName)).toEqual(['Ranunculus Orange 40cm', 'Gypsophila White 60cm']);
+  });
+
+  it('subtracts premade reservations from available on-hand when sizing the buy', () => {
+    const groups = [group(
+      { type_name: 'Hydrangea', colour: 'Blue', size_cm: 50 },
+      [batch('h-b', 5, '2026-06-19'), demand('h-de', 5, '2026-06-22')], // onHand 5 vs demand 5
+    )];
+    const premadeMap = { 'h-b': { qty: 3 } }; // 3 of the 5 locked to premades → only 2 free
+    const out = buildPoSuggestions(groups, {}, premadeMap);
+    expect(out).toHaveLength(1);
+    expect(out[0].quantity).toBe(3); // 5 demand − (5 onHand − 3 reserved) = 3
+  });
+});

--- a/packages/shared/utils/buildPoSuggestions.js
+++ b/packages/shared/utils/buildPoSuggestions.js
@@ -1,0 +1,79 @@
+// buildPoSuggestions — Y-model New-PO-form pre-fill source.
+//
+// Replaces the legacy `stock.filter(qty < 0).map(...)` pre-fill, which (under
+// STOCK_Y_MODEL) listed one line per raw Demand Entry row and never netted
+// pending POs — so it over-proposed Varieties already covered by on-hand stock
+// AND re-proposed stems already on a Sent PO.
+//
+// Here we work at Variety granularity and reuse the single availability model:
+//   effective = onHand − committed − reserved + incoming   (getVarietyAvailability)
+// `incoming` is the sum of ALL pending PO arrivals for the Variety, DATE-AGNOSTIC
+// (arrivalsForVariety). That is deliberate and differs from the stock-panel
+// SHORTFALLS list (allocateVarietyCoverage, date-aware: a late PO still shows as
+// short with a "+N late" flag). The form must NOT re-buy what is already on order,
+// so a late PO nets out here even though the panel keeps flagging the gap.
+//
+// A Variety is suggested only when it has genuine customer demand (committed > 0)
+// AND remains short after stock + all open POs (effective < 0). The buy quantity
+// is `−effective`, which already accounts for premade reservations reducing the
+// free on-hand pool.
+//
+// Attachment (pitfall #9): link the line to the Variety's UNDATED orig row
+// (date === null) so receiveIntoStock absorbs into the right Variety. When the
+// Variety has no orig card (e.g. a DE-only Variety), send the 4-tuple identity
+// with no stockItemId — the #304 new-Variety PO path creates the card on receipt.
+
+import { getVarietyAvailability, arrivalsForVariety } from './stockMath.js';
+import { varietyFinancials } from './varietyFinancials.js';
+import { varietyDisplayName } from './varietyKey.js';
+
+/**
+ * @param {Array} groups        GET /stock?grouped=true → groups[]
+ * @param {Object} pendingPO    GET /stock/pending-po → { stockId: { ordered, plannedDate, pos:[{quantity, plannedDate}] } }
+ * @param {Object} premadeMap   GET /stock/premade-committed → { stockId: { qty, bouquets } }
+ * @returns {Array} form-line objects ready to spread into the New-PO form's formLines
+ */
+export function buildPoSuggestions(groups = [], pendingPO = {}, premadeMap = {}) {
+  const out = [];
+  for (const g of groups) {
+    const rows = g.rows || [];
+    const reservations = new Map(rows.map(r => [r.id, Number(premadeMap?.[r.id]?.qty) || 0]));
+    const arrivals = arrivalsForVariety(rows, pendingPO);
+    const { committed, effective } = getVarietyAvailability(rows, reservations, arrivals);
+
+    // Demand-driven only: a Variety with zero customer demand (premade reservation
+    // alone) is never auto-proposed — matches the SHORTFALLS panel's mental model.
+    if (committed <= 0 || effective >= 0) continue;
+    const quantity = Math.ceil(-effective);
+    if (quantity <= 0) continue;
+
+    const fin = varietyFinancials(rows);
+    const orig = rows.find(r => r.date == null) || null;
+    const canonical = orig || rows[0] || {};
+    const flowerName = canonical['Display Name'] || varietyDisplayName(g) || '';
+    const cost = fin.cost != null && fin.cost > 0 ? fin.cost : 0;
+    const sell = fin.sell != null && fin.sell > 0 ? fin.sell : 0;
+
+    out.push({
+      stockItemId: orig ? orig.id : '',
+      flowerName,
+      quantity,
+      lotSize: Number(canonical['Lot Size']) || 0,
+      packages: 0,
+      supplier: fin.supplier || canonical.Supplier || '',
+      costPrice: cost > 0 ? String(cost) : '',
+      sellPrice: sell > 0 ? String(sell) : '',
+      sellPriceManual: sell > 0,
+      farmer: canonical.Farmer || '',
+      notes: '',
+      // Carry the 4-tuple identity only when there is no orig card to link to
+      // (new-Variety PO line, #304). When linking to an orig, leave blank so the
+      // line is a plain stock-linked line.
+      type: orig ? '' : (g.type_name || ''),
+      colour: orig ? '' : (g.colour || ''),
+      size: orig ? '' : (g.size_cm != null ? String(g.size_cm) : ''),
+      cultivar: orig ? '' : (g.cultivar || ''),
+    });
+  }
+  return out;
+}


### PR DESCRIPTION
## What

Fixes two bugs in the **New Purchase Order** form pre-fill under `STOCK_Y_MODEL` (found in the 2026-06-21/22 owner lab test session):

- **Bug A — over-proposal.** The form pre-filled one line per raw `qty<0` stock row. In Y-model those rows are **Demand Entries**, so it listed Varieties that on-hand batches already cover (Lisianthus, the two Sarah-Bernhardt Peonies, Tulip) — 7 lines where the SHORTFALLS panel correctly showed only 3.
- **Bug B — no open-PO netting.** It re-proposed stems already on an open PO (the 7 Peony Pink already on Sent `PO-GUIDE-1`), because the pre-fill never subtracted PO coverage.

## How

New shared util **`buildPoSuggestions(groups, pendingPO, premadeMap)`** — one suggested line per Variety still short after on-hand stock **+ ALL open POs**:

- Uses `getVarietyAvailability(...).effective` (date-agnostic `incoming`), so even a **late** PO nets out. This **intentionally differs** from the date-aware SHORTFALLS panel (`allocateVarietyCoverage`), which keeps flagging the gap with `+N late` — the panel *warns*, the form *doesn't re-buy*.
- `qty = −effective`; demand-driven (`committed > 0` only, so a premade-reservation-only Variety isn't auto-proposed); premade reservations reduce free on-hand.
- Attaches the line to the Variety's **undated orig** row (`date === null`); when none exists, carries the 4-tuple identity with no `stockItemId` (the #304 new-Variety PO path) so receipt lands correctly (pitfall #9).

**Cross-app parity:** florist `PurchaseOrderPage` now fetches grouped + pending-po + premade-committed and pre-fills via the util; dashboard `StockTab` passes a `poSuggestions` prop to `StockOrderPanel` (whose legacy `negativeStock` is empty under the flag). **Legacy (flag-off) pre-fill is unchanged.**

For the owner's scenario the form now shows **Ranunculus Orange 40cm (5)** + **Gypsophila White (5)**; Peony Pink 50cm drops out (covered by `PO-GUIDE-1`), as do the on-hand-covered Varieties.

## Verification

- `packages/shared` vitest: **476 pass**, incl. **8 new** `buildPoSuggestions` tests (over-proposal exclusion, late-PO netting, partial-PO residual, no-orig identity, demand-only gate, premade-reservation sizing).
- `vite build` green for **florist + dashboard + delivery**.
- Frontend + shared only — **no backend / E2E / lab changes**.

## Notes

- Net-new CR from the lab session (not in the S0–S3 session-2 plan). Captured alongside the session-2 CRs.
- Flag-gated: inert with `STOCK_Y_MODEL` off (current prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)