### PR TITLE
feat(orders): click-to-sort headers + clearer funnel filters; fix per-keystroke search focus loss

### DIFF
--- a/apps/dashboard/CLAUDE.md
+++ b/apps/dashboard/CLAUDE.md
@@ -9,7 +9,7 @@ The owner needs two things: (1) daily operational control — same visibility as
 | Tab | Component | Purpose |
 |-----|-----------|---------|
 | Today | DayToDayTab.jsx | Kanban board of today's orders, pending deliveries, low stock alerts, unpaid orders. Cross-tab navigation to drill into details. |
-| Orders | OrdersTab.jsx | Full order list with per-column filter popovers (# / Order date / Customer / Bouquet / Status+Payment / Type / Fulfilment date / Total). Fulfilment column split into Type (🚗/🏪) + date cells. Date inputs use custom DatePicker (day-month-year). Shared `orderFilters` util drives filter state. Opens OrderDetailPanel for inline editing. |
+| Orders | OrdersTab.jsx | Full order list. **Click a column header to sort** by it (asc ⇄ desc on repeat click; brand ▲/▼ on the active column, faint ⇅ on hover for idle sortable columns); a **funnel button** beside each header opens that column's filter popover (# / Order date / Customer / Bouquet / Status+Payment / Type / Fulfilment date / Total). Fulfilment column split into Type (🚗/🏪) + date cells. Date inputs use custom DatePicker (day-month-year). Shared `orderFilters` util drives filter state; only server fields refetch — client text/price filters apply in memory (no per-keystroke fetch). Opens OrderDetailPanel for inline editing. |
 | New Order | NewOrderTab.jsx | 4-step order creation wizard (same steps as florist: Customer → Bouquet → Details → Review). |
 | Stock | StockTab.jsx | Inventory management with optimistic qty adjustments, write-off, visibility toggles, stock receive form. Uses `getEffectiveStock` from shared. Y-model collapsed Variety list under `STOCK_Y_MODEL` (TypeGroupHeader + VarietyListItem + BatchTracePanel inline from shared); legacy flat list when flag off. |
 | Customers | CustomersTab.jsx | CRM — customer list with segmentation (RFM scoring), detail panel with order history, editable fields. |
@@ -35,7 +35,7 @@ The owner needs two things: (1) daily operational control — same visibility as
 | PremadeBouquetCreateModal.jsx / PremadeBouquetList.jsx | Premade bouquet template editor + listing. |
 | TopProductsWidget.jsx / SourceChart.jsx / SummaryCard.jsx / Pills.jsx | Financial-tab building blocks. |
 | InlineEdit.jsx / DatePicker.jsx / Skeleton.jsx / Toast.jsx / HelpPanel.jsx | UI primitives. DatePicker is duplicated with florist — TODO move to shared. |
-| order/ColumnFilterPopover.jsx | Generic header `▾` popover shell for per-column filters. Props: `active` (highlights ▾ + shows dot), `title` (popover heading), `children` (filter controls). Consumed by OrdersTab for all 8 column header popovers. |
+| order/ColumnFilterPopover.jsx | Generic header **funnel-button** popover shell for per-column filters. Props: `active` (fills the funnel + shows a dot), `title` (popover heading + aria-label), `align` ('left' \| 'right' — right-anchor the panel on right-aligned columns so it doesn't spill past the viewport), `children` (filter controls). Consumed by OrdersTab for all 8 column header popovers; the header label itself is a separate sort control (SortHeader). |
 | `admin/`, `order/`, `products/`, `settings/`, `steps/` | Sub-folders for AdminTab panels, OrderDetailPanel sections, Products tab subpanels, Settings sections, NewOrder wizard steps. |
 
 ## Dashboard ↔ Florist Feature Parity (IMPORTANT)

--- a/apps/dashboard/src/components/OrdersTab.jsx
+++ b/apps/dashboard/src/components/OrdersTab.jsx
@@ -57,7 +57,35 @@ function getSortOptions() {
     { value: 'deliveryDate', label: t.sortByDelivery || 'Delivery date' },
     { value: 'type',         label: t.sortByType || 'Delivery/Pickup' },
     { value: 'orderDate',    label: t.sortByOrderDate || 'Order date' },
+    { value: 'orderId',      label: t.sortByOrderId || 'Order #' },
+    { value: 'customer',     label: t.sortByCustomer || 'Customer' },
+    { value: 'bouquet',      label: t.sortByBouquet || 'Bouquet' },
+    { value: 'total',        label: t.sortByTotal || 'Total' },
   ];
+}
+
+// Clickable column-header label that drives the table sort. The header text is
+// the sort control (click to sort, click again to flip direction); the funnel
+// button beside it opens the column's filter popover — two distinct affordances.
+// Idle sortable columns reveal a faint ⇅ on hover; the active column shows a
+// brand-coloured ▲ / ▼.
+function SortHeader({ label, sortKey, sortBy, sortDir, onSort }) {
+  const active = sortBy === sortKey;
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(sortKey)}
+      className="group inline-flex items-center gap-0.5 hover:text-ios-secondary transition-colors"
+      title={`${t.sortBy}: ${label}`}
+    >
+      <span className={active ? 'text-brand-600' : ''}>{label}</span>
+      <span className={`text-[9px] leading-none ${
+        active ? 'text-brand-600' : 'text-ios-tertiary opacity-0 group-hover:opacity-100'
+      }`}>
+        {active ? (sortDir === 'asc' ? '▲' : '▼') : '⇅'}
+      </span>
+    </button>
+  );
 }
 
 function todayStr() {
@@ -112,23 +140,32 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
   const initialLoaded = useRef(false);
   const fetchKeyRef = useRef('');
 
+  // Only the SERVER-supported filter fields drive a refetch. Client-only fields
+  // (orderIdQuery / customerQuery / bouquetQuery / price) are applied in memory
+  // below, so typing in a column-search box must NOT hit the network or flip
+  // `loading` — which would unmount the header inputs mid-keystroke and slam the
+  // popover shut after the first letter. Keep this dep list in sync with the
+  // server fields that buildOrderQueryParams reads.
+  // In upcoming mode, fetch by the backend's "upcoming" shortcut, but let
+  // `upcoming` own the date scope by blanking date fields first — all non-date
+  // server filters (status, paymentStatus, source, deliveryType, paymentMethod,
+  // excludeCancelled) still apply. Filter by delivery/pickup date (Required By),
+  // not submission date — the owner thinks "when does this go out" — #337.
+  const queryParams = useMemo(() => (
+    upcomingMode
+      ? { upcoming: '1', ...buildOrderQueryParams({ ...filter, requiredByFrom: '', requiredByTo: '', orderDateFrom: '', orderDateTo: '' }) }
+      : buildOrderQueryParams(filter)
+  ), [
+    upcomingMode,
+    filter.status, filter.source, filter.deliveryType, filter.paymentStatus,
+    filter.paymentMethod, filter.excludeCancelled,
+    filter.orderDateFrom, filter.orderDateTo, filter.requiredByFrom, filter.requiredByTo,
+  ]);
+
   const fetchOrders = useCallback(async (silent = false) => {
     if (!silent) setLoading(true);
     try {
-      // In upcoming mode, fetch by the backend's "upcoming" shortcut — but
-      // status still applies (it was sent regardless of mode pre-refactor).
-      // Otherwise, route through the shared param builder so all filter
-      // fields (date range, status, payment, delivery type, etc.) are sent
-      // consistently. Filter by delivery/pickup date (Required By), not
-      // submission date — the owner thinks in terms of "when does this go
-      // out", not "when was it placed" — #337.
-      // In upcoming mode, let `upcoming` own the date scope by blanking date fields
-      // before building params — all non-date server filters (status, paymentStatus,
-      // source, deliveryType, paymentMethod, excludeCancelled) still apply.
-      const params = upcomingMode
-        ? { upcoming: '1', ...buildOrderQueryParams({ ...filter, requiredByFrom: '', requiredByTo: '', orderDateFrom: '', orderDateTo: '' }) }
-        : buildOrderQueryParams(filter);
-      const res = await client.get('/orders', { params });
+      const res = await client.get('/orders', { params: queryParams });
       setOrders(prev => {
         if (!initialLoaded.current) return res.data;
         const newMap = new Map(res.data.map(o => [o.id, o]));
@@ -146,9 +183,9 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
     } finally {
       setLoading(false);
     }
-  }, [filter, upcomingMode, showToast]);
+  }, [queryParams, showToast]);
 
-  const fetchKey = JSON.stringify({ filter, upcomingMode });
+  const fetchKey = JSON.stringify(queryParams);
 
   useEffect(() => {
     if (!isActive) return undefined;
@@ -225,11 +262,39 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
       case 'orderDate':
         result = (a['Order Date'] || '').localeCompare(b['Order Date'] || '');
         break;
+      case 'orderId':
+        result = (Number(a['App Order ID']) || 0) - (Number(b['App Order ID']) || 0);
+        break;
+      case 'customer':
+        result = (a['Customer Name'] || '').localeCompare(b['Customer Name'] || '');
+        break;
+      case 'bouquet':
+        result = (a['Customer Request'] || '').localeCompare(b['Customer Request'] || '');
+        break;
+      case 'total': {
+        const ta = Number(a['Final Price'] || a['Price Override'] || a['Sell Total'] || 0);
+        const tb = Number(b['Final Price'] || b['Price Override'] || b['Sell Total'] || 0);
+        result = ta - tb;
+        break;
+      }
       default:
         result = 0;
     }
     return result * dirMul;
   });
