### PR TITLE
feat(lab): seed rich Y-model stock history — write-offs, PO receipts, absorption arc

### DIFF
--- a/lab/factories/index.js
+++ b/lab/factories/index.js
@@ -4,3 +4,5 @@ export { makeOrder, ORDER_STATUSES } from './order.js';
 export { makeOrderLine } from './orderLine.js';
 export { makeDelivery } from './delivery.js';
 export { makeDriverTelegramChat } from './driverTelegramChat.js';
+export { makeStockLoss, LOSS_REASON } from './stockLoss.js';
+export { makeStockPurchase } from './stockPurchase.js';

--- a/lab/factories/stockLoss.js
+++ b/lab/factories/stockLoss.js
@@ -1,0 +1,35 @@
+// lab/factories/stockLoss.js
+//
+// Synthetic Stock Loss Log row — matches backend/src/db/schema.js `stock_loss_log` table.
+//
+// Schema: id, airtable_id, date (YYYY-MM-DD NOT NULL), stock_id (uuid FK→stock.id),
+//         quantity (numeric 8,2 NOT NULL — POSITIVE stems lost), reason (text NOT NULL),
+//         notes (text NOT NULL DEFAULT ''), created_at (timestamptz), deleted_at
+//
+// Factory-only shaping keys (stripped from output):
+//   stockId → maps to stock_id
+
+import { faker } from '@faker-js/faker';
+
+export const LOSS_REASON = ['Wilted', 'Damaged', 'Arrived Broken', 'Overstock', 'Other'];
+
+export function makeStockLoss(overrides = {}) {
+  // Extract factory-only shaping keys — never included in the returned row.
+  const { stockId, ...columnOverrides } = overrides;
+
+  return {
+    id: faker.string.uuid(),
+    airtable_id: null,
+    date: columnOverrides.date ?? '2026-01-01',
+    stock_id: stockId ?? columnOverrides.stock_id ?? null,
+    quantity: columnOverrides.quantity ?? 1,
+    reason: columnOverrides.reason ?? 'Wilted',
+    notes: columnOverrides.notes ?? '',
+    created_at: new Date(),
+    deleted_at: null,
+    // Apply column-level overrides last, excluding factory-only keys already handled.
+    ...columnOverrides,
+    // Ensure FK column is always correct (shorthand takes priority).
+    stock_id: stockId ?? columnOverrides.stock_id ?? null,
+  };
+}

--- a/lab/factories/stockLoss.test.js
+++ b/lab/factories/stockLoss.test.js
@@ -1,0 +1,90 @@
+// lab/factories/stockLoss.test.js
+//
+// TDD coverage for makeStockLoss factory.
+// Tests were written BEFORE the factory implementation (red phase).
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { faker } from '@faker-js/faker';
+import { makeStockLoss, LOSS_REASON } from './stockLoss.js';
+
+describe('makeStockLoss', () => {
+  beforeEach(() => faker.seed(42));
+
+  it('returns a uuid id', () => {
+    const r = makeStockLoss({ date: '2026-06-12' });
+    expect(r.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/);
+  });
+
+  it('has required NOT-NULL columns present and non-null', () => {
+    const r = makeStockLoss({ date: '2026-06-12' });
+    expect(r.date).toBeTruthy();
+    expect(r.quantity).not.toBeNull();
+    expect(r.quantity).not.toBeUndefined();
+    expect(r.reason).toBeTruthy();
+    expect(r.notes).not.toBeUndefined();
+  });
+
+  it('defaults reason to Wilted (a valid LOSS_REASON)', () => {
+    const r = makeStockLoss({ date: '2026-06-12' });
+    expect(LOSS_REASON).toContain(r.reason);
+    expect(r.reason).toBe('Wilted');
+  });
+
+  it('honours explicit reason when it is a valid LOSS_REASON', () => {
+    for (const reason of LOSS_REASON) {
+      const r = makeStockLoss({ date: '2026-06-12', reason });
+      expect(r.reason).toBe(reason);
+    }
+  });
+
+  it('stockId shorthand maps to stock_id and is not leaked', () => {
+    const id = faker.string.uuid();
+    const r = makeStockLoss({ date: '2026-06-12', stockId: id });
+    expect(r.stock_id).toBe(id);
+    expect(r.stockId).toBeUndefined();
+  });
+
+  it('stock_id defaults to null', () => {
+    const r = makeStockLoss({ date: '2026-06-12' });
+    expect(r.stock_id).toBeNull();
+  });
+
+  it('deleted_at defaults to null', () => {
+    const r = makeStockLoss({ date: '2026-06-12' });
+    expect(r.deleted_at).toBeNull();
+  });
+
+  it('airtable_id defaults to null', () => {
+    const r = makeStockLoss({ date: '2026-06-12' });
+    expect(r.airtable_id).toBeNull();
+  });
+
+  it('created_at is a Date', () => {
+    const r = makeStockLoss({ date: '2026-06-12' });
+    expect(r.created_at).toBeInstanceOf(Date);
+  });
+
+  it('honours explicit quantity', () => {
+    const r = makeStockLoss({ date: '2026-06-12', quantity: 7 });
+    expect(r.quantity).toBe(7);
+  });
+
+  it('is deterministic under the same faker seed', () => {
+    faker.seed(42);
+    const a = makeStockLoss({ date: '2026-06-12' });
+    faker.seed(42);
+    const b = makeStockLoss({ date: '2026-06-12' });
+    // Compare only faker-derived fields — created_at uses wall clock.
+    expect(a.id).toEqual(b.id);
+  });
+});
+
+describe('LOSS_REASON export', () => {
+  it('contains the five canonical values', () => {
+    expect(LOSS_REASON).toContain('Wilted');
+    expect(LOSS_REASON).toContain('Damaged');
+    expect(LOSS_REASON).toContain('Arrived Broken');
+    expect(LOSS_REASON).toContain('Overstock');
+    expect(LOSS_REASON).toContain('Other');
+  });
+});

