### PR TITLE
feat(stock): step-chart balance trace (axes, zero line, event markers) + fix shared JSX test CI gap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,6 +80,26 @@ jobs:
           PIN_OWNER: '1111'
           PIN_FLORIST: '2222'
 
+  shared:
+    name: Shared unit tests (vitest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run shared tests (utils, hooks, components)
+        run: npx vitest run
+        working-directory: packages/shared
+
   e2e:
     name: E2E harness suite
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,27 +40,6 @@
         "vite": "^5.3.1"
       }
     },
-    "apps/dashboard/node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
-      }
-    },
     "apps/dashboard/node_modules/vite": {
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
@@ -138,27 +117,6 @@
         "postcss": "^8.4.39",
         "tailwindcss": "^3.4.4",
         "vite": "^5.3.1"
-      }
-    },
-    "apps/delivery/node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "apps/delivery/node_modules/vite": {
@@ -240,27 +198,6 @@
         "postcss": "^8.4.39",
         "tailwindcss": "^3.4.4",
         "vite": "^5.3.1"
-      }
-    },
-    "apps/florist/node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.28.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "apps/florist/node_modules/vite": {
@@ -3977,6 +3914,27 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -11016,6 +10974,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^14.3.1",
+        "@vitejs/plugin-react": "^4.3.1",
         "jsdom": "^29.1.1"
       },
       "peerDependencies": {

--- a/packages/shared/CLAUDE.md
+++ b/packages/shared/CLAUDE.md
@@ -28,9 +28,10 @@ components/
   VarietyIdentity.jsx         → Single source of truth for Variety 4-tuple typography (#311). Prominent mode (Type + Colour bold, Size small, Cultivar italic) for picker; compact mode (Type as tiny caption when shown, same Colour/Size/Cultivar hierarchy) for Stock list rows under TypeGroupHeader.
   TypeGroupHeader.jsx         → Sticky collapsible Type header for the Y-model stock list. Renders Type label, aggregate bucket totals, and expand/collapse chevron.
   VarietyListItem.jsx         → Variety row with 4-bucket header (onHand / planned / reserved / net), expand-to-Stock-Items, tap-on-reserved → premade list, tap-on-Batch → trace. Consumed by StockPanelPage (florist) and StockTab (dashboard) under `STOCK_Y_MODEL`.
-  BatchTracePanel.jsx         → Inline per-Batch usage trace panel (florist uses this via BatchTraceModal; dashboard renders it directly as an inline panel).
+  BalanceSparkline.jsx        → Shared step-chart balance trace (S7). Time-proportional X axis, inverted Y axis, always-on zero line (dashed), staircase path (hold→jump), Y/X axis labels, colour-coded event markers. Props: events, t, onOrderClick, asOf. Consumed by BatchTracePanel and VarietyTracePanel.
+  BatchTracePanel.jsx         → Inline per-Batch usage trace panel (florist uses this via BatchTraceModal; dashboard renders it directly as an inline panel). Uses shared BalanceSparkline.
   BatchTraceModal.jsx         → Modal wrapper around BatchTracePanel. Used by the florist app where trace opens over a sheet.
-  VarietyTracePanel.jsx       → Per-Variety usage trail — unions events across every Batch + DE in a Variety (GET /stock/varieties/:key/usage). Renders the 4 event kinds + an "unaccounted stems" drift footer. Absorption events deferred (PRD #324 T5).
+  VarietyTracePanel.jsx       → Per-Variety usage trail — unions events across every Batch + DE in a Variety (GET /stock/varieties/:key/usage). Renders the 4 event kinds + an "unaccounted stems" drift footer. Absorption events deferred (PRD #324 T5). Uses shared BalanceSparkline.
   WriteOffBatchPicker.jsx     → Batch-targeted write-off form. Excludes Demand Entries; defaults to oldest Batch by date. Behind `STOCK_Y_MODEL`.
   DissolvePremadesDialog.jsx  → Confirm modal for dissolving premade bouquets in an order
   WixPushModal.jsx            → Async-job progress modal for /products/push (florist + dashboard)

--- a/packages/shared/components/BalanceSparkline.jsx
+++ b/packages/shared/components/BalanceSparkline.jsx
@@ -1,0 +1,281 @@
+import { formatDateDMY } from '../utils/formatDate.js';
+
+/**
+ * BalanceSparkline — step-chart rendering of stock balance over time.
+ *
+ * Replaces the old diagonal-line sparkline in BatchTracePanel and
+ * VarietyTracePanel. Key corrections:
+ *   1. Stock HOLDS its level until an event fires — staircase, not diagonal.
+ *   2. X axis is time-proportional (3 days wide = 3x a 1-day column), not
+ *      evenly spaced by event index.
+ *   3. Y axis always includes 0. Zero line always rendered (dashed gray).
+ *   4. Axis labels: max balance (top-left) + 0 label + date ticks.
+ *   5. Event markers: green = purchase/in, red = consume/out, gray = dissolve.
+ *   6. Order markers are clickable via onOrderClick.
+ *
+ * Props
+ *   events      — raw event array (same shape as /stock/:id/usage,
+ *                 /stock/varieties/:key/usage). Undated events are ignored.
+ *   t           — translation strings (stems, traceTypeOrder, traceTypeWriteoff,
+ *                 traceTypePurchase, traceTypePremade, traceTypeDissolve)
+ *   onOrderClick — optional (orderRecordId, event) => void — fires when an
+ *                  order-type marker is clicked.
+ *   asOf        — optional ISO date string for "now"; defaults to the last
+ *                 dated event's date.
+ */
+export default function BalanceSparkline({ events = [], t = {}, onOrderClick, asOf }) {
+  // --- 1. Prepare dated events -------------------------------------------
+  const dated = (events || [])
+    .filter((e) => e.date)
+    .sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+
+  if (dated.length < 1) return null;
+
+  // --- 2. Running balance ---------------------------------------------------
+  let running = 0;
+  const points = dated.map((e) => {
+    const qty = e.qty ?? e.quantity ?? 0;
+    running += qty;
+    return { event: e, balance: running };
+  });
+
+  const lastPoint = points[points.length - 1];
+  const lastBal = lastPoint.balance;
+
+  // --- 3. Layout constants ---------------------------------------------------
+  const W = 320;
+  const H = 130;
+  const padLeft = 28;   // room for y-axis labels
+  const padRight = 6;
+  const padTop = 14;    // room for max-balance label
+  const padBottom = 18; // room for x-axis date ticks
+
+  const plotW = W - padLeft - padRight;
+  const plotH = H - padTop - padBottom;
+
+  // --- 4. Scale: time → x ---------------------------------------------------
+  const firstDate = dated[0].date;
+  const lastDate = asOf ?? lastPoint.event.date;
+  const t0 = new Date(firstDate).getTime();
+  const t1 = new Date(lastDate).getTime();
+  const tRange = Math.max(t1 - t0, 1); // avoid divide-by-zero for single events
+
+  function xOf(dateStr) {
+    const ms = new Date(dateStr).getTime();
+    return padLeft + ((ms - t0) / tRange) * plotW;
+  }
+
+  // --- 5. Scale: balance → y ------------------------------------------------
+  const allBals = [0, ...points.map((p) => p.balance)];
+  const yMin = Math.min(...allBals);
+  const yMax = Math.max(...allBals);
+  const yRange = Math.max(1, yMax - yMin);
+
+  function yOf(val) {
+    // Inverted: higher balance = higher on chart = smaller SVG y
+    return padTop + plotH - ((val - yMin) / yRange) * plotH;
+  }
+
+  const zeroY = yOf(0);
+
+  // --- 6. Staircase path ----------------------------------------------------
+  // Start at first event's x, at balance=0 (before the event lands)
+  // Then jump vertically to balance after first event,
+  // then for each subsequent event: H-segment (hold) then V-segment (jump).
+  // Finally trail horizontal to asOf.
+  const pathParts = [];
+
+  const x0 = xOf(firstDate);
+  const y0 = yOf(0);
+  pathParts.push(`M ${x0.toFixed(1)} ${y0.toFixed(1)}`);           // start at zero
+  pathParts.push(`L ${x0.toFixed(1)} ${yOf(points[0].balance).toFixed(1)}`); // jump after first event
+
+  for (let i = 1; i < points.length; i++) {
+    const xi = xOf(points[i].event.date);
+    const prevBal = points[i - 1].balance;
+    const currBal = points[i].balance;
+    pathParts.push(`L ${xi.toFixed(1)} ${yOf(prevBal).toFixed(1)}`);  // hold
+    pathParts.push(`L ${xi.toFixed(1)} ${yOf(currBal).toFixed(1)}`);  // jump
+  }
+
+  // Trail to asOf
+  const xEnd = xOf(lastDate);
+  pathParts.push(`L ${xEnd.toFixed(1)} ${yOf(lastBal).toFixed(1)}`);
+
+  const pathD = pathParts.join(' ');
+
+  // --- 7. X-axis tick labels ------------------------------------------------
+  // Show tick under each event date if ≤6 dated events, else first/middle/last.
+  const tickDates = (() => {
+    if (dated.length <= 6) {
+      return [...new Set(dated.map((e) => e.date))];
+    }
+    const all = [...new Set(dated.map((e) => e.date))];
+    const mid = all[Math.floor(all.length / 2)];
+    return [all[0], mid, all[all.length - 1]];
+  })();
+
+  // --- 8. Marker helpers ----------------------------------------------------
+  function typeLabelFor(type) {
+    switch (type) {
+      case 'order':    return t.traceTypeOrder    ?? 'Order';
+      case 'writeoff': return t.traceTypeWriteoff ?? 'Write-off';
+      case 'purchase': return t.traceTypePurchase ?? 'Purchase';
+      case 'premade':  return t.traceTypePremade  ?? 'Premade';
+      case 'dissolve': return t.traceTypeDissolve ?? 'Dissolved';
+      default:         return type;
+    }
+  }
+
+  function trailDetailFor(ev) {
+    switch (ev.type) {
+      case 'order': {
+        const oid = ev.orderId ?? null;
+        const customer = ev.customer ?? null;
+        if (oid && customer) return `${oid} — ${customer}`;
+        return oid ?? customer ?? null;
+      }
+      case 'writeoff': return ev.reason ?? null;
+      case 'purchase': return ev.supplier ?? null;
+      case 'premade':  return ev.bouquetName ?? null;
+      case 'dissolve': {
+        const released = ev.releasedQty ? `+${ev.releasedQty} ${t.stems ?? 'stems'} freed` : null;
+        return [ev.bouquetName, released].filter(Boolean).join(' · ') || null;
+      }
+      default: return null;
+    }
+  }
+
+  function markerFill(ev) {
+    const qty = ev.qty ?? ev.quantity ?? 0;
+    if (ev.type === 'dissolve') return '#9ca3af'; // gray
+    return qty > 0 ? '#10b981' : '#ef4444';
+  }
+
+  // --- 9. Y-axis labels: max + 0 -------------------------------------------
+  const maxBalStr = `${yMax > 0 ? '+' : ''}${yMax}`;
+  const maxY = yOf(yMax);
+
+  // --- Render -----------------------------------------------------------------
+  return (
+    <div
+      data-testid="trace-sparkline"
+      className="bg-gradient-to-b from-blue-50/40 to-white px-3 py-2 border-b border-gray-100"
+    >
+      <div className="flex items-center justify-between text-[10px] uppercase tracking-wide text-gray-500 mb-1">
+        <span>{t.traceBalance ?? 'Balance'}</span>
+        <span className={`tabular-nums font-semibold ${lastBal < 0 ? 'text-red-600' : 'text-gray-700'}`}>
+          {lastBal} {t.stems}
+        </span>
+      </div>
+
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        className="w-full"
+        style={{ height: H }}
+        preserveAspectRatio="xMidYMid meet"
+      >
+        {/* Y-axis: max balance label */}
+        <text
+          x={padLeft - 3}
+          y={maxY + 3}
+          textAnchor="end"
+          fontSize="8"
+          fill="#9ca3af"
+          data-testid="y-label-max"
+        >
+          {maxBalStr}
+        </text>
+
+        {/* Y-axis: faint gridline at max */}
+        <line
+          x1={padLeft} x2={W - padRight}
+          y1={maxY} y2={maxY}
+          stroke="#f3f4f6" strokeWidth="1"
+        />
+
+        {/* Zero line — ALWAYS rendered */}
+        <line
+          data-testid="zero-line"
+          x1={padLeft} x2={W - padRight}
+          y1={zeroY} y2={zeroY}
+          stroke="#e5e7eb" strokeWidth="1" strokeDasharray="3 3"
+        />
+
+        {/* Zero label */}
+        <text
+          x={padLeft - 3}
+          y={zeroY + 3}
+          textAnchor="end"
+          fontSize="8"
+          fill="#9ca3af"
+          data-testid="y-label-zero"
+        >
+          0
+        </text>
+
+        {/* Staircase line */}
+        <path
+          d={pathD}
+          fill="none"
+          stroke={lastBal < 0 ? '#ef4444' : '#10b981'}
+          strokeWidth="1.5"
+          strokeLinecap="square"
+          strokeLinejoin="miter"
+        />
+
+        {/* Event markers */}
+        {points.map((p, i) => {
+          const cx = xOf(p.event.date);
+          const cy = yOf(p.balance);
+          const ev = p.event;
+          const qty = ev.qty ?? ev.quantity ?? 0;
+          const detail = trailDetailFor(ev);
+          const label = typeLabelFor(ev.type);
+          const qtyStr = qty > 0 ? `+${qty}` : `${qty}`;
+          const titleText = `${label} · ${qtyStr} ${t.stems ?? 'stems'} · ${formatDateDMY(ev.date)}${detail ? ` · ${detail}` : ''}`;
+          const isOrderClickable = ev.type === 'order' && !!onOrderClick && !!ev.orderRecordId;
+          const r = isOrderClickable ? 4 : 3;
+          const fill = markerFill(ev);
+
+          return (
+            <circle
+              key={i}
+              data-testid={`marker-${ev.type}`}
+              cx={cx.toFixed(1)}
+              cy={cy.toFixed(1)}
+              r={r}
+              fill={fill}
+              {...(isOrderClickable ? {
+                role: 'button',
+                style: { cursor: 'pointer' },
+                onClick: (e) => { e.stopPropagation(); onOrderClick(ev.orderRecordId, ev); },
+              } : {})}
+            >
+              <title>{titleText}</title>
+            </circle>
+          );
+        })}
+
+        {/* X-axis date ticks */}
+        {tickDates.map((d) => {
+          const tx = xOf(d);
+          const label = formatDateDMY(d).slice(0, 5); // DD.MM only
+          return (
+            <text
+              key={d}
+              x={tx.toFixed(1)}
+              y={H - 3}
+              textAnchor="middle"
+              fontSize="7"
+              fill="#9ca3af"
+              data-testid={`x-tick-${d}`}
+            >
+              {label}
+            </text>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/packages/shared/components/BatchTracePanel.jsx
+++ b/packages/shared/components/BatchTracePanel.jsx
@@ -1,5 +1,6 @@
 import { formatDateDMY } from '../utils/formatDate.js';
 import { byDateAsc } from '../utils/sortByDate.js';
+import BalanceSparkline from './BalanceSparkline.jsx';
 
 /**
  * BatchTracePanel — presentational component rendering the per-batch usage trail.
@@ -40,7 +41,7 @@ export default function BatchTracePanel({ trail = [], t }) {
 
   return (
     <div className="bg-white rounded-lg border border-gray-100 overflow-hidden">
-      <BalanceSparkline points={withBalance} t={t} />
+      <BalanceSparkline events={dated} t={t} />
       <ul className="divide-y divide-gray-50 max-h-72 overflow-y-auto">
         {withBalance.map(({ entry, balance: bal }, i) => (
           <TraceRow key={`d-${i}`} entry={entry} balance={bal} t={t} />
@@ -58,71 +59,6 @@ export default function BatchTracePanel({ trail = [], t }) {
           </ul>
         </>
       )}
-    </div>
-  );
-}
-
-/**
- * BalanceSparkline — compact SVG line of the running balance after each dated
- * event. Helps the operator see arrivals, drains, and crossings into negative
- * at a glance. Width fluid via viewBox; height ~64px. Negative segments
- * highlighted in red.
- */
-function BalanceSparkline({ points, t }) {
-  if (!points || points.length < 1) return null;
-  const W = 320;
-  const H = 64;
-  const PAD = 6;
-  const xs = points.map((_, i) => i);
-  const ys = points.map((p) => p.balance);
-  const yMin = Math.min(0, ...ys);
-  const yMax = Math.max(0, ...ys);
-  const yRange = Math.max(1, yMax - yMin);
-  const xStep = points.length > 1 ? (W - PAD * 2) / (points.length - 1) : 0;
-  const px = (i) => PAD + xStep * i;
-  const py = (v) => PAD + (1 - (v - yMin) / yRange) * (H - PAD * 2);
-  const path = points
-    .map((p, i) => `${i === 0 ? 'M' : 'L'} ${px(i).toFixed(1)} ${py(p.balance).toFixed(1)}`)
-    .join(' ');
-  const zeroY = py(0);
-  const lastBal = ys[ys.length - 1];
-
-  return (
-    <div
-      data-testid="trace-sparkline"
-      className="bg-gradient-to-b from-blue-50/40 to-white px-3 py-2 border-b border-gray-100"
-    >
-      <div className="flex items-center justify-between text-[10px] uppercase tracking-wide text-gray-500 mb-1">
-        <span>{t.traceBalance ?? 'Balance'}</span>
-        <span className={`tabular-nums font-semibold ${lastBal < 0 ? 'text-red-600' : 'text-gray-700'}`}>
-          {lastBal} {t.stems}
-        </span>
-      </div>
-      <svg viewBox={`0 0 ${W} ${H}`} className="w-full h-16" preserveAspectRatio="none">
-        {yMin < 0 && yMax >= 0 && (
-          <line
-            x1={PAD} x2={W - PAD} y1={zeroY} y2={zeroY}
-            stroke="#e5e7eb" strokeWidth="1" strokeDasharray="3 3"
-          />
-        )}
-        <path
-          d={path}
-          fill="none"
-          stroke={lastBal < 0 ? '#ef4444' : '#10b981'}
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        {points.map((p, i) => (
-          <circle
-            key={i}
-            cx={px(i)}
-            cy={py(p.balance)}
-            r="2"
-            fill={p.balance < 0 ? '#ef4444' : '#10b981'}
-          />
-        ))}
-      </svg>
     </div>
   );
 }

--- a/packages/shared/components/VarietyTracePanel.jsx
+++ b/packages/shared/components/VarietyTracePanel.jsx
@@ -1,5 +1,6 @@
 import { formatDateDMY } from '../utils/formatDate.js';
 import { byDateAsc } from '../utils/sortByDate.js';
+import BalanceSparkline from './BalanceSparkline.jsx';
 
 /**
  * VarietyTracePanel — presentational per-Variety usage trail (PRD #324 T5).
@@ -27,15 +28,9 @@ export default function VarietyTracePanel({ events = [], unaccountedStems = 0, d
 
   const sorted = hasEvents ? [...events].sort(byDateAsc) : [];
 
-  const dated = sorted.filter((e) => e.date);
-  let running = 0;
-  const balancePts = dated.length
-    ? [{ balance: 0 }, ...dated.map((e) => { running += (e.qty ?? e.quantity ?? 0); return { balance: running }; })]
-    : [];
-
   return (
     <div>
-      <BalanceSparkline points={balancePts} t={t} />
+      <BalanceSparkline events={sorted} t={t} onOrderClick={onOrderClick} />
       {hasEvents ? (
         <ul className="divide-y divide-gray-50 bg-white rounded-lg border border-gray-100 overflow-hidden max-h-64 overflow-y-auto">
           {sorted.map((entry, i) => (
@@ -100,34 +95,6 @@ function trailDetail(entry, t) {
     }
     default:         return null;
   }
-}
-
-function BalanceSparkline({ points, t }) {
-  if (!points || points.length < 2) return null;
-  const W = 320, H = 64, PAD = 6;
-  const ys = points.map((p) => p.balance);
-  const yMin = Math.min(0, ...ys);
-  const yMax = Math.max(0, ...ys);
-  const yRange = Math.max(1, yMax - yMin);
-  const xStep = points.length > 1 ? (W - PAD * 2) / (points.length - 1) : 0;
-  const px = (i) => PAD + xStep * i;
-  const py = (v) => PAD + (1 - (v - yMin) / yRange) * (H - PAD * 2);
-  const path = points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${px(i).toFixed(1)} ${py(p.balance).toFixed(1)}`).join(' ');
-  const zeroY = py(0);
-  const lastBal = ys[ys.length - 1];
-  return (
-    <div data-testid="trace-sparkline" className="bg-gradient-to-b from-blue-50/40 to-white px-3 py-2 border-b border-gray-100">
-      <div className="flex items-center justify-between text-[10px] uppercase tracking-wide text-gray-500 mb-1">
-        <span>{t.traceBalance ?? 'Balance'}</span>
-        <span className={`tabular-nums font-semibold ${lastBal < 0 ? 'text-red-600' : 'text-gray-700'}`}>{lastBal} {t.stems}</span>
-      </div>
-      <svg viewBox={`0 0 ${W} ${H}`} className="w-full h-16" preserveAspectRatio="none">
-        {yMin < 0 && yMax >= 0 && (<line x1={PAD} x2={W - PAD} y1={zeroY} y2={zeroY} stroke="#e5e7eb" strokeWidth="1" strokeDasharray="3 3" />)}
-        <path d={path} fill="none" stroke={lastBal < 0 ? '#ef4444' : '#10b981'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-        {points.map((p, i) => (<circle key={i} cx={px(i)} cy={py(p.balance)} r="2" fill={p.balance < 0 ? '#ef4444' : '#10b981'} />))}
-      </svg>
-    </div>
-  );
 }
 
 function TraceRow({ entry, t, onOrderClick }) {

--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -115,6 +115,9 @@ export { default as PendingArrivalsPanel } from './components/PendingArrivalsPan
 export { default as useStockYModelFlag } from './hooks/useStockYModelFlag.js';
 export { useVarietyTraceExpand } from './hooks/useVarietyTraceExpand.js';
 
+// Step-chart balance trace — shared by BatchTracePanel and VarietyTracePanel (S7)
+export { default as BalanceSparkline } from './components/BalanceSparkline.jsx';
+
 // Per-batch trace UX seam — panel (inline, dashboard) + modal wrapper (florist) (issue #289)
 export { default as BatchTracePanel } from './components/BatchTracePanel.jsx';
 export { default as BatchTraceModal } from './components/BatchTraceModal.jsx';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^14.3.1",
+    "@vitejs/plugin-react": "^4.3.1",
     "jsdom": "^29.1.1"
   }
 }

--- a/packages/shared/test/BalanceSparkline.test.jsx
+++ b/packages/shared/test/BalanceSparkline.test.jsx
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import BalanceSparkline from '../components/BalanceSparkline.jsx';
+
+const t = {
+  stems: 'stems',
+  traceBalance: 'Balance',
+  traceTypeOrder: 'Order',
+  traceTypeWriteoff: 'Write-off',
+  traceTypePurchase: 'Purchase',
+  traceTypePremade: 'Premade',
+  traceTypeDissolve: 'Dissolved',
+};
+
+const basicEvents = [
+  { type: 'purchase', date: '2026-05-01', quantity: 30, supplier: 'Wholesale' },
+  { type: 'order',    date: '2026-05-05', quantity: -10, orderId: '202605-001', customer: 'Anna', orderRecordId: 'rec_001' },
+  { type: 'order',    date: '2026-05-10', quantity: -5,  orderId: '202605-002', customer: 'Bob',  orderRecordId: 'rec_002' },
+];
+
+// Parse SVG path "d" attribute into coordinate pairs [x, y]
+function parsePath(d) {
+  const coords = [];
+  const parts = d.trim().split(/\s+/);
+  for (let i = 0; i < parts.length; i++) {
+    const tok = parts[i];
+    if (tok === 'M' || tok === 'L') {
+      const x = parseFloat(parts[i + 1]);
+      const y = parseFloat(parts[i + 2]);
+      coords.push({ x, y });
+      i += 2;
+    }
+  }
+  return coords;
+}
+
+describe('BalanceSparkline — staircase shape', () => {
+  it('returns null for no events', () => {
+    const { container } = render(<BalanceSparkline events={[]} t={t} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null for events with no dates', () => {
+    const { container } = render(
+      <BalanceSparkline events={[{ type: 'premade', quantity: -3 }]} t={t} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a single-event chart gracefully (flat line)', () => {
+    render(<BalanceSparkline events={[{ type: 'purchase', date: '2026-05-01', quantity: 20 }]} t={t} />);
+    expect(screen.getByTestId('trace-sparkline')).toBeInTheDocument();
+    const path = document.querySelector('path');
+    expect(path).not.toBeNull();
+  });
+
+  it('path contains vertical segments (staircase jumps)', () => {
+    render(<BalanceSparkline events={basicEvents} t={t} />);
+    const path = document.querySelector('path');
+    const coords = parsePath(path.getAttribute('d'));
+
+    // A vertical segment = two consecutive coords with same x, different y
+    let hasVertical = false;
+    for (let i = 1; i < coords.length; i++) {
+      if (
+        Math.abs(coords[i].x - coords[i - 1].x) < 0.1 &&
+        Math.abs(coords[i].y - coords[i - 1].y) > 0.1
+      ) {
+        hasVertical = true;
+        break;
+      }
+    }
+    expect(hasVertical).toBe(true);
+  });
+
+  it('path contains horizontal segments (hold between events)', () => {
+    render(<BalanceSparkline events={basicEvents} t={t} />);
+    const path = document.querySelector('path');
+    const coords = parsePath(path.getAttribute('d'));
+
+    let hasHorizontal = false;
+    for (let i = 1; i < coords.length; i++) {
+      if (
+        Math.abs(coords[i].y - coords[i - 1].y) < 0.1 &&
+        Math.abs(coords[i].x - coords[i - 1].x) > 0.1
+      ) {
+        hasHorizontal = true;
+        break;
+      }
+    }
+    expect(hasHorizontal).toBe(true);
+  });
+});
+
+describe('BalanceSparkline — zero line', () => {
+  it('renders zero line even when all balances are positive', () => {
+    const positiveOnly = [
+      { type: 'purchase', date: '2026-05-01', quantity: 30 },
+      { type: 'purchase', date: '2026-05-05', quantity: 10 },
+    ];
+    render(<BalanceSparkline events={positiveOnly} t={t} />);
+    expect(screen.getByTestId('zero-line')).toBeInTheDocument();
+  });
+
+  it('renders zero line when balances go negative', () => {
+    const mixed = [
+      { type: 'purchase', date: '2026-05-01', quantity: 5 },
+      { type: 'order',    date: '2026-05-05', quantity: -10 },
+    ];
+    render(<BalanceSparkline events={mixed} t={t} />);
+    expect(screen.getByTestId('zero-line')).toBeInTheDocument();
+  });
+});
+
+describe('BalanceSparkline — markers', () => {
+  it('renders one marker per dated event', () => {
+    render(<BalanceSparkline events={basicEvents} t={t} />);
+    const markers = screen.getAllByTestId(/^marker-/);
+    expect(markers).toHaveLength(basicEvents.length);
+  });
+
+  it('purchase marker is green', () => {
+    render(<BalanceSparkline events={[{ type: 'purchase', date: '2026-05-01', quantity: 20 }]} t={t} />);
+    const marker = screen.getByTestId('marker-purchase');
+    expect(marker.getAttribute('fill')).toBe('#10b981');
+  });
+
+  it('order marker (negative qty) is red', () => {
+    render(<BalanceSparkline events={[{ type: 'order', date: '2026-05-05', quantity: -5, orderRecordId: 'r1' }]} t={t} />);
+    const marker = screen.getByTestId('marker-order');
+    expect(marker.getAttribute('fill')).toBe('#ef4444');
+  });
+
+  it('dissolve marker is gray', () => {
+    render(<BalanceSparkline events={[{ type: 'dissolve', date: '2026-05-07', quantity: 0, releasedQty: 3 }]} t={t} />);
+    const marker = screen.getByTestId('marker-dissolve');
+    expect(marker.getAttribute('fill')).toBe('#9ca3af');
+  });
+
+  it('undated events produce no markers', () => {
+    render(<BalanceSparkline events={[
+      { type: 'purchase', date: '2026-05-01', quantity: 20 },
+      { type: 'premade',  date: null,         quantity: -3 },
+    ]} t={t} />);
+    const markers = screen.getAllByTestId(/^marker-/);
+    expect(markers).toHaveLength(1); // only the purchase
+  });
+});
+
+describe('BalanceSparkline — axis labels', () => {
+  it('renders a y-label for 0', () => {
+    render(<BalanceSparkline events={basicEvents} t={t} />);
+    expect(screen.getByTestId('y-label-zero')).toBeInTheDocument();
+    expect(screen.getByTestId('y-label-zero')).toHaveTextContent('0');
+  });
+
+  it('renders a y-label for the max balance', () => {
+    render(<BalanceSparkline events={basicEvents} t={t} />);
+    const maxLabel = screen.getByTestId('y-label-max');
+    expect(maxLabel).toBeInTheDocument();
+    // max after events: purchase(30) → order(-10) → order(-5) → max is 30
+    expect(maxLabel.textContent).toContain('30');
+  });
+
+  it('renders x-tick for first date (DD.MM format)', () => {
+    render(<BalanceSparkline events={basicEvents} t={t} />);
+    const firstTick = screen.getByTestId('x-tick-2026-05-01');
+    expect(firstTick).toBeInTheDocument();
+    expect(firstTick.textContent).toBe('01.05');
+  });
+
+  it('renders x-tick for last date', () => {
+    render(<BalanceSparkline events={basicEvents} t={t} />);
+    const lastTick = screen.getByTestId('x-tick-2026-05-10');
+    expect(lastTick).toBeInTheDocument();
+    expect(lastTick.textContent).toBe('10.05');
+  });
+});
+
+describe('BalanceSparkline — interactivity', () => {
+  it('calls onOrderClick with orderRecordId when an order marker is clicked', () => {
+    const onOrderClick = vi.fn();
+    render(<BalanceSparkline events={basicEvents} t={t} onOrderClick={onOrderClick} />);
+    const orderMarkers = screen.getAllByTestId('marker-order');
+    fireEvent.click(orderMarkers[0]);
+    expect(onOrderClick).toHaveBeenCalledWith('rec_001', expect.objectContaining({ orderId: '202605-001' }));
+  });
+
+  it('does not call onOrderClick when a purchase marker is clicked', () => {
+    const onOrderClick = vi.fn();
+    render(<BalanceSparkline events={basicEvents} t={t} onOrderClick={onOrderClick} />);
+    const purchaseMarker = screen.getByTestId('marker-purchase');
+    fireEvent.click(purchaseMarker);
+    expect(onOrderClick).not.toHaveBeenCalled();
+  });
+
+  it('order marker without onOrderClick is not a button', () => {
+    render(<BalanceSparkline events={basicEvents} t={t} />);
+    const orderMarkers = screen.getAllByTestId('marker-order');
+    orderMarkers.forEach((m) => {
+      expect(m.getAttribute('role')).not.toBe('button');
+    });
+  });
+
+  it('order marker with onOrderClick has role=button', () => {
+    const onOrderClick = vi.fn();
+    render(<BalanceSparkline events={basicEvents} t={t} onOrderClick={onOrderClick} />);
+    const orderMarkers = screen.getAllByTestId('marker-order');
+    orderMarkers.forEach((m) => {
+      expect(m.getAttribute('role')).toBe('button');
+    });
+  });
+
+  it('order marker without orderRecordId is not clickable', () => {
+    const onOrderClick = vi.fn();
+    const noRecId = [{ type: 'order', date: '2026-05-05', quantity: -5, orderId: '202605-001' }];
+    render(<BalanceSparkline events={noRecId} t={t} onOrderClick={onOrderClick} />);
+    const orderMarker = screen.getByTestId('marker-order');
+    expect(orderMarker.getAttribute('role')).not.toBe('button');
+    fireEvent.click(orderMarker);
+    expect(onOrderClick).not.toHaveBeenCalled();
+  });
+});
+
+describe('BalanceSparkline — data-testid preserved', () => {
+  it('root element has data-testid="trace-sparkline"', () => {
+    render(<BalanceSparkline events={basicEvents} t={t} />);
+    expect(screen.getByTestId('trace-sparkline')).toBeInTheDocument();
+  });
+});

--- a/packages/shared/test/setup.js
+++ b/packages/shared/test/setup.js
@@ -1,1 +1,11 @@
 import '@testing-library/jest-dom';
+
+// jsdom does not implement URL.createObjectURL / revokeObjectURL, which
+// components like BouquetImageEditor call on file pick. Stub them so those
+// component tests can mount. (Real browsers provide these.)
+if (typeof URL.createObjectURL !== 'function') {
+  URL.createObjectURL = () => 'blob:mock';
+}
+if (typeof URL.revokeObjectURL !== 'function') {
+  URL.revokeObjectURL = () => {};
+}

--- a/packages/shared/vitest.config.js
+++ b/packages/shared/vitest.config.js
@@ -1,22 +1,16 @@
 import { defineConfig } from 'vitest/config';
-import { fileURLToPath, URL } from 'node:url';
-import { createRequire } from 'node:module';
+import react from '@vitejs/plugin-react';
 
-const require = createRequire(import.meta.url);
-
-// @vitejs/plugin-react is not a direct dep of packages/shared but is available
-// via the apps' node_modules — resolve it explicitly so JSX tests work.
-const reactPluginPath = new URL(
-  '../../apps/florist/node_modules/@vitejs/plugin-react/dist/index.js',
-  import.meta.url
-).pathname;
-const { default: react } = await import(reactPluginPath);
-
+// The React plugin sets esbuild's automatic JSX runtime so component/hook
+// tests (*.test.jsx) compile without an explicit `import React`. Without it,
+// JSX falls back to the classic `React.createElement` transform and every
+// component test throws "React is not defined". jsdom is the default env so
+// @testing-library/react can mount.
 export default defineConfig({
   plugins: [react()],
   test: {
     globals: true,
-    setupFiles: ['./test/setup.js'],
     environment: 'jsdom',
+    setupFiles: ['./test/setup.js'],
   },
 });

--- a/packages/shared/vitest.config.js
+++ b/packages/shared/vitest.config.js
@@ -1,8 +1,22 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath, URL } from 'node:url';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+// @vitejs/plugin-react is not a direct dep of packages/shared but is available
+// via the apps' node_modules — resolve it explicitly so JSX tests work.
+const reactPluginPath = new URL(
+  '../../apps/florist/node_modules/@vitejs/plugin-react/dist/index.js',
+  import.meta.url
+).pathname;
+const { default: react } = await import(reactPluginPath);
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     globals: true,
     setupFiles: ['./test/setup.js'],
+    environment: 'jsdom',
   },
 });


### PR DESCRIPTION
Slice S7 of the Y-model trace work + a test-infra fix surfaced while building it.

## Owner feedback addressed (screenshot)
The balance line sloped diagonally between events — misleading. Stock HOLDS a level until an event then jumps. Also no axes / no zero line / no link from a point to what consumed it.

## Chart redesign — new shared `BalanceSparkline.jsx`
- **Staircase line** (hold-then-jump): flat segment held at each balance until the next event date, vertical jump at the event. Leading 0 → first jump.
- **Time-proportional X axis** (dates as ms): a 3-day hold is literally 3× wider than a 1-day hold; DD.MM tick labels.
- **Stems Y axis** + an **always-visible dashed zero line**.
- **Event markers** colour-coded (green in / red out / gray dissolve), each with a hover `<title>` (type · ±qty · date · who), order markers clickable → open the order.
- Replaces the private sparkline in BOTH `VarietyTracePanel` + `BatchTracePanel` (now share one component); exported from `index.js`.

## Test-infra fix (found while building — important)
The shared vitest config had **no React plugin**, so every `*.test.jsx` threw "React is not defined" — the component/hook tests **never ran**, and CI had **no `packages/shared` job** (only backend vitest), so PRs went green with broken frontend tests (S2/S3/S6 reported green JSX tests that were actually red).
- `packages/shared`: `@vitejs/plugin-react` added as a devDependency; `vitest.config.js` uses it normally + jsdom.
- `test/setup.js`: stub `URL.createObjectURL`/`revokeObjectURL` (jsdom lacks them).
- `.github/workflows/test.yml`: **new "Shared unit tests (vitest)" CI job** so this can't regress.

## Verification
- Full shared suite now genuinely green: **45 files / 509 tests** (was: 44 JSX files silently failing).
- New `BalanceSparkline.test.jsx` (22 tests): staircase path shape, zero line, marker colours/count, axis labels, order-marker click.
- Built all three apps clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYtMTKWXKc5Hyz9nuEYatD