+
+  // Click a column header to sort by it; click the same header again to flip
+  // direction (asc ⇄ desc). A new column always starts ascending.
+  function handleSort(key) {
+    if (sortBy === key) setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
+    else { setSortBy(key); setSortDir('asc'); }
+  }
+
+  // Only blank the list to a skeleton on the FIRST load. A refetch triggered by
+  // changing a server filter keeps the previous rows + header on screen (so an
+  // open date/status popover doesn't get torn down mid-edit) and swaps in fresh
+  // data when the request resolves.
+  const showSkeleton = loading && orders.length === 0;
 
   function daysSince(dateStr) {
     if (!dateStr) return 0;
@@ -524,11 +589,11 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
       )}
 
       {/* Loading */}
-      {!showPremade && loading && <SkeletonTable rows={8} cols={5} />}
+      {!showPremade && showSkeleton && <SkeletonTable rows={8} cols={5} />}
 
       {/* Order list */}
       {/* Results count */}
-      {!showPremade && !loading && (
+      {!showPremade && !showSkeleton && (
         <div className="flex items-center gap-3 px-1">
           <label className="flex items-center gap-1.5 cursor-pointer" onClick={e => e.stopPropagation()}>
             <input
@@ -548,7 +613,7 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
         </div>
       )}
 
-      {!showPremade && !loading && fetchError && (
+      {!showPremade && !showSkeleton && fetchError && (
         <div className="text-center py-12">
           <p className="text-ios-tertiary mb-3">{t.error}</p>
           <button onClick={fetchOrders}
@@ -557,19 +622,19 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
         </div>
       )}
 
-      {!showPremade && !loading && !fetchError && sorted.length === 0 && (
+      {!showPremade && !showSkeleton && !fetchError && sorted.length === 0 && (
         <div className="text-center py-12 text-ios-tertiary">{t.noResults}</div>
       )}
 
       {/* Column headers — mirror the collapsed-row flex widths below. Until
           now the order rows had no labels, so users had to guess what each
           column represented. */}
-      {!showPremade && !loading && sorted.length > 0 && (
+      {!showPremade && !showSkeleton && sorted.length > 0 && (
         <div className="px-4 py-2 flex items-center gap-4 text-[10px] font-semibold uppercase tracking-wide text-ios-tertiary">
           <span className="w-4 shrink-0" />
           {/* # — Order ID */}
           <span className="w-10 shrink-0 flex items-center">
-            {t.colOrderId || '#'}
+            <SortHeader label={t.colOrderId || '#'} sortKey="orderId" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
             <ColumnFilterPopover active={!!filter.orderIdQuery} title={t.colOrderId || '#'}>
               <input
                 className="w-full px-2 py-1 rounded-lg bg-gray-50 border border-gray-200 text-xs"
@@ -581,7 +646,7 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
           </span>
           {/* Order date */}
           <span className="w-20 shrink-0 flex items-center">
-            {t.orderDate || 'Order date'}
+            <SortHeader label={t.orderDate || 'Order date'} sortKey="orderDate" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
             <ColumnFilterPopover active={!!(filter.orderDateFrom || filter.orderDateTo)} title={t.orderDate || 'Order date'}>
               <div className="space-y-1.5 min-w-[160px]">
                 <div>
@@ -597,7 +662,7 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
           </span>
           {/* Customer */}
           <span className="w-36 flex items-center">
-            {t.colCustomer || t.customer || 'Customer'}
+            <SortHeader label={t.colCustomer || t.customer || 'Customer'} sortKey="customer" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
             <ColumnFilterPopover active={!!filter.customerQuery} title={t.colCustomer || t.customer || 'Customer'}>
               <input
                 className="w-full px-2 py-1 rounded-lg bg-gray-50 border border-gray-200 text-xs"
@@ -609,7 +674,7 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
           </span>
           {/* Bouquet */}
           <span className="flex-1 flex items-center">
-            {t.colBouquet || t.bouquetComposition || 'Bouquet'}
+            <SortHeader label={t.colBouquet || t.bouquetComposition || 'Bouquet'} sortKey="bouquet" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
             <ColumnFilterPopover active={!!filter.bouquetQuery} title={t.colBouquet || t.bouquetComposition || 'Bouquet'}>
               <input
                 className="w-full px-2 py-1 rounded-lg bg-gray-50 border border-gray-200 text-xs"
@@ -621,10 +686,11 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
           </span>
           {/* Status (bundled: status + payment status + payment method + source) */}
           <span className="shrink-0 w-20 text-right flex items-center justify-end">
-            {t.labelStatus}
+            <SortHeader label={t.labelStatus} sortKey="status" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
             <ColumnFilterPopover
               active={!!(filter.status || filter.paymentStatus || filter.paymentMethod || filter.source)}
               title={t.labelStatus}
+              align="right"
             >
               <div className="space-y-3 min-w-[200px]">
                 {/* Status */}
@@ -689,7 +755,7 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
           </span>
           {/* Type — split from Fulfilment (w-12 matches body cell) */}
           <span className="shrink-0 w-12 flex items-center">
-            {t.deliveryType}
+            <SortHeader label={t.deliveryType} sortKey="type" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
             <ColumnFilterPopover active={!!filter.deliveryType} title={t.deliveryType}>
               <div className="flex gap-1 flex-wrap">
                 {[['', t.allStatuses], ['Delivery', t.delivery || 'Delivery'], ['Pickup', t.pickup || 'Pickup']].map(([v, label]) => (
@@ -714,8 +780,8 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
               since those are always set — comparing to "set at all" would keep
               the dot permanently lit and stop signalling "filtered here". */}
           <span className="shrink-0 w-24 text-right flex items-center justify-end">
-            {t.colFulfillment}
-            <ColumnFilterPopover active={filter.requiredByFrom !== monthStart() || filter.requiredByTo !== todayStr()} title={t.byFulfilmentDate}>
+            <SortHeader label={t.colFulfillment} sortKey="deliveryDate" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
+            <ColumnFilterPopover active={filter.requiredByFrom !== monthStart() || filter.requiredByTo !== todayStr()} title={t.byFulfilmentDate} align="right">
               <div className="space-y-1.5 min-w-[160px]">
                 <div>
                   <p className="text-[10px] text-ios-tertiary mb-0.5">{t.dateFrom}</p>
@@ -731,8 +797,8 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
           <span className="shrink-0 w-2" />{/* margin dot column */}
           {/* Total */}
           <span className="shrink-0 w-20 text-right flex items-center justify-end">
-            {t.orderTotal || t.total || 'Total'}
-            <ColumnFilterPopover active={filter.priceMin != null || filter.priceMax != null} title={t.orderTotal || 'Total'}>
+            <SortHeader label={t.orderTotal || t.total || 'Total'} sortKey="total" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
+            <ColumnFilterPopover active={filter.priceMin != null || filter.priceMax != null} title={t.orderTotal || 'Total'} align="right">
               <div className="space-y-1.5">
                 <div className="flex items-center gap-1.5">
                   <label className="text-[10px] text-ios-tertiary w-6 shrink-0">{t.filterMin}</label>
@@ -762,7 +828,7 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
         </div>
       )}
 
-      {!showPremade && !loading && sorted.map(order => {
+      {!showPremade && !showSkeleton && sorted.map(order => {
         const isExpanded = expandedId === order.id;
         const days = daysSince(order['Order Date']);
         const isOverdue = unpaidOnly && days > 7;

--- a/apps/dashboard/src/components/order/ColumnFilterPopover.jsx
+++ b/apps/dashboard/src/components/order/ColumnFilterPopover.jsx
@@ -2,7 +2,13 @@ import { useState, useRef, useEffect } from 'react';
 
 // Header-anchored filter popover. The column passes its own control(s) as
 // children; this shell owns only open/close + the active-state affordance.
-export default function ColumnFilterPopover({ active, title, children }) {
+// The trigger is an explicit funnel button (not a bare ▾ glyph) so it reads as
+// "filter this column" and gives a real tap target — header text itself is now
+// the sort control, so the two affordances must be visually distinct.
+// `align="right"` anchors the panel to the button's right edge — use it on
+// right-aligned columns (Status / Total / Fulfilment) so the panel doesn't
+// spill past the viewport edge.
+export default function ColumnFilterPopover({ active, title, align = 'left', children }) {
   const [open, setOpen] = useState(false);
   const ref = useRef(null);
 
@@ -18,16 +24,26 @@ export default function ColumnFilterPopover({ active, title, children }) {
       <button
         type="button"
         onClick={() => setOpen(o => !o)}
-        className={`ml-0.5 text-[10px] leading-none px-0.5 rounded transition-colors ${
-          active ? 'text-brand-600' : 'text-ios-tertiary hover:text-ios-secondary'
+        className={`relative ml-1 inline-flex items-center justify-center w-5 h-5 rounded-md border transition-colors ${
+          active
+            ? 'bg-brand-50 border-brand-300 text-brand-600'
+            : 'border-transparent text-ios-tertiary hover:bg-gray-100 hover:text-ios-secondary'
         }`}
         title={title}
+        aria-label={title}
       >
-        ▾{active ? <span className="ml-0.5 inline-block w-1 h-1 rounded-full bg-brand-600 align-middle" /> : null}
+        {/* Funnel / filter icon */}
+        <svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor"
+          strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M22 3H2l8 9.46V19l4 2v-8.54L22 3z" />
+        </svg>
+        {active && <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-brand-600" />}
       </button>
       {open && (
-        <div className="absolute left-0 top-5 z-30 min-w-[180px] bg-white rounded-xl shadow-2xl border border-gray-200 p-3 space-y-2">
-          {title && <p className="text-[11px] font-semibold text-ios-tertiary uppercase tracking-wide">{title}</p>}
+        <div className={`absolute top-6 z-30 min-w-[180px] bg-white rounded-xl shadow-2xl border border-gray-200 p-3 space-y-2 ${
+          align === 'right' ? 'right-0' : 'left-0'
+        }`}>
+          {title && <p className="text-[11px] font-semibold text-ios-tertiary tracking-wide">{title}</p>}
           {children}
         </div>
       )}

--- a/apps/dashboard/src/translations.js
+++ b/apps/dashboard/src/translations.js
@@ -101,6 +101,10 @@ const en = {
   sortByDelivery:   'Sort: Delivery date',
   sortByType:       'Sort: Type',
   sortByOrderDate:  'Sort: Order date',
+  sortByOrderId:    'Sort: Order #',
+  sortByCustomer:   'Sort: Customer',
+  sortByBouquet:    'Sort: Bouquet',
+  sortByTotal:      'Sort: Total',
 
   // Stock tab
   stockName:        'Name',
@@ -1218,6 +1222,10 @@ const ru = {
   sortByDelivery:   'Сорт: Дата доставки',
   sortByType:       'Сорт: Тип',
   sortByOrderDate:  'Сорт: Дата заказа',
+  sortByOrderId:    'Сорт: № заказа',
+  sortByCustomer:   'Сорт: Клиент',
+  sortByBouquet:    'Сорт: Букет',
+  sortByTotal:      'Сорт: Сумма',
 
   // Stock tab
   stockName:        'Название',

--- a/apps/florist/src/pages/OrderListPage.jsx
+++ b/apps/florist/src/pages/OrderListPage.jsx
@@ -127,6 +127,18 @@ export default function OrderListPage() {
   // Track whether we've done the initial load (show spinner only on first load)
   const initialLoaded = useRef(false);
 
+  // Only the server-supported filter fields drive a refetch. Client-only fields
+  // (customerQuery / bouquetQuery / price) are applied in memory in the render
+  // via orderMatchesClientFilter, so typing in the filter drawer must NOT
+  // trigger a network fetch — otherwise the list flashes to the skeleton on
+  // every keystroke. Keep this dep list in sync with the server fields that
+  // buildOrderQueryParams reads.
+  const baseParams = useMemo(() => buildOrderQueryParams(filter), [
+    filter.status, filter.source, filter.deliveryType, filter.paymentStatus,
+    filter.paymentMethod, filter.excludeCancelled,
+    filter.orderDateFrom, filter.orderDateTo, filter.requiredByFrom, filter.requiredByTo,
+  ]);
+
   const fetchOrders = useCallback(async (silent = false) => {
     if (!silent) setLoading(true);
     try {
@@ -141,7 +153,7 @@ export default function OrderListPage() {
 
       // Merge shared filter params with view-mode params.
       // buildOrderQueryParams handles status/type/date/price; view flags override the set.
-      const params = { ...buildOrderQueryParams(filter) };
+      const params = { ...baseParams };
       if (status) params.status = status; // status tab overrides drawer status
 
       if (viewMode === VIEW_MODES.ACTIVE) {
@@ -175,7 +187,7 @@ export default function OrderListPage() {
     } finally {
       setLoading(false);
     }
-  }, [viewMode, date, status, filter]);
+  }, [viewMode, date, status, baseParams]);
 
   // Stable identities so React.memo inside OrderCard can skip re-renders.
   // Using the functional setter form means the callbacks never close over


### PR DESCRIPTION
Follow-up refinements to the dashboard Orders per-field filtering (#440), from owner feedback in live testing.

## What changed
1. **Bug fix — column search lost focus after one letter.** The fetch effect keyed off the entire `filter` object, so typing in a *client-only* field (#/customer/bouquet search, price range) triggered a network refetch and flipped `loading`, which unmounted the header inputs mid-keystroke and slammed the popover shut. You couldn't type a full name. Server params are now memoized over only the server-supported fields (`queryParams`); client text/price filters apply in memory — no round-trip, no focus loss. **Mirrored in the florist app** (`OrderListPage` `baseParams` memo) so drawer typing no longer flashes the list to a skeleton on every keystroke.

2. **Click a column header to sort** (ascending ⇄ descending on repeat click), like a normal data table. New `SortHeader` label-button with a brand-coloured ▲/▼ on the active column and a faint ⇅ on hover for idle sortable columns. Sort engine extended with order # / customer / bouquet / total; the existing top-bar sort dropdown stays a superset and shares state.

3. **Clearer per-column filter button.** Replaced the easy-to-miss `▾` glyph with an explicit **funnel** button — a real tap target, filled + dotted when active. `ColumnFilterPopover` gains an `align` prop so right-aligned columns (Status / Type / Fulfilment / Total) anchor their panel to the right edge instead of spilling past the viewport.

Bonus: a refetch triggered by a *server* filter no longer blanks the list to a skeleton — it keeps the current rows and any open date/status popover on screen until fresh data lands (so you can set a date From→To without the popover closing after the first pick).

## Scope
- Dashboard `OrdersTab.jsx`, `order/ColumnFilterPopover.jsx`, `translations.js` (+4 RU/EN sort labels)
- Florist `OrderListPage.jsx` (focus/refetch fix only — the drawer already stays mounted)
- No backend, no `packages/shared`, no schema. `GET /orders` already supported every server param.

## Verification
- `vite build` green for **dashboard** and **florist**.
- Full **Playwright browser smoke** on the harness (8 seeded varied orders):
  - Typed all 9 letters of "Kawiarnia" into the Customer column filter — input kept focus, list narrowed live (the reported bug).
  - Header sort: Customer asc → desc, Total ascending numeric (60→635 zł).
  - Status funnel → Payment "Unpaid": popover **stayed open** across the refetch, list filtered to the 4 unpaid orders.
  - Right-aligned Total popover measured fully within the 1440px viewport (no clipping).
  - Price client filter (`min 300`) kept focus + narrowed to 3 rows.
  - Funnel buttons clearly visible with active (pink + dot) state; RU strings render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)