### PR TITLE
fix(analytics): net flower revenue so total = flowers + delivery reconciles

### DIFF
--- a/backend/src/__tests__/analyticsRevenueReconcile.test.js
+++ b/backend/src/__tests__/analyticsRevenueReconcile.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { calculateRevenueMetrics } from '../services/analyticsService.js';
+
+// Repro for the prod revenue mismatch: total (net charged) < flowers (gross list)
+// when orders carry a Price Override / Final Price discount. The invariant the
+// owner expects: total === flowers + delivery.
+function order({ id, flowerSell, deliveryFee = 0, override, finalPrice }) {
+  const effective = finalPrice ?? ((override ?? flowerSell) + deliveryFee);
+  return { id, _flowerSell: flowerSell, _deliveryFee: deliveryFee, _cost: 0, 'Effective Price': effective };
+}
+
+describe('computeAnalytics revenue reconciliation', () => {
+  it('total must equal flowers + delivery, even with discounts/overrides', () => {
+    const orders = [
+      order({ id: 'a', flowerSell: 100, deliveryFee: 20 }),               // plain: charged 120
+      order({ id: 'b', flowerSell: 200, override: 150 }),                 // discounted to 150
+      order({ id: 'c', flowerSell: 300, deliveryFee: 30, finalPrice: 250 }), // final price 250 (incl delivery)
+    ];
+    const r = calculateRevenueMetrics(orders, orders, 2.2);
+    // total = 120 + 150 + 250 = 520
+    expect(r.totalRevenue).toBe(520);
+    // delivery = 20 + 0 + 30 = 50
+    expect(r.deliveryRevenue).toBe(50);
+    // THE INVARIANT: flowers must be the net flower portion so it reconciles.
+    expect(r.totalRevenue).toBe(r.flowerRevenue + r.deliveryRevenue);
+    expect(r.flowerRevenue).toBe(470); // 520 - 50
+  });
+});

--- a/backend/src/__tests__/analyticsService.test.js
+++ b/backend/src/__tests__/analyticsService.test.js
@@ -73,7 +73,7 @@ describe('calculateRevenueMetrics', () => {
     const result = calculateRevenueMetrics(orders, paidOrders, 2.2);
 
     expect(result.totalRevenue).toBe(370); // 135 + 235
-    expect(result.flowerRevenue).toBe(300); // 100 + 200
+    expect(result.flowerRevenue).toBe(300); // net = total 370 − delivery 70 (no discounts here)
     expect(result.deliveryRevenue).toBe(70); // 35 + 35
     expect(result.avgOrderValue).toBe(185); // 370 / 2
     expect(result.paidFlowerCost).toBe(120); // 40 + 80

--- a/backend/src/services/analyticsService.js
+++ b/backend/src/services/analyticsService.js
@@ -238,8 +238,13 @@ export function enrichOrderPrices(orders, orderSellTotals, orderCostTotals, deli
  */
 export function calculateRevenueMetrics(orders, paidOrders, targetMarkup) {
   const totalRevenue = paidOrders.reduce((sum, o) => sum + (o['Effective Price'] || 0), 0);
-  const flowerRevenue = paidOrders.reduce((sum, o) => sum + o._flowerSell, 0);
   const deliveryRevenue = paidOrders.reduce((sum, o) => sum + o._deliveryFee, 0);
+  // Net flower revenue = what was actually charged for flowers, after Price
+  // Override / Final Price discounts. Defined as total − delivery so the figures
+  // always reconcile (total = flowers + delivery) and Flower Margin reflects the
+  // realized margin, not catalog list price. Prior bug: summed gross `_flowerSell`
+  // (catalog list), which made flowers > total on discounted orders (#prod revenue mismatch).
+  const flowerRevenue = totalRevenue - deliveryRevenue;
   const avgOrderValue = paidOrders.length ? totalRevenue / paidOrders.length : 0;
 
   const paidFlowerCost = paidOrders.reduce((sum, o) => sum + o._cost, 0);


### PR DESCRIPTION
## Bug
On prod, the assistant (and the dashboard's `/api/analytics`) showed **Total Revenue (16 853 zł) < Flower Revenue (17 506,50 zł)** for May 2026, and `total ≠ flowers + delivery` (1 050). Numbers didn't reconcile.

## Root cause
`analyticsService.calculateRevenueMetrics`:
- `totalRevenue` = Σ **Effective Price** — net of `Price Override` / `Final Price` discounts (what was actually charged).
- `flowerRevenue` = Σ `_flowerSell` — **gross flower lines at catalog list price**, ignoring discounts.

On discounted orders, gross flowers exceed net total → `total < flowers`. The gap (1 703,50 zł in May) is discount/override leakage on flower lines.

## Fix (owner-chosen definition)
`flowerRevenue = totalRevenue − deliveryRevenue` — the **net** flower revenue actually charged. Now `total = flowers + delivery` holds by construction, and `flowerMargin` reflects the **realized** margin (lower than the prior catalog-list margin, because discounts now count). One source (`computeAnalytics`) feeds both the dashboard and the assistant, so they're corrected together.

For May 2026: flowers 15 803 + delivery 1 050 = total 16 853. ✓

## Verification
- New regression test `analyticsRevenueReconcile.test.js` asserts `total === flowers + delivery` under discounts/overrides/final-price (reproduced the bug first, red→green).
- `analyticsService.test.js` + `financePack` parity test still green (existing case had no discounts, so net == gross there).
- Full backend suite green (one unrelated stock-auth test flaked on a 10s timeout under load; passes 12/12 in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Q85Nscp6hSQzw5ddLAs6w