### PR TITLE
feat(orders): header formatting polish + selection totals bar

### DIFF
--- a/apps/dashboard/src/components/OrdersTab.jsx
+++ b/apps/dashboard/src/components/OrdersTab.jsx
@@ -65,24 +65,27 @@ function getSortOptions() {
 }
 
 // Clickable column-header label that drives the table sort. The header text is
-// the sort control (click to sort, click again to flip direction); the funnel
-// button beside it opens the column's filter popover — two distinct affordances.
-// Idle sortable columns reveal a faint ⇅ on hover; the active column shows a
-// brand-coloured ▲ / ▼.
+// the sort control (click to sort, click again to flip direction); the filter
+// chip beside it opens the column's filter popover — two distinct affordances.
+// A faint ↕ sits next to every sortable label so the column reads as sortable
+// at rest (and is visually distinct from the filter chip's bars icon); the
+// active column shows a brand-coloured ▲ / ▼.
 function SortHeader({ label, sortKey, sortBy, sortDir, onSort }) {
   const active = sortBy === sortKey;
   return (
     <button
       type="button"
       onClick={() => onSort(sortKey)}
-      className="group inline-flex items-center gap-0.5 hover:text-ios-secondary transition-colors"
+      className={`group inline-flex items-center gap-1 whitespace-nowrap transition-colors ${
+        active ? 'text-brand-600' : 'hover:text-ios-secondary'
+      }`}
       title={`${t.sortBy}: ${label}`}
     >
-      <span className={active ? 'text-brand-600' : ''}>{label}</span>
+      <span>{label}</span>
       <span className={`text-[9px] leading-none ${
-        active ? 'text-brand-600' : 'text-ios-tertiary opacity-0 group-hover:opacity-100'
+        active ? 'text-brand-600' : 'text-gray-300 group-hover:text-gray-400'
       }`}>
-        {active ? (sortDir === 'asc' ? '▲' : '▼') : '⇅'}
+        {active ? (sortDir === 'asc' ? '▲' : '▼') : '↕'}
       </span>
     </button>
   );
@@ -630,10 +633,10 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
           now the order rows had no labels, so users had to guess what each
           column represented. */}
       {!showPremade && !showSkeleton && sorted.length > 0 && (
-        <div className="px-4 py-2 flex items-center gap-4 text-[10px] font-semibold uppercase tracking-wide text-ios-tertiary">
+        <div className="px-4 py-2 flex items-center gap-4 text-[11.5px] font-semibold uppercase tracking-wide text-ios-tertiary">
           <span className="w-4 shrink-0" />
           {/* # — Order ID */}
-          <span className="w-10 shrink-0 flex items-center">
+          <span className="group w-10 shrink-0 flex items-center">
             <SortHeader label={t.colOrderId || '#'} sortKey="orderId" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
             <ColumnFilterPopover active={!!filter.orderIdQuery} title={t.colOrderId || '#'}>
               <input
@@ -645,7 +648,7 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
             </ColumnFilterPopover>
           </span>
           {/* Order date */}
-          <span className="w-20 shrink-0 flex items-center">
+          <span className="group w-20 shrink-0 flex items-center">
             <SortHeader label={t.orderDate || 'Order date'} sortKey="orderDate" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
             <ColumnFilterPopover active={!!(filter.orderDateFrom || filter.orderDateTo)} title={t.orderDate || 'Order date'}>
               <div className="space-y-1.5 min-w-[160px]">
@@ -661,7 +664,7 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
             </ColumnFilterPopover>
           </span>
           {/* Customer */}
-          <span className="w-36 flex items-center">
+          <span className="group w-36 flex items-center">
             <SortHeader label={t.colCustomer || t.customer || 'Customer'} sortKey="customer" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
             <ColumnFilterPopover active={!!filter.customerQuery} title={t.colCustomer || t.customer || 'Customer'}>
               <input
@@ -673,7 +676,7 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
             </ColumnFilterPopover>
           </span>
           {/* Bouquet */}
-          <span className="flex-1 flex items-center">
+          <span className="group flex-1 flex items-center">
             <SortHeader label={t.colBouquet || t.bouquetComposition || 'Bouquet'} sortKey="bouquet" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
             <ColumnFilterPopover active={!!filter.bouquetQuery} title={t.colBouquet || t.bouquetComposition || 'Bouquet'}>
               <input
@@ -685,7 +688,7 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
             </ColumnFilterPopover>
           </span>
           {/* Status (bundled: status + payment status + payment method + source) */}
-          <span className="shrink-0 w-20 text-right flex items-center justify-end">
+          <span className="group shrink-0 w-20 text-right flex items-center justify-end">
             <SortHeader label={t.labelStatus} sortKey="status" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
             <ColumnFilterPopover
               active={!!(filter.status || filter.paymentStatus || filter.paymentMethod || filter.source)}
@@ -754,7 +757,7 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
             </ColumnFilterPopover>
           </span>
           {/* Type — split from Fulfilment (w-12 matches body cell) */}
-          <span className="shrink-0 w-12 flex items-center">
+          <span className="group shrink-0 w-12 flex items-center">
             <SortHeader label={t.deliveryType} sortKey="type" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
             <ColumnFilterPopover active={!!filter.deliveryType} title={t.deliveryType}>
               <div className="flex gap-1 flex-wrap">
@@ -779,7 +782,7 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
               Active compares against the initial defaults (monthStart/today)
               since those are always set — comparing to "set at all" would keep
               the dot permanently lit and stop signalling "filtered here". */}
-          <span className="shrink-0 w-24 text-right flex items-center justify-end">
+          <span className="group shrink-0 w-24 text-right flex items-center justify-end">
             <SortHeader label={t.colFulfillment} sortKey="deliveryDate" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
             <ColumnFilterPopover active={filter.requiredByFrom !== monthStart() || filter.requiredByTo !== todayStr()} title={t.byFulfilmentDate} align="right">
               <div className="space-y-1.5 min-w-[160px]">
@@ -796,7 +799,7 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
           </span>
           <span className="shrink-0 w-2" />{/* margin dot column */}
           {/* Total */}
-          <span className="shrink-0 w-20 text-right flex items-center justify-end">
+          <span className="group shrink-0 w-20 text-right flex items-center justify-end">
             <SortHeader label={t.orderTotal || t.total || 'Total'} sortKey="total" sortBy={sortBy} sortDir={sortDir} onSort={handleSort} />
             <ColumnFilterPopover active={filter.priceMin != null || filter.priceMax != null} title={t.orderTotal || 'Total'} align="right">
               <div className="space-y-1.5">

--- a/apps/dashboard/src/components/OrdersTab.jsx
+++ b/apps/dashboard/src/components/OrdersTab.jsx
@@ -91,6 +91,20 @@ function SortHeader({ label, sortKey, sortBy, sortDir, onSort }) {
   );
 }
 