--- a/lab/factories/stockPurchase.js
+++ b/lab/factories/stockPurchase.js
@@ -1,0 +1,35 @@
+// lab/factories/stockPurchase.js
+//
+// Synthetic Stock Purchase row — matches backend/src/db/schema.js `stock_purchases` table.
+//
+// Schema: id, airtable_id, purchase_date (text YYYY-MM-DD NOT NULL), supplier (text NOT NULL),
+//         stock_id (uuid FK→stock.id), stock_airtable_id, quantity_purchased (int NOT NULL),
+//         price_per_unit (numeric 10,4 nullable), notes (text NOT NULL DEFAULT ''),
+//         created_at (timestamptz)
+//
+// Factory-only shaping keys (stripped from output):
+//   stockId → maps to stock_id
+
+import { faker } from '@faker-js/faker';
+
+export function makeStockPurchase(overrides = {}) {
+  // Extract factory-only shaping keys — never included in the returned row.
+  const { stockId, ...columnOverrides } = overrides;
+
+  return {
+    id: faker.string.uuid(),
+    airtable_id: null,
+    purchase_date: columnOverrides.purchase_date ?? '2026-01-01',
+    supplier: columnOverrides.supplier ?? '',
+    stock_id: stockId ?? columnOverrides.stock_id ?? null,
+    stock_airtable_id: null,
+    quantity_purchased: columnOverrides.quantity_purchased ?? 0,
+    price_per_unit: columnOverrides.price_per_unit ?? null,
+    notes: columnOverrides.notes ?? '',
+    created_at: new Date(),
+    // Apply column-level overrides last, excluding factory-only keys already handled.
+    ...columnOverrides,
+    // Ensure FK column is always correct (shorthand takes priority).
+    stock_id: stockId ?? columnOverrides.stock_id ?? null,
+  };
+}

