### PR TITLE
fix(bouquet): net same-Variety sibling lines (stop "not in stock" double-count)

### DIFF
--- a/apps/dashboard/src/components/steps/Step2Bouquet.jsx
+++ b/apps/dashboard/src/components/steps/Step2Bouquet.jsx
@@ -5,7 +5,7 @@ import client from '../../api/client.js';
 import t from '../../translations.js';
 import { useToast } from '../../context/ToastContext.jsx';
 import useConfigLists from '../../hooks/useConfigLists.js';
-import { renderStockName, VarietyAllocationPicker, VarietyAvailabilityLine, useStockYModelFlag, varietyDisplayName, groupByVariety, resolveStockLinePrice, resolveVarietySell, getVarietyAvailability, arrivalsForVariety } from '@flower-studio/shared';
+import { renderStockName, VarietyAllocationPicker, VarietyAvailabilityLine, useStockYModelFlag, varietyDisplayName, groupByVariety, resolveStockLinePrice, resolveVarietySell, getVarietyAvailability, arrivalsForVariety, allocateLinesAgainstVariety } from '@flower-studio/shared';
 
 const PO_MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
 function formatPoDate(dateStr) {
@@ -229,6 +229,18 @@ export default function Step2Bouquet({
     }
     return map;
   }, [yEnabled, adaptedStock, pendingPO, reservations, todayIso]);
+
+  // Net each cart line's available stock against earlier lines of the SAME
+  // Variety so two lines of one Variety never both claim the same on-hand stems
+  // (the "3 not in stock" double-count). remainingNet[i] = what's left for line
+  // i after earlier same-Variety lines took their share.
+  const lineNets = useMemo(() => allocateLinesAgainstVariety(orderLines, (l) => {
+    if (l.stockDeferred) return null; // future-PO lines don't pull current stock
+    const a = yEnabled ? varietyAvailById[l.stockItemId] : null;
+    if (a) return { key: a, net: a.net };
+    const si = stock.find(s => s.id === l.stockItemId);
+    return { key: l.stockItemId ?? l.flowerName, net: Number(si?.['Current Quantity']) || 0 };
+  }), [orderLines, varietyAvailById, yEnabled, stock]);
 
   function addOne(stockItem, amount = 1) {
     const add = Math.max(1, Number(amount) || 1);
@@ -596,14 +608,14 @@ export default function Step2Bouquet({
                 </span>
               </div>
             ))}