+// One labelled figure in the selection-totals strip (label over a bold value,
+// with an optional muted suffix like the margin %).
+function SelStat({ label, value, sub = null, valueClass = 'text-ios-label' }) {
+  return (
+    <div className="flex flex-col leading-tight">
+      <span className="text-[10px] font-medium uppercase tracking-wide text-ios-tertiary">{label}</span>
+      <span className={`text-sm font-semibold ${valueClass}`}>
+        {value}
+        {sub != null && <span className="ml-1 text-[11px] font-medium text-ios-tertiary">{sub}</span>}
+      </span>
+    </div>
+  );
+}
+
 function todayStr() {
   return new Date().toISOString().split('T')[0];
 }
@@ -298,6 +312,35 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
   // open date/status popover doesn't get torn down mid-edit) and swaps in fresh
   // data when the request resolves.
   const showSkeleton = loading && orders.length === 0;
+
+  // Totals for the orders the owner has ticked — answers "how much did this
+  // selection earn". Tick select-all after filtering by a date range to total a
+  // whole period. Paid is status-aware (Paid = full value, Partial = recorded
+  // payments, Unpaid = 0) so it matches the per-row money display. Sums the
+  // selected orders out of the full fetched set so a later filter change doesn't
+  // silently drop a ticked order from the total.
+  const selectionTotals = useMemo(() => {
+    const sel = orders.filter(o => selected.has(o.id));
+    let sales = 0, cost = 0, paid = 0;
+    for (const o of sel) {
+      const total = Number(o['Final Price'] || o['Price Override'] || o['Sell Total'] || 0);
+      sales += total;
+      cost += Number(o['Flowers Cost Total'] || 0);
+      if (o['Payment Status'] === 'Paid') paid += total;
+      else if (o['Payment Status'] === 'Partial') paid += Number(o['Payment 1 Amount'] || 0) + Number(o['Payment 2 Amount'] || 0);
+    }
+    const profit = sales - cost;
+    return {
+      count: sel.length,
+      sales,
+      paid,
+      outstanding: Math.max(0, sales - paid),
+      profit,
+      margin: sales > 0 ? (profit / sales) * 100 : null,
+      avg: sel.length ? sales / sel.length : 0,
+      hasCost: cost > 0,
+    };
+  }, [orders, selected]);
 
   function daysSince(dateStr) {
     if (!dateStr) return 0;
@@ -613,6 +656,32 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
             className="ml-auto text-xs text-ios-secondary hover:text-brand-600 transition-colors"
             title={t.refresh}
           >↻ {t.refresh}</button>
+        </div>
+      )}
+
+      {/* Selection totals — appears when the owner ticks orders. Filter by a
+          date range, tick select-all, and read the period's takings here. */}
+      {!showPremade && !showSkeleton && selected.size > 0 && (
+        <div className="glass-card px-4 py-2.5 flex flex-wrap items-center gap-x-6 gap-y-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-brand-600">
+            {selectionTotals.count} {t.selected}
+          </span>
+          <SelStat label={t.totalsSales} value={`${selectionTotals.sales.toFixed(0)} ${t.zl}`} />
+          <SelStat label={t.totalsPaid} value={`${selectionTotals.paid.toFixed(0)} ${t.zl}`} valueClass="text-emerald-600" />
+          <SelStat
+            label={t.totalsOutstanding}
+            value={`${selectionTotals.outstanding.toFixed(0)} ${t.zl}`}
+            valueClass={selectionTotals.outstanding > 0 ? 'text-ios-red' : 'text-ios-label'}
+          />
+          {selectionTotals.hasCost && (
+            <SelStat
+              label={t.totalsProfit}
+              value={`${selectionTotals.profit.toFixed(0)} ${t.zl}`}
+              sub={selectionTotals.margin != null ? `${selectionTotals.margin.toFixed(0)}%` : null}
+              valueClass={selectionTotals.profit >= 0 ? 'text-ios-label' : 'text-ios-red'}
+            />
+          )}
+          <SelStat label={t.totalsAvg} value={`${selectionTotals.avg.toFixed(0)} ${t.zl}`} />
         </div>
       )}
 

