### PR TITLE
fix(waste-log): format Date column as DD.MM.YYYY

### DIFF
--- a/apps/dashboard/src/components/StockTab.jsx
+++ b/apps/dashboard/src/components/StockTab.jsx
@@ -8,6 +8,7 @@ import { useToast } from '../context/ToastContext.jsx';
 import t from '../translations.js';
 import {
   stockBaseName, renderDateTag, parseBatchName, LOSS_REASONS, reasonLabel,
+  formatDateDMY,
   useStockYModelFlag,
   TypeGroupHeader,
   VarietyListItem,
@@ -665,7 +666,7 @@ export default function StockTab({ initialFilter, onNavigate, isActive = true })
           if (isEditing) {
             return (
               <tr key={e.id} className="border-b border-gray-50 bg-blue-50/50">
-                <td className="px-3 py-1.5 text-xs text-ios-tertiary">{e.Date}</td>
+                <td className="px-3 py-1.5 text-xs text-ios-tertiary">{formatDateDMY(e.Date)}</td>
                 <td className="px-3 py-1.5 text-xs font-medium text-ios-label">{baseName}</td>
                 <td className="px-3 py-1.5 text-xs">{batchTag}</td>
                 <td className="px-3 py-1.5 text-xs text-ios-secondary">{e.supplier || '—'}</td>
@@ -691,7 +692,7 @@ export default function StockTab({ initialFilter, onNavigate, isActive = true })
 
           return (
             <tr key={e.id} className="border-b border-gray-50 group">
-              <td className="px-3 py-1.5 text-xs text-ios-tertiary">{e.Date}</td>
+              <td className="px-3 py-1.5 text-xs text-ios-tertiary">{formatDateDMY(e.Date)}</td>
               <td className="px-3 py-1.5 text-xs font-medium text-ios-label">{baseName}</td>
               <td className="px-3 py-1.5 text-xs">{batchTag}</td>
               <td className="px-3 py-1.5 text-xs text-ios-secondary">{e.supplier || '—'}</td>


### PR DESCRIPTION
## What

The dashboard Waste log Date column rendered the raw ISO date (`2026-06-22`). The owner wants the app-wide **DD.MM.YYYY** convention (`22.06.2026`), as used by `DateTag` and the rest of the UI.

## Change

`apps/dashboard/src/components/StockTab.jsx` — render `e.Date` through the shared `formatDateDMY()` (the canonical formatter `DateTag` already uses) in both the display and inline-edit `WasteRow` variants.

## Verification

- `vite build` dashboard ✅.
- Verified live on the lab: Date column now shows `22.06.2026 / 21.06.2026 / …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)