-            {!premadeLocked && orderLines.map(l => {
+            {!premadeLocked && orderLines.map((l, idx) => {
               const key = lineKey(l);
               const stockItem = stock.find(s => s.id === l.stockItemId);
               // CR-27: whole-Variety net under Y-model, not the single bound row.
               const lineVarietyAvail = yEnabled ? varietyAvailById[l.stockItemId] : null;
-              const availableQty = lineVarietyAvail
-                ? lineVarietyAvail.net
-                : Number(stockItem?.['Current Quantity']) || 0;
+              // ...further reduced by earlier same-Variety lines so two lines of
+              // one Variety never double-count the same on-hand stems.
+              const availableQty = lineNets[idx];
               const overStock = l.stockItemId && !l.stockDeferred && l.quantity > availableQty;
               // Pending-PO flowers price off their PO, not the stale card sell (#377).
               const sellPrice = resolveStockLinePrice(stockItem, pendingPO[l.stockItemId]).sellPricePerUnit

--- a/apps/florist/src/components/BouquetEditor.jsx
+++ b/apps/florist/src/components/BouquetEditor.jsx
@@ -3,6 +3,7 @@ import {
   renderStockName, parseBatchName, findAllMatchingVariety,
   BatchPickerModal, VarietyAllocationPicker, TierSwitchChip, useStockYModelFlag, useAuth,
   groupByVariety, varietyDisplayName, resolveStockLinePrice, resolveVarietySell,
+  allocateLinesAgainstVariety,
 } from '@flower-studio/shared';
 import t from '../translations.js';
 
@@ -40,6 +41,14 @@ export default function BouquetEditor({ editing, saving, detail, isTerminal, isO
     }
     return visibleStock;
   }, [visibleStock, showOutOfStock, editing.pendingPO]);
+
+  // Net each cart line's available stock against earlier lines bound to the SAME
+  // stock item, so two lines never both claim the same on-hand stems. lineNets[i]
+  // = what's left for line i after earlier same-item lines took their share.
+  const lineNets = useMemo(() => allocateLinesAgainstVariety(editing.editLines, (l) => {
+    const si = editing.stockItems.find(s => s.id === l.stockItemId);
+    return { key: l.stockItemId ?? l.flowerName, net: Number(si?.['Current Quantity']) || 0 };
+  }), [editing.editLines, editing.stockItems]);
 
   // Group catalog: Y-model = one row per Variety 4-tuple; legacy = one row per base name
   const catalogVarieties = useMemo(() => {
@@ -250,7 +259,7 @@ export default function BouquetEditor({ editing, saving, detail, isTerminal, isO
               <div className="bg-white rounded-xl border border-gray-100 overflow-hidden divide-y divide-gray-50">
                 {editing.editLines.map((line, idx) => {
                   const si = editing.stockItems.find(s => s.id === line.stockItemId);
-                  const availableQty = Number(si?.['Current Quantity']) || 0;
+                  const availableQty = lineNets[idx]; // sibling-netted (see lineNets memo)
                   // Pending-PO flowers price off their PO, not the stale card sell (#377).
                   const liveSell = resolveStockLinePrice(si, editing.pendingPO?.[line.stockItemId]).sellPricePerUnit
                     || Number(line.sellPricePerUnit) || 0;

--- a/apps/florist/src/components/steps/Step2Bouquet.jsx
+++ b/apps/florist/src/components/steps/Step2Bouquet.jsx
@@ -10,7 +10,7 @@ import { useToast } from '../../context/ToastContext.jsx';
 import { useAuth } from '../../context/AuthContext.jsx';
 import t from '../../translations.js';
 import useConfigLists from '../../hooks/useConfigLists.js';
-import { renderStockName, VarietyAllocationPicker, VarietyAvailabilityLine, useStockYModelFlag, varietyDisplayName, groupByVariety, resolveStockLinePrice, resolveVarietySell, getVarietyAvailability, arrivalsForVariety } from '@flower-studio/shared';
+import { renderStockName, VarietyAllocationPicker, VarietyAvailabilityLine, useStockYModelFlag, varietyDisplayName, groupByVariety, resolveStockLinePrice, resolveVarietySell, getVarietyAvailability, arrivalsForVariety, allocateLinesAgainstVariety } from '@flower-studio/shared';
 
 const PO_MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
 function formatPoDate(dateStr) {
@@ -29,14 +29,17 @@ const CONFIDENCE_STYLES = {
   none: 'border-l-4 border-l-red-300',
 };
 
-function CartLine({ line: l, stock, onChangeQty, onCommitQty, onCommitPrices, onRemove, isFutureOrder, onToggleDeferred, pendingPO, isOwner, varietyAvail }) {
+function CartLine({ line: l, stock, onChangeQty, onCommitQty, onCommitPrices, onRemove, isFutureOrder, onToggleDeferred, pendingPO, isOwner, varietyAvail, siblingNet }) {
   const stockItem = stock.find(s => s.id === l.stockItemId);
   // CR-27: under Y-model, availability is the whole Variety's net (free now), not
   // the single bound sub-row — so binding to a Demand Entry no longer reads as a
   // phantom shortfall while physical batches exist in the same Variety.
-  const availableQty = varietyAvail
-    ? varietyAvail.net
-    : Number(stockItem?.['Current Quantity']) || 0;
+  // siblingNet (when provided) is that Variety net already reduced by earlier
+  // lines of the same Variety in this bouquet, so two lines never double-count
+  // the same on-hand stems.
+  const availableQty = siblingNet != null
+    ? siblingNet
+    : (varietyAvail ? varietyAvail.net : Number(stockItem?.['Current Quantity']) || 0);
   // Pending-PO flowers price off their PO, not the stale card sell (#377).
   const sellPrice = resolveStockLinePrice(stockItem, pendingPO?.[l.stockItemId]).sellPricePerUnit
     || Number(l.sellPricePerUnit) || 0;
@@ -383,6 +386,18 @@ export default function Step2Bouquet({
     }
     return map;
   }, [yEnabled, adaptedStock, pendingPO, reservations, todayIso]);
+
+  // Net each cart line's available stock against earlier lines of the SAME
+  // Variety so two lines never both claim the same on-hand stems (the "3 not in
+  // stock" double-count). Walks orderLines in order; remainingNet[i] is what's
+  // left for line i after earlier same-Variety lines took their share.
+  const lineNets = useMemo(() => allocateLinesAgainstVariety(orderLines, (l) => {
+    if (l.stockDeferred) return null; // future-PO lines don't pull current stock
+    const a = yEnabled ? varietyAvailById[l.stockItemId] : null;
+    if (a) return { key: a, net: a.net };
+    const si = stock.find(s => s.id === l.stockItemId);
+    return { key: l.stockItemId ?? l.flowerName, net: Number(si?.['Current Quantity']) || 0 };
+  }), [orderLines, varietyAvailById, yEnabled, stock]);
 
   function addOne(stockItem, amount = 1) {
     const add = Math.max(1, Number(amount) || 1);
@@ -844,7 +859,7 @@ export default function Step2Bouquet({
                 </div>
               ))
             ) : (
-              orderLines.map(l => (
+              orderLines.map((l, idx) => (
                 <CartLine
                   key={lineKey(l)}
                   line={l}
@@ -858,6 +873,7 @@ export default function Step2Bouquet({
                   onToggleDeferred={(key) => toggleDeferred(key)}
                   pendingPO={pendingPO}
                   varietyAvail={yEnabled ? varietyAvailById[l.stockItemId] : null}
+                  siblingNet={lineNets[idx]}
                 />
               ))
             )}

--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -44,7 +44,7 @@ export {
   REASON_COLORS,
   reasonBadgeClass,
 } from './utils/lossReasons.js';
-export { getEffectiveStock, hasStockShortfall, getVarietyTotals, getVarietyAvailability, arrivalsForVariety, allocateVarietyCoverage } from './utils/stockMath.js';
+export { getEffectiveStock, hasStockShortfall, getVarietyTotals, getVarietyAvailability, arrivalsForVariety, allocateVarietyCoverage, allocateLinesAgainstVariety } from './utils/stockMath.js';
 export { resolveStockLinePrice, resolveVarietySell } from './utils/stockLinePrice.js';
 export { shouldShowBouquetSection } from './utils/bouquetVisibility.js';
 export { getStatusOptions, ALL_ORDER_STATUSES } from './utils/orderStatusOptions.js';

--- a/packages/shared/test/stockMath.test.js
+++ b/packages/shared/test/stockMath.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getEffectiveStock, hasStockShortfall, getVarietyTotals, getVarietyAvailability, arrivalsForVariety } from '../utils/stockMath.js';
+import { getEffectiveStock, hasStockShortfall, getVarietyTotals, getVarietyAvailability, arrivalsForVariety, allocateLinesAgainstVariety } from '../utils/stockMath.js';
 
 // Model (see stockMath.js header): stock is deducted at order creation, so
 // Current Quantity already reflects every pending order's demand. `committed`
@@ -173,5 +173,62 @@ describe('arrivalsForVariety — S1.2 overdue tagging', () => {
     const rawArrivals = arrivalsForVariety(rows, pendingPO, '2026-06-21');
     const a = getVarietyAvailability(rows, new Map(), rawArrivals);
     expect(a.arrivals[0].overdue).toBe(true);
+  });
+});
+
+describe('allocateLinesAgainstVariety — sibling netting', () => {
+  // The exact reported bug: Anemone Burgundy, 7 on hand, two lines [7, 10].
+  // Earlier line claims the 7 → line 2 sees 0 left → shows 10 short, not 3.
+  it('nets the on-hand across same-Variety sibling lines (7 → [7,10])', () => {
+    const variety = { net: 7 }; // one shared avail object, as the UI maps it
+    const lines = [{ stockItemId: 'a', quantity: 7 }, { stockItemId: 'b', quantity: 10 }];
+    const nets = allocateLinesAgainstVariety(lines, () => ({ key: variety, net: 7 }));
+    expect(nets).toEqual([7, 0]);
+    // shortfall the badge shows = qty - remaining
+    const shortfalls = lines.map((l, i) => Math.max(0, l.quantity - nets[i]));
+    expect(shortfalls).toEqual([0, 10]);
+    // invariant: total short === totalRequested - onHand
+    expect(shortfalls.reduce((s, x) => s + x, 0)).toBe(17 - 7);
+  });
+
+  it('three lines drain progressively ([5,5,5] vs net 12)', () => {
+    const v = { net: 12 };
+    const lines = [{ quantity: 5 }, { quantity: 5 }, { quantity: 5 }];
+    const nets = allocateLinesAgainstVariety(lines, () => ({ key: v, net: 12 }));
+    expect(nets).toEqual([12, 7, 2]);
+    const short = lines.map((l, i) => Math.max(0, l.quantity - nets[i]));
+    expect(short).toEqual([0, 0, 3]); // total 3 = 15 - 12
+  });
+
+  it('different varieties do not cross-consume', () => {
+    const a = { net: 5 }, b = { net: 4 };
+    const lines = [{ quantity: 5 }, { quantity: 4 }, { quantity: 3 }];
+    const nets = allocateLinesAgainstVariety(lines, (l, i) =>
+      i < 2 ? { key: a, net: 5 } : { key: b, net: 4 });
+    // line0 drains a; line1 a is gone → 0; line2 is variety b, full 4 available
+    expect(nets).toEqual([5, 0, 4]);
+  });
+
+  it('skips lines whose resolve returns null (deferred — no consumption)', () => {
+    const v = { net: 7 };
+    const lines = [{ quantity: 7, deferred: true }, { quantity: 10 }];
+    const nets = allocateLinesAgainstVariety(lines, (l) =>
+      l.deferred ? null : { key: v, net: 7 });
+    // deferred line consumes nothing → line 2 still sees the full 7
+    expect(nets[1]).toBe(7);
+  });
+
+  it('order matters — first line gets the stock', () => {
+    const v = { net: 6 };
+    const a = allocateLinesAgainstVariety([{ quantity: 6 }, { quantity: 2 }], () => ({ key: v, net: 6 }));
+    const b = allocateLinesAgainstVariety([{ quantity: 2 }, { quantity: 6 }], () => ({ key: v, net: 6 }));
+    expect(a).toEqual([6, 0]);
+    expect(b).toEqual([6, 4]);
+  });
+
+  it('legacy fallback nets against single-item qty by stockItemId key', () => {
+    const lines = [{ stockItemId: 's1', quantity: 4 }, { stockItemId: 's1', quantity: 5 }];
+    const nets = allocateLinesAgainstVariety(lines, (l) => ({ key: l.stockItemId, net: 6 }));
+    expect(nets).toEqual([6, 2]); // 6 - 4 = 2 left for line 2 → shows 3 short
   });
 });

--- a/packages/shared/utils/stockMath.js
+++ b/packages/shared/utils/stockMath.js
@@ -191,6 +191,39 @@ export function getVarietyAvailability(rows = [], reservations = new Map(), arri
 }
 
 /**
+ * allocateLinesAgainstVariety — net each bouquet line's available stock against
+ * SIBLING lines of the same Variety in the same bouquet.
+ *
+ * Without this, two lines of one Variety each compared their quantity to the
+ * WHOLE Variety's free stock and so counted the same stems twice: with 7 on hand
+ * and lines [7, 10], line 1 read "0 short" and line 2 read "10 − 7 = 3 short",
+ * hiding 7 stems of real shortfall. This walks the lines in order so earlier
+ * lines claim on-hand first; a later line then sees only what is left. The per-
+ * Variety invariant holds: Σ max(0, qty − remaining) === max(0, ΣqtyShown − net).
+ *
+ * @param {Array} lines  ordered bouquet lines
+ * @param {(line, index) => ({ key, net }|null)} resolve
+ *        key — grouping identity for the line's Variety (the shared varietyAvail
+ *              object, a variety key, or the stockItemId in legacy single-item mode).
+ *        net — the Variety's free stock available to the whole bouquet.
+ *        Return null to skip a line entirely (no consumption) — e.g. a deferred
+ *        line that pulls from a future PO, not current stock.
+ * @returns {number[]} remainingNet per line, aligned to `lines` — the value to
+ *          subtract from line.quantity for the "N not in stock" badge.
+ */
+export function allocateLinesAgainstVariety(lines = [], resolve) {
+  const consumed = new Map();
+  return lines.map((line, i) => {
+    const r = resolve(line, i);
+    if (!r || r.key == null) return r ? (Number(r.net) || 0) : 0;
+    const used = consumed.get(r.key) || 0;
+    const remaining = Math.max(0, (Number(r.net) || 0) - used);
+    consumed.set(r.key, used + (Number(line.quantity) || 0));
+    return remaining;
+  });
+}
+
+/**
  * arrivalsForVariety — collect a Variety's pending PO arrivals as [{date, qty, overdue}]
  * from the /stock/pending-po map (keyed by stockId). Mirrors the shape consumed
  * by getVarietyAvailability + allocateVarietyCoverage so the picker and the


### PR DESCRIPTION
## What

Y-model New Order builder. Owner added two **Anemone Burgundy** lines: line 1 = 7 from an existing dated batch (7 on hand), line 2 = 10 as new demand. Line 2 showed **"3 not in stock"** (10 − 7) instead of **"10"** — the 7 on-hand stems were counted once per line. True shortfall = 17 − 7 = 10.

## Root cause

Every bouquet line compared its quantity to the **whole Variety's net** (`getVarietyAvailability.net`, shared across all rows of the Variety per CR-27) and the available number was never reduced by what **sibling lines of the same Variety** already claimed. Line 1 read 0 short; line 2 read 10 − 7 = 3.

## Fix — one shared pure helper, consumed by every badge surface

- `packages/shared/utils/stockMath.js`: `allocateLinesAgainstVariety(lines, resolve)` walks lines in order, accumulating consumed per Variety, returns each line's `remainingNet = max(0, varietyNet − earlierSiblings)`. Invariant: `Σ max(0, qty − remaining) === max(0, ΣrequestedShown − net)`. `resolve` may return `null` to skip a line (deferred/future-PO lines pull no current stock). Exported from the barrel.
- `apps/florist/src/components/steps/Step2Bouquet.jsx` + `apps/dashboard/src/components/steps/Step2Bouquet.jsx`: compute `lineNets` over `orderLines` (grouped by the shared varietyAvail object under Y-model; by stockItemId/Current-Quantity in legacy) and feed each line's `remainingNet` into the "N not in stock" badge.
- `apps/florist/src/components/BouquetEditor.jsx`: same netting by stockItemId (its single-item availability model) for parity.

## Tests

`packages/shared/test/stockMath.test.js` — new block: the exact 7→[7,10]→shortfalls [0,10] case, progressive drain, multi-Variety isolation, deferred-skip, ordering, legacy fallback.

## Verification

- Shared vitest **527/527**; florist + dashboard + delivery `vite build` green.
- **Verified live on the lab** (Y-model dashboard New Order, Playwright): line 1 (7 from batch) shows no warning; line 2 (10 new demand) now reads **"10 not in stock"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)