--- a/apps/dashboard/src/components/order/ColumnFilterPopover.jsx
+++ b/apps/dashboard/src/components/order/ColumnFilterPopover.jsx
@@ -2,9 +2,13 @@ import { useState, useRef, useEffect } from 'react';
 
 // Header-anchored filter popover. The column passes its own control(s) as
 // children; this shell owns only open/close + the active-state affordance.
-// The trigger is an explicit funnel button (not a bare ▾ glyph) so it reads as
-// "filter this column" and gives a real tap target — header text itself is now
-// the sort control, so the two affordances must be visually distinct.
+// The trigger is a defined chip-button carrying the universal "filter"
+// (decreasing-bars) icon — deliberately NOT a triangle/caret, so it can never be
+// mistaken for the sort arrow on the header label. To keep the header clean it
+// stays hidden at rest and reveals on column hover (the parent header cell owns
+// the `group`); it stays visible whenever that column is actively filtered or
+// its popover is open. Space is reserved (opacity, not display) so the label
+// never shifts when the chip appears.
 // `align="right"` anchors the panel to the button's right edge — use it on
 // right-aligned columns (Status / Total / Fulfilment) so the panel doesn't
 // spill past the viewport edge.
@@ -19,25 +23,31 @@ export default function ColumnFilterPopover({ active, title, align = 'left', chi
     return () => document.removeEventListener('mousedown', onClick);
   }, [open]);
 