--- a/lab/factories/stockPurchase.test.js
+++ b/lab/factories/stockPurchase.test.js
@@ -1,0 +1,89 @@
+// lab/factories/stockPurchase.test.js
+//
+// TDD coverage for makeStockPurchase factory.
+// Tests were written BEFORE the factory implementation (red phase).
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { faker } from '@faker-js/faker';
+import { makeStockPurchase } from './stockPurchase.js';
+
+describe('makeStockPurchase', () => {
+  beforeEach(() => faker.seed(42));
+
+  it('returns a uuid id', () => {
+    const r = makeStockPurchase({ purchase_date: '2026-06-12' });
+    expect(r.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/);
+  });
+
+  it('has required NOT-NULL columns present and non-null', () => {
+    const r = makeStockPurchase({ purchase_date: '2026-06-12' });
+    expect(r.purchase_date).toBeTruthy();
+    expect(r.supplier).not.toBeUndefined();
+    expect(r.quantity_purchased).not.toBeNull();
+    expect(r.quantity_purchased).not.toBeUndefined();
+    expect(r.notes).not.toBeUndefined();
+  });
+
+  it('stockId shorthand maps to stock_id and is not leaked', () => {
+    const id = faker.string.uuid();
+    const r = makeStockPurchase({ purchase_date: '2026-06-12', stockId: id });
+    expect(r.stock_id).toBe(id);
+    expect(r.stockId).toBeUndefined();
+  });
+
+  it('stock_id defaults to null', () => {
+    const r = makeStockPurchase({ purchase_date: '2026-06-12' });
+    expect(r.stock_id).toBeNull();
+  });
+
+  it('airtable_id defaults to null', () => {
+    const r = makeStockPurchase({ purchase_date: '2026-06-12' });
+    expect(r.airtable_id).toBeNull();
+  });
+
+  it('stock_airtable_id defaults to null', () => {
+    const r = makeStockPurchase({ purchase_date: '2026-06-12' });
+    expect(r.stock_airtable_id).toBeNull();
+  });
+
+  it('supplier defaults to empty string', () => {
+    const r = makeStockPurchase({ purchase_date: '2026-06-12' });
+    expect(r.supplier).toBe('');
+  });
+
+  it('quantity_purchased defaults to 0', () => {
+    const r = makeStockPurchase({ purchase_date: '2026-06-12' });
+    expect(r.quantity_purchased).toBe(0);
+  });
+
+  it('price_per_unit defaults to null', () => {
+    const r = makeStockPurchase({ purchase_date: '2026-06-12' });
+    expect(r.price_per_unit).toBeNull();
+  });
+
+  it('created_at is a Date', () => {
+    const r = makeStockPurchase({ purchase_date: '2026-06-12' });
+    expect(r.created_at).toBeInstanceOf(Date);
+  });
+
+  it('honours explicit quantity_purchased and price_per_unit', () => {
+    const r = makeStockPurchase({ purchase_date: '2026-06-12', quantity_purchased: 40, price_per_unit: 5 });
+    expect(r.quantity_purchased).toBe(40);
+    expect(r.price_per_unit).toBe(5);
+  });
+
+  it('honours explicit supplier and notes', () => {
+    const r = makeStockPurchase({ purchase_date: '2026-06-12', supplier: 'Stojek', notes: 'PO #PO-1 L#1 primary' });
+    expect(r.supplier).toBe('Stojek');
+    expect(r.notes).toBe('PO #PO-1 L#1 primary');
+  });
+
+  it('is deterministic under the same faker seed', () => {
+    faker.seed(42);
+    const a = makeStockPurchase({ purchase_date: '2026-06-12' });
+    faker.seed(42);
+    const b = makeStockPurchase({ purchase_date: '2026-06-12' });
+    // Compare only faker-derived fields — created_at uses wall clock.
+    expect(a.id).toEqual(b.id);
+  });
+});

--- a/lab/helpers/seed.js
+++ b/lab/helpers/seed.js
@@ -2,8 +2,9 @@
 //
 // Insert a fixture (returned by a scenario builder) into Postgres.
 // Inserts in FK order:
-//   customers → stock → stock_orders → stock_order_lines → premade_bouquets
-//   → orders → order_lines → premade_bouquet_lines → deliveries
+//   customers → stock → stock_loss_log → stock_purchases → stock_orders
+//   → stock_order_lines → premade_bouquets → orders → order_lines
+//   → premade_bouquet_lines → deliveries
 // Uses a single transaction so partial seeds don't leave the DB inconsistent.
 //
 // premadeBouquets, premadeBouquetLines, stockOrders and stockOrderLines are
