### PR TITLE
feat(stock): one-tap history button on every Variety row (Y-model trace reach)

### DIFF
--- a/packages/shared/components/VarietyListItem.jsx
+++ b/packages/shared/components/VarietyListItem.jsx
@@ -173,6 +173,19 @@ export default function VarietyListItem({
           <span className="text-[10px] text-gray-400 mt-0.5">{statusLabel}</span>
         </div>
 
+        {/* Inline history (trace) button — always visible when hasTrace */}
+        {hasTrace && (
+          <button
+            type="button"
+            data-testid="variety-history-btn"
+            onClick={handleTraceClick}
+            className="shrink-0 self-center mr-2 text-[13px] px-2 py-1 rounded-full bg-indigo-50 active:bg-indigo-100"
+            aria-label={t.trace ?? 'Trace'}
+          >
+            📈
+          </button>
+        )}
+
         {/* Inline write-off */}
         {onWriteOff && (
           <button

--- a/packages/shared/test/VarietyListItem.test.jsx
+++ b/packages/shared/test/VarietyListItem.test.jsx
@@ -88,6 +88,32 @@ describe('VarietyListItem header', () => {
   });
 });
 
+describe('VarietyListItem history button (S2)', () => {
+  it('renders variety-history-btn when onVarietyTrace is provided', () => {
+    const onVarietyTrace = vi.fn();
+    render(<VarietyListItem variety={variety} reservations={new Map()} t={t}
+      hideType={true} expanded={false} onToggle={() => {}} onVarietyTrace={onVarietyTrace} />);
+    expect(screen.getByTestId('variety-history-btn')).toBeInTheDocument();
+  });
+
+  it('does NOT render variety-history-btn when neither onVarietyTrace nor onRowClick+row is provided', () => {
+    // No onVarietyTrace, no onRowClick → hasTrace is false → button absent.
+    render(<VarietyListItem variety={variety} reservations={new Map()} t={t}
+      hideType={true} expanded={false} onToggle={() => {}} />);
+    expect(screen.queryByTestId('variety-history-btn')).toBeNull();
+  });
+
+  it('clicking history-btn calls onVarietyTrace(variety.key) AND does NOT call onToggle', () => {
+    const onVarietyTrace = vi.fn();
+    const onToggle = vi.fn();
+    render(<VarietyListItem variety={variety} reservations={new Map()} t={t}
+      hideType={true} expanded={false} onToggle={onToggle} onVarietyTrace={onVarietyTrace} />);
+    fireEvent.click(screen.getByTestId('variety-history-btn'));
+    expect(onVarietyTrace).toHaveBeenCalledWith('Rose|Pink|60|');
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+});
+
 describe('VarietyListItem expansion', () => {
   const v = {
     key: 'Rose|Pink|60|',


### PR DESCRIPTION
Slice S2 of the Y-model trace full-fidelity work (plan: `docs/superpowers/plans/2026-06-22-trace-full-fidelity-plan.md`).

## What
A `📈` history button on every collapsed Variety row in `packages/shared/components/VarietyListItem.jsx` (header right cluster, before write-off). One tap opens the existing graphical trace (modal in florist, inline in dashboard) — no need to expand the row first. Renders only when a trace handler is wired (`hasTrace`); reuses `handleTraceClick` which already `stopPropagation`s so the header does not toggle. The existing in-body "Trace ›" button is unchanged. One shared edit → both apps.

## Why
Live test-session ask: "see the trace on any flower we choose from." Previously trace was reachable only via expand → "Trace ›" (buried).

## Verification
- `packages/shared` — 39/39 tests green, incl. 3 new (button renders with `onVarietyTrace`; absent without; click fires trace and NOT `onToggle`).
- Built all three apps (florist, dashboard, delivery) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYtMTKWXKc5Hyz9nuEYatD