+  const pinned = active || open; // always-visible states
+
   return (
     <span ref={ref} className="relative inline-flex">
       <button
         type="button"
         onClick={() => setOpen(o => !o)}
-        className={`relative ml-1 inline-flex items-center justify-center w-5 h-5 rounded-md border transition-colors ${
+        className={`relative ml-1.5 inline-flex items-center justify-center w-5 h-5 rounded-md border transition-all ${
+          pinned ? 'opacity-100' : 'opacity-0 group-hover:opacity-100 focus-visible:opacity-100'
+        } ${
           active
             ? 'bg-brand-50 border-brand-300 text-brand-600'
-            : 'border-transparent text-ios-tertiary hover:bg-gray-100 hover:text-ios-secondary'
+            : 'bg-gray-50 border-gray-200 text-gray-400 hover:bg-gray-100 hover:text-gray-600'
         }`}
         title={title}
         aria-label={title}
       >
-        {/* Funnel / filter icon */}
-        <svg viewBox="0 0 24 24" width="11" height="11" fill="none" stroke="currentColor"
-          strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <path d="M22 3H2l8 9.46V19l4 2v-8.54L22 3z" />
+        {/* Filter icon (decreasing horizontal bars) — never reads as a sort caret */}
+        <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor"
+          strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+          <line x1="3" y1="7" x2="21" y2="7" />
+          <line x1="6.5" y1="12" x2="17.5" y2="12" />
+          <line x1="10" y1="17" x2="14" y2="17" />
         </svg>
-        {active && <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-brand-600" />}
+        {active && <span className="absolute -top-1 -right-1 w-1.5 h-1.5 rounded-full bg-brand-600 ring-2 ring-white" />}
       </button>
       {open && (
         <div className={`absolute top-6 z-30 min-w-[180px] bg-white rounded-xl shadow-2xl border border-gray-200 p-3 space-y-2 ${

--- a/apps/dashboard/src/translations.js
+++ b/apps/dashboard/src/translations.js
@@ -105,6 +105,11 @@ const en = {
   sortByCustomer:   'Sort: Customer',
   sortByBouquet:    'Sort: Bouquet',
   sortByTotal:      'Sort: Total',
+  totalsSales:      'Sales',
+  totalsPaid:       'Paid',
+  totalsOutstanding:'Outstanding',
+  totalsProfit:     'Profit',
+  totalsAvg:        'Avg order',
 
   // Stock tab
   stockName:        'Name',
@@ -1226,6 +1231,11 @@ const ru = {
   sortByCustomer:   'Сорт: Клиент',
   sortByBouquet:    'Сорт: Букет',
   sortByTotal:      'Сорт: Сумма',
+  totalsSales:      'Продажи',
+  totalsPaid:       'Оплачено',
+  totalsOutstanding:'Остаток',
+  totalsProfit:     'Прибыль',
+  totalsAvg:        'Средний чек',
 
   // Stock tab
   stockName:        'Название',


### PR DESCRIPTION
Two owner-requested Orders-tab improvements from the same session, on one branch (both touch `OrdersTab.jsx`, so kept together to avoid a conflict with #442).

## 1 — Header formatting polish
Feedback on the header shipped in #442: cramped, weak hierarchy, the filter glyph (`▽`) read like a sort arrow.
- **Filter trigger** is now a defined chip-button with the universal **filter (decreasing-bars) icon** — can't be mistaken for a caret. **Hidden at rest, reveals on column hover**; stays visible while that column is actively filtered or its popover is open (space reserved via opacity, so labels don't shift).
- **Sort affordance** is a persistent faint `↕` next to every sortable label, turning brand `▲/▼` on the active column.
- Labels no longer wrap; header font 10px → 11.5px.

## 2 — Selection totals bar
Tick a set of orders (e.g. select-all after filtering to a date range) → a totals strip appears above the list summing the **ticked** orders:
- **Sales** — sum of order value
- **Paid** — status-aware (Paid = full, Partial = recorded payments, Unpaid = 0)
- **Outstanding** — sales − paid
- **Profit + margin %** — sales − flower cost; hidden when no selected order carries cost
- **Avg order** — sales ÷ count

Sums out of the full fetched set, so a later filter change doesn't drop a ticked order from the total.

## Scope
Dashboard `OrdersTab.jsx` + `order/ColumnFilterPopover.jsx` + `translations.js` (RU/EN). No behavior/data/backend/shared change. Florist untouched (its filters are a bottom-sheet drawer; its list has no multi-select).

## Verification
- `vite build` green (dashboard).
- Playwright on the harness: filter chips `opacity 0` at rest, hover raises only that column's chip; select-all on 8 seeded orders shows Sales 2265 / Paid 1430 / Outstanding 835 / Avg 283 zł (arithmetic confirmed); 0 console errors.

Best reviewed on the **Vercel preview** — purely visual + a read-only summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)