@@ -17,6 +18,8 @@ export async function seedFixture(pool, fixture) {
     await client.query('BEGIN');
     await insertMany(client, 'customers', fixture.customers ?? []);
     await insertMany(client, 'stock', fixture.stockItems ?? []);
+    await insertMany(client, 'stock_loss_log', fixture.stockLosses ?? []);
+    await insertMany(client, 'stock_purchases', fixture.stockPurchases ?? []);
     await insertMany(client, 'stock_orders', fixture.stockOrders ?? []);
     await insertMany(client, 'stock_order_lines', fixture.stockOrderLines ?? []);
     await insertMany(client, 'premade_bouquets', fixture.premadeBouquets ?? []);

--- a/lab/scenarios/yModelGuide.js
+++ b/lab/scenarios/yModelGuide.js
@@ -29,6 +29,8 @@ import { randomUUID } from 'crypto';
 import { faker } from '@faker-js/faker';
 import { buildBaseline } from './baseline.js';
 import { makeStockItem, makeOrder, makeOrderLine } from '../factories/index.js';
+import { makeStockLoss } from '../factories/stockLoss.js';
+import { makeStockPurchase } from '../factories/stockPurchase.js';
 
 const TODAY        = '2026-06-12';
 const BATCH_RECENT = '2026-06-10';
@@ -54,6 +56,8 @@ export function buildYModelGuide() {
   const deliveries      = [];
   const stockOrders     = [];
   const stockOrderLines = [];
+  const stockLosses     = [];
+  const stockPurchases  = [];
 
   // ── Helpers ────────────────────────────────────────────────────────────────
   function batch({ display, type, colour, size, cultivar, qty, date, cost = 6, sell = 18, supplier = 'Stojek' }) {
@@ -108,13 +112,30 @@ export function buildYModelGuide() {
       supplier, cost_price: cost, sell_price: sell, created_at: new Date(),
     });
   }
+  function loss({ stock, qty, date, reason = 'Wilted', notes = '' }) {
+    const r = makeStockLoss({ stockId: stock.id, quantity: qty, date, reason, notes });
+    stockLosses.push(r);
+    return r;
+  }
+  function purchase({ stock, qty, date, cost, supplier = 'Stojek', notes = '' }) {
+    const r = makeStockPurchase({ stockId: stock.id, quantity_purchased: qty, purchase_date: date, price_per_unit: cost, supplier, notes });
+    stockPurchases.push(r);
+    return r;
+  }
 
   // ── 1. Healthy stock, single batch, no demand ──────────────────────────────
-  batch({
+  // ARC A: 40 purchased, 20+10 consumed by orders, 6 wilted → 4 remaining.
+  const roseRed = batch({
     display: 'Rose Red 50cm Naomi (10.Jun.)',
     type: 'Rose', colour: 'Red', size: 50, cultivar: 'Naomi',
-    qty: 40, date: BATCH_RECENT, cost: 5, sell: 18,
+    qty: 4, date: BATCH_RECENT, cost: 5, sell: 18,
   });
+  purchase({ stock: roseRed, qty: 40, date: BATCH_RECENT, cost: 5, supplier: 'Stojek', notes: 'PO #PO-ROSE-1 L#1 primary' });
+  const ordRoseA = order({ requiredBy: NEED_13 });
+  line({ order: ordRoseA, stock: roseRed, qty: 20, name: 'Rose Red 50cm Naomi' });
+  const ordRoseB = order({ requiredBy: NEED_15, status: 'Delivered' });
+  line({ order: ordRoseB, stock: roseRed, qty: 10, name: 'Rose Red 50cm Naomi' });
+  loss({ stock: roseRed, qty: 6, date: TODAY, reason: 'Wilted', notes: 'wilted on the shelf' });
 
   // ── 2. Multiple batches, one Variety (FEFO drains oldest first) ─────────────
   batch({
@@ -170,11 +191,14 @@ export function buildYModelGuide() {
   line({ order: ordLisi, stock: lisiDE, qty: 12, name: 'Lisianthus White 50cm' });
 
   // ── 7. Premade reservation ties up physical stock ───────────────────────────
+  // ARC B: 28 purchased, 10 damaged in transit → 12 net effective + 6 tied to premade.
   const hydBlue = batch({
     display: 'Hydrangea Blue 30cm (10.Jun.)',
     type: 'Hydrangea', colour: 'Blue', size: 30, cultivar: null,
-    qty: 28, date: BATCH_RECENT, cost: 9, sell: 28,
+    qty: 12, date: BATCH_RECENT, cost: 9, sell: 28,
   });
+  purchase({ stock: hydBlue, qty: 28, date: BATCH_RECENT, cost: 9, notes: 'PO #PO-HYD-1 L#1 primary' });
+  loss({ stock: hydBlue, qty: 10, date: '2026-06-11', reason: 'Damaged', notes: 'crushed in transit' });
 
   // ── 8. Same Variety, TWO demand dates (06-13 sole + 06-17 summed from 2) ────
   batch({
@@ -211,11 +235,13 @@ export function buildYModelGuide() {
   stockItems.push(attrless);
 
   // ── 10. Undated legacy aggregate (no date chip → "fuzzy") ───────────────────
-  batch({
+  // ARC C: 5 stems written off as old stock; remaining qty 10.
+  const gyp = batch({
     display: 'Gypsophila White',
     type: 'Gypsophila', colour: 'White', size: null, cultivar: null,
-    qty: 15, date: null, cost: 4, sell: 9,
+    qty: 10, date: null, cost: 4, sell: 9,
   });
+  loss({ stock: gyp, qty: 5, date: '2026-06-09', reason: 'Overstock', notes: 'old stock cleared' });
 
   // ── The incoming PO (covers concepts 5, 6, 9) ───────────────────────────────
   // Sent + assigned → also visible on the delivery app's shopping run.
@@ -223,6 +249,25 @@ export function buildYModelGuide() {
   poLine({ po: guidePo, stock: peony50DE, qty: 7,  name: 'Peony Pink 50cm (2026-06-15)',      supplier: 'Stojek', cost: 18, sell: 38 });
   poLine({ po: guidePo, stock: lisiDE,    qty: 20, name: 'Lisianthus White 50cm (2026-06-18)', supplier: 'Stojek', cost: 5,  sell: 14 });
   poLine({ po: guidePo, stock: attrless,  qty: 50, name: 'peony',                              supplier: '4f',     cost: 12, sell: 20 });
+
+  // ── ABSORPTION CASE — Anemone Burgundy 50cm ─────────────────────────────────
+  // Post-absorption STATE: DE=0 (zeroed), Batch=7 (received 12 + existing −5 = 7).
+  // The lab seeds raw rows — it does NOT run receiveIntoStock; this is the end-state.
+  const anemDE = de({
+    display: 'Anemone Burgundy 50cm (2026-06-14)',
+    type: 'Anemone', colour: 'Burgundy', size: 50, cultivar: null,
+    qty: 0, date: '2026-06-14', sell: 22,
+  });
+  const ordAnem = order({ requiredBy: '2026-06-14', status: 'Ready' });
+  line({ order: ordAnem, stock: anemDE, qty: 5, name: 'Anemone Burgundy 50cm' });
+  const anemBatch = batch({
+    display: 'Anemone Burgundy 50cm (16.Jun.)',
+    type: 'Anemone', colour: 'Burgundy', size: 50, cultivar: null,
+    qty: 7, date: PO_ARRIVE, cost: 8, sell: 22, supplier: 'Stojek',
+  });
+  purchase({ stock: anemBatch, qty: 12, date: PO_ARRIVE, cost: 8, supplier: 'Stojek', notes: 'PO #PO-ABSORB-1 L#1 primary' });
+  const absorbPo = po({ number: 'PO-ABSORB-1', status: 'Complete', driver: 'Nikita', plannedDate: PO_ARRIVE });
+  poLine({ po: absorbPo, stock: anemDE, qty: 12, name: 'Anemone Burgundy 50cm (2026-06-14)', supplier: 'Stojek', cost: 8, sell: 22 });
 
   // ── Premade reservation: "Spring Set" reserves 6 Hydrangea Blue ─────────────
   const bouquets = [
@@ -239,6 +284,8 @@ export function buildYModelGuide() {
   return {
     customers: base.customers,
     stockItems,
+    stockLosses,
+    stockPurchases,
     stockOrders,
     stockOrderLines,
     orders,


### PR DESCRIPTION
Slice S1 of the Y-model trace full-fidelity work (plan: `docs/superpowers/plans/2026-06-22-trace-full-fidelity-plan.md`). Lab-only — no app/backend code.

## What
- New factories `lab/factories/stockLoss.js` (`stock_loss_log`) + `lab/factories/stockPurchase.js` (`stock_purchases`), each with a `.test.js` (12 + 13 tests).
- `lab/helpers/seed.js` — two new `insertMany` calls (`stock_loss_log`, `stock_purchases`) in FK order (after `stock`), empty-array-guarded so baseline is unaffected.
- `lab/scenarios/yModelGuide.js` — three full arcs (Rose Red 40→4 via orders+wilt; Hydrangea Blue 28→12 via damage; Gypsophila 15→10 via overstock) + an Anemone Burgundy absorption end-state (DE=0, batch=7, PO-ABSORB-1 Complete, 12-stem receive).

## Why
So the owner can actually *see* a Variety's stock develop over time in the trace (PO receipt → orders → wilting → low), per the live test-session request.

## Verification
- `npm run lab:test:unit` — 65 tests green (incl. 25 new factory tests).
- `npm run lab:test:api` (baseline) — local run, output in PR thread.
- `npm run lab:template:rebuild -- --scenario=y-model-guide` + `lab:reset` — seeds clean (no FK/column errors); data visible on the lab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYtMTKWXKc5Hyz9nuEYatD