### PR TITLE
fix(stock): trace footer shows true drift, not on-hand stock

### DIFF
--- a/apps/dashboard/src/components/StockTab.jsx
+++ b/apps/dashboard/src/components/StockTab.jsx
@@ -71,6 +71,7 @@ export default function StockTab({ initialFilter, onNavigate, isActive = true })
   const [varietyTraceKey, setVarietyTraceKey]           = useState(null);
   const [varietyTrail, setVarietyTrail]                 = useState([]);
   const [varietyUnaccounted, setVarietyUnaccounted]     = useState(0);
+  const [varietyDrift, setVarietyDrift]                 = useState(0);
   const [varietyTraceLoading, setVarietyTraceLoading]   = useState(false);
   const [writeOffVariety, setWriteOffVariety] = useState(null); // write-off picker (modal)
   // Per-row "Reconcile" button on premade chips. Gated on a backend setting
@@ -972,16 +973,19 @@ export default function StockTab({ initialFilter, onNavigate, isActive = true })
                               setVarietyTraceKey(null);
                               setVarietyTrail([]);
                               setVarietyUnaccounted(0);
+                              setVarietyDrift(0);
                               return;
                             }
                             setVarietyTraceKey(key);
                             setVarietyTrail([]);
                             setVarietyUnaccounted(0);
+                            setVarietyDrift(0);
                             setVarietyTraceLoading(true);
                             try {
                               const res = await client.get(`/stock/varieties/${encodeURIComponent(key)}/usage`);
                               setVarietyTrail(res.data.events || []);
                               setVarietyUnaccounted(res.data.unaccountedStems ?? 0);
+                              setVarietyDrift(res.data.drift ?? 0);
                             } catch {
                               setVarietyTrail([]);
                             } finally {
@@ -1001,7 +1005,7 @@ export default function StockTab({ initialFilter, onNavigate, isActive = true })
                                 {t.varietyTraceTitle ?? 'Variety history'}
                               </span>
                               <button
-                                onClick={() => { setVarietyTraceKey(null); setVarietyTrail([]); setVarietyUnaccounted(0); }}
+                                onClick={() => { setVarietyTraceKey(null); setVarietyTrail([]); setVarietyUnaccounted(0); setVarietyDrift(0); }}
                                 className="text-xs text-indigo-400 hover:text-indigo-600"
                               >
                                 ✕
@@ -1010,7 +1014,7 @@ export default function StockTab({ initialFilter, onNavigate, isActive = true })
                             {varietyTraceLoading ? (
                               <p className="text-xs text-ios-tertiary">{t.loading}</p>
                             ) : (
-                              <VarietyTracePanel events={varietyTrail} unaccountedStems={varietyUnaccounted} t={t} onOrderClick={(recordId) => onNavigate?.({ tab: 'orders', filter: { orderId: recordId } })} />
+                              <VarietyTracePanel events={varietyTrail} unaccountedStems={varietyUnaccounted} drift={varietyDrift} t={t} onOrderClick={(recordId) => onNavigate?.({ tab: 'orders', filter: { orderId: recordId } })} />
                             )}
                           </div>
                         )}

--- a/apps/florist/src/pages/StockPanelPage.jsx
+++ b/apps/florist/src/pages/StockPanelPage.jsx
@@ -77,6 +77,7 @@ export default function StockPanelPage() {
   const [varietyTraceKey, setVarietyTraceKey]         = useState(null);
   const [varietyTrail, setVarietyTrail]               = useState([]);
   const [varietyUnaccounted, setVarietyUnaccounted]   = useState(0);
+  const [varietyDrift, setVarietyDrift]               = useState(0);
   const [varietyTraceLoading, setVarietyTraceLoading] = useState(false);
   // Write-off modal state
   const [writeOffVariety, setWriteOffVariety] = useState(null);
@@ -607,11 +608,13 @@ export default function StockPanelPage() {
                             setVarietyTraceKey(key);
                             setVarietyTrail([]);
                             setVarietyUnaccounted(0);
+                            setVarietyDrift(0);
                             setVarietyTraceLoading(true);
                             try {
                               const res = await client.get(`/stock/varieties/${encodeURIComponent(key)}/usage`);
                               setVarietyTrail(res.data.events || []);
                               setVarietyUnaccounted(res.data.unaccountedStems ?? 0);
+                              setVarietyDrift(res.data.drift ?? 0);
                             } catch {
                               setVarietyTrail([]);
                             } finally {
@@ -708,7 +711,7 @@ export default function StockPanelPage() {
         <div
           data-testid="variety-trace-modal-backdrop"
           className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4"
-          onClick={() => { setVarietyTraceKey(null); setVarietyTrail([]); setVarietyUnaccounted(0); }}
+          onClick={() => { setVarietyTraceKey(null); setVarietyTrail([]); setVarietyUnaccounted(0); setVarietyDrift(0); }}
         >
           <div
             data-testid="variety-trace-modal-content"
@@ -722,13 +725,13 @@ export default function StockPanelPage() {
               {varietyTraceLoading ? (
                 <p className="text-xs text-ios-tertiary">{t.loading}</p>
               ) : (
-                <VarietyTracePanel events={varietyTrail} unaccountedStems={varietyUnaccounted} t={t} onOrderClick={(recordId) => navigate('/orders/' + recordId)} />
+                <VarietyTracePanel events={varietyTrail} unaccountedStems={varietyUnaccounted} drift={varietyDrift} t={t} onOrderClick={(recordId) => navigate('/orders/' + recordId)} />
               )}
             </div>
             <div className="px-4 pb-4 pt-1 border-t border-gray-50">
               <button
                 type="button"
-                onClick={() => { setVarietyTraceKey(null); setVarietyTrail([]); setVarietyUnaccounted(0); }}
+                onClick={() => { setVarietyTraceKey(null); setVarietyTrail([]); setVarietyUnaccounted(0); setVarietyDrift(0); }}
                 className="w-full py-2 text-sm text-gray-500 hover:text-gray-700"
               >
                 {t.close}

--- a/backend/src/__tests__/varietyUsageTrace.integration.test.js
+++ b/backend/src/__tests__/varietyUsageTrace.integration.test.js
@@ -334,3 +334,59 @@ describe('T5.3 — listGroupedByVariety includeEmpty=false keeps Variety with ac
     expect(keys).not.toContain('Rose|Pink|60|');
   });
 });
+
+// ── S6 drift tests ────────────────────────────────────────────────────────────
+
+describe('S6 — getUsageByVarietyKey drift computation', () => {
+  it('drift is 0 when events reconcile with on-hand stock', async () => {
+    // purchase +20, order −5, writeoff −3 → unaccountedStems=12; on-hand=12 → drift=0
+    const batch1 = await seedBatch({ displayName: 'Tulip Red 40', currentQuantity: 12, typeName: 'Tulip', colour: 'Red', sizeCm: 40 });
+    await seedPurchase(batch1.id, 20, '2026-06-01');
+    const customer = await seedCustomer();
+    const ord = await seedOrder(customer.id, '2026-06-10');
+    await seedOrderLine(ord.id, batch1.id, 5, 'Tulip Red');
+    await seedWriteOff(batch1.id, 3, '2026-06-05');
+
+    const result = await stockRepo.getUsageByVarietyKey('Tulip|Red|40|');
+    // unaccountedStems = +20 − 5 − 3 = 12; reservedStems = 0; onHand = 12; drift = 0
+    expect(result.unaccountedStems).toBe(12);
+    expect(result.reservedStems).toBe(0);
+    expect(result.onHand).toBe(12);
+    expect(result.drift).toBe(0);
+  });
+
+  it('drift is > 0 when on-hand is below what events predict (stems vanished)', async () => {
+    // purchase +30; on-hand only 20 (10 stems unrecorded loss) → drift = 10
+    const batch1 = await seedBatch({ displayName: 'Iris Purple 50', currentQuantity: 20, typeName: 'Iris', colour: 'Purple', sizeCm: 50 });
+    await seedPurchase(batch1.id, 30, '2026-06-01');
+
+    const result = await stockRepo.getUsageByVarietyKey('Iris|Purple|50|');
+    // unaccountedStems = +30; reservedStems = 0; onHand = 20; drift = 30 − 20 = 10
+    expect(result.unaccountedStems).toBe(30);
+    expect(result.reservedStems).toBe(0);
+    expect(result.onHand).toBe(20);
+    expect(result.drift).toBe(10);
+  });
+
+  it('drift is 0 for a premade-reserved Variety (reservedStems excluded from physical)', async () => {
+    // purchase +28, writeoff −10, premade −6; physical on-hand = 18 (premade does not move stock)
+    // unaccountedStems = 28 − 10 − 6 = 12; reservedStems = 6; onHand = 18; drift = 12+6−18 = 0
+    const batch1 = await seedBatch({ displayName: 'Hydrangea Blue 30', currentQuantity: 18, typeName: 'Hydrangea', colour: 'Blue', sizeCm: 30 });
+    await seedPurchase(batch1.id, 28, '2026-06-10');
+    await seedWriteOff(batch1.id, 10, '2026-06-11');
+    await seedPremade(batch1.id, 6);
+
+    const result = await stockRepo.getUsageByVarietyKey('Hydrangea|Blue|30|');
+    expect(result.unaccountedStems).toBe(12);  // 28 − 10 − 6
+    expect(result.reservedStems).toBe(6);
+    expect(result.onHand).toBe(18);
+    expect(result.drift).toBe(0);
+  });
+
+  it('drift fields are present and zero for an unknown key', async () => {
+    const result = await stockRepo.getUsageByVarietyKey('Unknown|Green|99|');
+    expect(result.drift).toBe(0);
+    expect(result.reservedStems).toBe(0);
+    expect(result.onHand).toBe(0);
+  });
+});

--- a/backend/src/repos/stockRepo.js
+++ b/backend/src/repos/stockRepo.js
@@ -1345,12 +1345,24 @@ export async function getUsageByExactId(stockItemId) {
 //   {
 //     variety: { key, type_name, colour, size_cm, cultivar },
 //     events:  TrailEvent[],  // sorted date ASC, null-dated last
-//     unaccountedStems: number, // signed sum; non-zero = drift
+//     unaccountedStems: number, // signed sum of ALL event quantities (kept for compat)
+//     reservedStems: number,   // stems tied up in premade reservations (positive)
+//     onHand: number,          // Σ current_quantity across all Variety rows
+//     drift: number,           // predicted − actual: (unaccountedStems + reservedStems − onHand)
+//                              // > 0 means stems vanished without a recorded event (real loss)
+//                              // ≤ 0 means reconciled or untraced opening balance → hidden
 //   }
 //
 // unaccountedStems = Σ purchase.quantity + Σ (order|writeoff|premade).quantity
 // (order/writeoff/premade are already stored as negative; purchases positive).
 // Absorption events are deferred — un-paired absorptions surface as drift.
+//
+// TRUE drift formula:
+//   reservedStems = −Σ(quantity) for premade events   (premades are negative; this is positive)
+//   onHand        = Σ(row.currentQuantity) across all Variety rows
+//   drift         = unaccountedStems + reservedStems − onHand
+// A healthy Variety (all stems accounted for) has drift === 0.
+// Only drift > 0 is actionable (stems missing with no event explaining them).
 export async function getUsageByVarietyKey(key) {
   if (!db) throw new Error('getUsageByVarietyKey: postgres backend not configured');
   if (!key) throw new Error('getUsageByVarietyKey: key is required');
@@ -1386,6 +1398,9 @@ export async function getUsageByVarietyKey(key) {
       },
       events:           [],
       unaccountedStems: 0,
+      reservedStems:    0,
+      onHand:           0,
+      drift:            0,
     };
   }
 
@@ -1413,8 +1428,23 @@ export async function getUsageByVarietyKey(key) {
   if (firstPoIdx    !== -1) allEvents[firstPoIdx].firstPo       = true;
   if (firstDemandIdx !== -1) allEvents[firstDemandIdx].firstDemand = true;
 
-  // Compute drift: signed sum across all events.
+  // Compute unaccountedStems: signed sum across all events (kept for compat).
   const unaccountedStems = allEvents.reduce((sum, e) => sum + (Number(e.quantity) || 0), 0);
+
+  // Compute TRUE drift:
+  //   reservedStems = stems locked in premade reservations (premade events are negative
+  //                   in the ledger but do NOT reduce physical stock under the Y-model).
+  //   onHand        = Σ current_quantity across all rows in this Variety.
+  //   drift         = unaccountedStems + reservedStems − onHand
+  //   drift > 0 → stems vanished without a recorded event (real loss, footer shown).
+  //   drift ≤ 0 → reconciled or untraced opening balance (footer hidden).
+  const reservedStems = allEvents
+    .filter(e => e.type === 'premade')
+    .reduce((sum, e) => sum + -(Number(e.quantity) || 0), 0); // premades are negative; negate → positive
+
+  const onHand = rows.reduce((sum, row) => sum + (Number(row.currentQuantity) || 0), 0);
+
+  const drift = unaccountedStems + reservedStems - onHand;
 
   return {
     variety: {
@@ -1426,6 +1456,9 @@ export async function getUsageByVarietyKey(key) {
     },
     events:  allEvents,
     unaccountedStems,
+    reservedStems,
+    onHand,
+    drift,
   };
 }
 

--- a/lab/scenarios/yModelGuide.js
+++ b/lab/scenarios/yModelGuide.js
@@ -195,7 +195,7 @@ export function buildYModelGuide() {
   const hydBlue = batch({
     display: 'Hydrangea Blue 30cm (10.Jun.)',
     type: 'Hydrangea', colour: 'Blue', size: 30, cultivar: null,
-    qty: 12, date: BATCH_RECENT, cost: 9, sell: 28,
+    qty: 18, date: BATCH_RECENT, cost: 9, sell: 28,
   });
   purchase({ stock: hydBlue, qty: 28, date: BATCH_RECENT, cost: 9, notes: 'PO #PO-HYD-1 L#1 primary' });
   loss({ stock: hydBlue, qty: 10, date: '2026-06-11', reason: 'Damaged', notes: 'crushed in transit' });

--- a/packages/shared/components/PendingArrivalsPanel.jsx
+++ b/packages/shared/components/PendingArrivalsPanel.jsx
@@ -235,7 +235,7 @@ export default function PendingArrivalsPanel({ pendingPO = {}, stock = [], t = {
                           <div className="ml-6 mt-1 mb-2">
                             {trace.loading && <p className="text-indigo-400 italic text-xs">{t.loading ?? 'Loading…'}</p>}
                             {!trace.loading && (
-                              <VarietyTracePanel events={trace.events} unaccountedStems={trace.unaccountedStems} t={t} onOrderClick={onOrderClick} />
+                              <VarietyTracePanel events={trace.events} unaccountedStems={trace.unaccountedStems} drift={trace.drift} t={t} onOrderClick={onOrderClick} />
                             )}
                           </div>
                         )}

--- a/packages/shared/components/ShortfallSummary.jsx
+++ b/packages/shared/components/ShortfallSummary.jsx
@@ -276,6 +276,7 @@ function DateRow({ date, rows, t, isOpen, toggle, getTrace, onVarietyClick, spli
                     <VarietyTracePanel
                       events={getTrace(r.key).events}
                       unaccountedStems={getTrace(r.key).unaccountedStems}
+                      drift={getTrace(r.key).drift}
                       t={t}
                       onOrderClick={onOrderClick}
                     />

--- a/packages/shared/components/VarietyTracePanel.jsx
+++ b/packages/shared/components/VarietyTracePanel.jsx
@@ -6,21 +6,23 @@ import { byDateAsc } from '../utils/sortByDate.js';
  *
  * Sibling of BatchTracePanel, but spans EVERY Stock row in a Variety (all
  * Batches + Demand Entries) rather than one Batch. Data comes from
- * GET /stock/varieties/:key/usage → { variety, events, unaccountedStems }.
+ * GET /stock/varieties/:key/usage → { variety, events, unaccountedStems, drift }.
  *
  * Props:
  *   events           — array of trail events (already date-asc from the API;
  *                      we re-sort defensively, undated last)
- *   unaccountedStems — signed Σ of all event quantities. Non-zero = drift
- *                      (e.g. a deferred absorption, or a qty change with no
- *                      emitting event). Surfaces a footer only when non-zero.
+ *   unaccountedStems — signed Σ of all event quantities (kept for callers;
+ *                      no longer drives the footer — use `drift` for that).
+ *   drift            — TRUE drift: unaccountedStems + reservedStems − onHand.
+ *                      Footer renders ONLY when drift > 0 (stems vanished with
+ *                      no recorded event). drift ≤ 0 = reconciled, footer hidden.
  *   t                — strings (traceTypeOrder/Writeoff/Purchase/Premade,
  *                      traceEmpty, stems, unaccountedStems)
  *
  * Absorption events are deferred (audit_log has no transaction_id) — they show
  * up inside `unaccountedStems` rather than as paired rows. See the T5 plan.
  */
-export default function VarietyTracePanel({ events = [], unaccountedStems = 0, t, onOrderClick }) {
+export default function VarietyTracePanel({ events = [], unaccountedStems = 0, drift = 0, t, onOrderClick }) {
   const hasEvents = events && events.length > 0;
 
   const sorted = hasEvents ? [...events].sort(byDateAsc) : [];
@@ -44,14 +46,14 @@ export default function VarietyTracePanel({ events = [], unaccountedStems = 0, t
         <p className="text-xs text-gray-400 py-2 text-center">{t.traceEmpty}</p>
       )}
 
-      {unaccountedStems !== 0 && (
+      {drift > 0 && (
         <div
           data-testid="unaccounted-footer"
           className="mt-2 flex items-center justify-between px-3 py-2 rounded-lg bg-amber-50 border border-amber-200 text-xs"
         >
           <span className="font-medium text-amber-800">{t.unaccountedStems ?? 'Unaccounted'}</span>
           <span className="font-semibold tabular-nums text-amber-800">
-            {unaccountedStems > 0 ? '+' : ''}{unaccountedStems} {t.stems}
+            +{drift} {t.stems}
           </span>
         </div>
       )}

--- a/packages/shared/hooks/useVarietyTraceExpand.js
+++ b/packages/shared/hooks/useVarietyTraceExpand.js
@@ -1,7 +1,7 @@
 // packages/shared/hooks/useVarietyTraceExpand.js
 import { useCallback, useState } from 'react';
 
-const EMPTY = { events: [], unaccountedStems: 0, loading: false, loaded: false };
+const EMPTY = { events: [], unaccountedStems: 0, drift: 0, loading: false, loaded: false };
 
 /**
  * useVarietyTraceExpand — expand state for date-grouped stock cards.
@@ -34,7 +34,7 @@ export function useVarietyTraceExpand(fetchVarietyUsage) {
       setCache((prev) => {
         if (prev.has(key)) return prev; // cache hit — no refetch
         const next = new Map(prev);
-        next.set(key, { events: [], unaccountedStems: 0, loading: true, loaded: false });
+        next.set(key, { events: [], unaccountedStems: 0, drift: 0, loading: true, loaded: false });
         return next;
       });
       if (!cache.has(key) && fetchVarietyUsage) {
@@ -44,6 +44,7 @@ export function useVarietyTraceExpand(fetchVarietyUsage) {
               new Map(prev).set(key, {
                 events: data?.events ?? [],
                 unaccountedStems: data?.unaccountedStems ?? 0,
+                drift: data?.drift ?? 0,
                 loading: false,
                 loaded: true,
               }),
@@ -51,7 +52,7 @@ export function useVarietyTraceExpand(fetchVarietyUsage) {
           )
           .catch(() =>
             setCache((prev) =>
-              new Map(prev).set(key, { events: [], unaccountedStems: 0, loading: false, loaded: true }),
+              new Map(prev).set(key, { events: [], unaccountedStems: 0, drift: 0, loading: false, loaded: true }),
             ),
           );
       }

--- a/packages/shared/test/VarietyTracePanel.test.jsx
+++ b/packages/shared/test/VarietyTracePanel.test.jsx
@@ -51,17 +51,18 @@ describe('VarietyTracePanel', () => {
     expect(screen.queryByTestId('unaccounted-footer')).not.toBeInTheDocument();
   });
 
-  it('shows the unaccounted footer with signed count when non-zero', () => {
+  it('shows the unaccounted footer with drift count when drift > 0', () => {
     const events = [{ type: 'purchase', date: '2026-05-08', quantity: 30 }];
-    render(<VarietyTracePanel events={events} unaccountedStems={7} t={t} />);
+    render(<VarietyTracePanel events={events} unaccountedStems={30} drift={7} t={t} />);
     const footer = screen.getByTestId('unaccounted-footer');
     expect(footer).toHaveTextContent('Unaccounted');
     expect(footer).toHaveTextContent('+7 stems');
   });
 
-  it('renders the unaccounted footer even with no events', () => {
-    render(<VarietyTracePanel events={[]} unaccountedStems={-4} t={t} />);
-    expect(screen.getByTestId('unaccounted-footer')).toHaveTextContent('-4 stems');
+  it('hides the footer when drift is 0 (even with unaccountedStems > 0)', () => {
+    // Footer is driven by drift, not unaccountedStems — drift=0 means reconciled.
+    render(<VarietyTracePanel events={[]} unaccountedStems={-4} drift={0} t={t} />);
+    expect(screen.queryByTestId('unaccounted-footer')).not.toBeInTheDocument();
   });
 
   it('renders a balance sparkline when there is at least one dated event', () => {
@@ -145,5 +146,36 @@ describe('VarietyTracePanel', () => {
     render(<VarietyTracePanel events={events} unaccountedStems={0} t={t} />);
     expect(screen.queryByText('First PO')).not.toBeInTheDocument();
     expect(screen.queryByText('First demand')).not.toBeInTheDocument();
+  });
+});
+
+describe('VarietyTracePanel — S6 drift-driven footer', () => {
+  it('hides the footer when drift is 0 even if unaccountedStems is large', () => {
+    // e.g. healthy Rose Red: unaccountedStems=4 but drift=0 (on-hand=4)
+    const events = [{ type: 'purchase', date: '2026-05-01', quantity: 40 }];
+    render(<VarietyTracePanel events={events} unaccountedStems={4} drift={0} t={t} />);
+    expect(screen.queryByTestId('unaccounted-footer')).not.toBeInTheDocument();
+  });
+
+  it('hides the footer when drift is negative (more physical stock than events explain)', () => {
+    // opening balance scenario: drift < 0 — not actionable
+    const events = [{ type: 'purchase', date: '2026-05-01', quantity: 10 }];
+    render(<VarietyTracePanel events={events} unaccountedStems={-5} drift={-5} t={t} />);
+    expect(screen.queryByTestId('unaccounted-footer')).not.toBeInTheDocument();
+  });
+
+  it('shows the footer with the drift value when drift > 0', () => {
+    // Iris Purple 50: purchase+30, on-hand=20, drift=10
+    const events = [{ type: 'purchase', date: '2026-06-01', quantity: 30 }];
+    render(<VarietyTracePanel events={events} unaccountedStems={30} drift={10} t={t} />);
+    const footer = screen.getByTestId('unaccounted-footer');
+    expect(footer).toHaveTextContent('Unaccounted');
+    expect(footer).toHaveTextContent('+10 stems');
+  });
+
+  it('drift defaults to 0 so footer is hidden when prop is omitted', () => {
+    const events = [{ type: 'purchase', date: '2026-05-01', quantity: 20 }];
+    render(<VarietyTracePanel events={events} unaccountedStems={20} t={t} />);
+    expect(screen.queryByTestId('unaccounted-footer')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Slice S6 of the Y-model trace work (plan: `docs/superpowers/plans/2026-06-22-trace-full-fidelity-plan.md`). Pure read-path + presentational; no schema change. (S4/S5 absorption migration cancelled — the balance line already shows absorption.)

## Problem
The trace's amber "Unaccounted" footer showed `Σ(all events)`, which ≈ on-hand stock for healthy Varieties — so it falsely flagged "+N unaccounted" on perfectly-fine stock (e.g. Rose Red: 40 in / 36 out / 4 on hand → "+4 unaccounted").

## Fix — true drift
`getUsageByVarietyKey` now also returns `reservedStems`, `onHand`, and `drift`:
- `reservedStems = −Σ(premade event qty)` (premade reservations are negative events but don't reduce physical stock under the Y-model).
- `onHand = Σ current_quantity` across the Variety's rows.
- `drift = unaccountedStems + reservedStems − onHand` (events-predicted physical minus actual).

The footer fires ONLY when `drift > 0` (stems vanished with no recorded event — a real loss). `drift <= 0` (reconciled, or untraced/opening stock) → hidden. `unaccountedStems` kept for back-compat.

Wired `drift` through: `useVarietyTraceExpand`, `ShortfallSummary`, `PendingArrivalsPanel`, dashboard `StockTab`, florist `StockPanelPage`. Lab seed reconcile: Hydrangea Blue batch 12→18 (28 in − 10 damaged = 18; the 6 reserved is not physical).

## Verification
- Backend `varietyUsageTrace.integration.test.js` — 10/10 (4 new: reconcile→0, vanished→drift>0, premade-reserved→0).
- Shared `VarietyTracePanel.test.jsx` — 18/18 (footer hidden when drift≤0 even if unaccountedStems large; shown when drift>0).
- Built all three apps clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYtMTKWXKc5Hyz9nuEYatD