### PR TITLE
fix(stock): Y-model cutover migration handles soft-deleted rows (#291 Phase-5 blocker)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ Review this entire file before flipping to production.
 
 ---
 
+## 2026-06-29 — Y-model cutover migration: fix Phase-5 failure on soft-deleted rows (#291 blocker)
+
+Pre-cutover dry-run prep against a prod read surfaced a defect in the cutover migration that would have made the live run **fail**. Fixed + regression-locked. No app/schema/env change — this only touches the standalone cutover script.
+
+### Backend (`backend/scripts/migrate-stock-y-model.js`)
+- **Defect:** Phase 5 runs `ALTER COLUMN date / type_name SET NOT NULL`, which validates **every physical row, including soft-deleted ones**. Phases 1-3 only date `deleted_at IS NULL` rows and the #292 backfill UI only types active rows, so soft-deleted undated/untyped tombstone rows (qty 0) make Phase 5 fail. On prod today: **150 soft-deleted rows are undated, 149 untyped** (the synthetic lab scenario has none, so it never caught this).
+- **Fix:** new `phaseDeletedFill` (phase 4b) back-fills `date = COALESCE(date, today)` and `type_name = COALESCE(type_name, first-word-of-display_name, 'Unknown')` on soft-deleted rows before phase 5. **Fills, never DELETEs** — `stock_purchases` / `stock_order_lines` / `premade_bouquet_lines` FK-reference `stock(id)` with default `RESTRICT`, so a purge would violate FKs. Active-row logic (phases 1-4 + the type_name pre-condition) is unchanged.
+- **Testability refactor:** script now exports `runMigration(client, {dryRun, today})` + each phase; CLI side-effects (`APPROVE=yes` guard, pool, `process.exit`) are gated behind `main()` so the module is import-safe. The pre-condition message now says "active" rows explicitly.
+
+### Tests
+- New `backend/src/__tests__/migrateStockYModel.integration.test.js` (pglite, 4 tests): regression — Phase 5 succeeds with a soft-deleted undated/untyped zombie present (no NULLs remain, tombstone keeps `deleted_at`, NOT NULL applied); pre-condition aborts on an active untyped row; `--dry-run` rolls back (NOT NULL not applied); idempotent no-op on re-run.
+
+### Cutover status (#291) — still blocked, now by data + infra only
+- **Gate 1 (data):** 23 active stock rows still have `type_name IS NULL` — run the #292 backfill UI before the live migration.
+- **Gate 2 (code):** ✅ this change.
+- **Gate 3 (infra):** prod is PG 18.3, lab harness is PG 15 + no local `pg_dump` — bump the lab container to PG 18 to run the dry-run against a real prod snapshot.
+- Verification: `migrateStockYModel.integration.test.js` 4/4 ✓ (isolation). E2E N/A — the migration is a standalone CLI script, exercised by no API route.
+
+---
+
 ## 2026-06-29 — Ask Blossom: deliveries / purchasing / hours coverage + florist-app mount
 
 The assistant can now answer about three more domains, and the owner can use it on her phone (florist app), not just the dashboard. No schema/env change — pure additive tool packs + a second mount of the existing panel.

--- a/backend/scripts/migrate-stock-y-model.js
+++ b/backend/scripts/migrate-stock-y-model.js
@@ -4,54 +4,52 @@
 // Migrates production Stock data from legacy aggregate Demand Entry model
 // to Y-model (dated Demand Entries + premade back-add).
 //
-// Pre-condition: All stock rows must have `type_name` set (run Owner
-// backfill UI from issue #292 first).
+// Pre-condition: All ACTIVE stock rows must have `type_name` set (run Owner
+// backfill UI from issue #292 first). Soft-deleted rows are back-filled
+// automatically by phaseDeletedFill (see below).
 //
 // Phases (single transaction):
 //   1. Split aggregate Demand Entries by linked order Required By.
 //   2. Orphan negative aggregates → today-dated Demand Entry.
 //   3. Positive-qty undated rows → synthetic Batch dated migration day.
 //   4. Premade reservation back-add to matching Batch on-hand.
+//   4b. Back-fill date/type_name on SOFT-DELETED rows (phases 1-3 skip
+//       them, but `ALTER ... SET NOT NULL` in phase 5 validates every
+//       physical row — incl. tombstones — so they must be non-NULL too).
+//       We fill, never DELETE: stock_purchases / stock_order_lines /
+//       premade_bouquet_lines FK-reference stock(id) with default RESTRICT.
 //   5. ALTER COLUMN date / type_name SET NOT NULL.
 //
 // Idempotent: re-running after Phase 5 (NOT NULL applied) is a no-op
-// via the early-exit guard `alreadyMigrated()`. Phases 1-3 also become
-// no-ops because their predicates require `date IS NULL`.
+// via the early-exit guard `alreadyMigrated()`. Phases 1-4b also become
+// no-ops because their predicates require `date IS NULL` / NULL attrs.
 //
 // Usage:
 //   APPROVE=yes node backend/scripts/migrate-stock-y-model.js --dry-run
 //   APPROVE=yes node backend/scripts/migrate-stock-y-model.js
 
-import 'dotenv/config';
 import pg from 'pg';
+import { pathToFileURL } from 'url';
 
 const DRY_RUN = process.argv.includes('--dry-run');
 
-if (process.env.APPROVE !== 'yes') {
-  console.error('Set APPROVE=yes to confirm you want to run the Y-model migration.');
-  process.exit(1);
-}
-if (!process.env.DATABASE_URL) {
-  console.error('DATABASE_URL not set. Aborting.');
-  process.exit(1);
+function isoToday() {
+  return new Date().toISOString().slice(0, 10);
 }
 
-const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
-const today = new Date().toISOString().slice(0, 10);
-
-async function preCondition(client) {
+export async function preCondition(client) {
   const { rows } = await client.query(
     `SELECT count(*)::int AS missing FROM stock WHERE type_name IS NULL AND deleted_at IS NULL`
   );
   if (rows[0].missing > 0) {
     throw new Error(
-      `Pre-condition failed: ${rows[0].missing} stock row(s) have type_name IS NULL. ` +
+      `Pre-condition failed: ${rows[0].missing} active stock row(s) have type_name IS NULL. ` +
       `Run the Owner-driven Variety attribute backfill (issue #292) first.`
     );
   }
 }
 
-async function phase1Split(client) {
+export async function phase1Split(client) {
   // Find aggregate DEs: negative qty, no date, linked to at least one active order_line.
   // Phase 1 sums only **active, non-deleted** order_lines (status NOT IN
   //   Cancelled/Delivered/Picked Up). If an aggregate's only linked lines
@@ -128,7 +126,7 @@ async function phase1Split(client) {
   console.log(`[phase1] Split ${aggregates.length} aggregate DE(s).`);
 }
 
-async function phase2OrphanNegative(client, today) {
+export async function phase2OrphanNegative(client, today) {
   const { rows: orphans } = await client.query(`
     SELECT s.id FROM stock s
     WHERE s.current_quantity < 0
@@ -149,7 +147,7 @@ async function phase2OrphanNegative(client, today) {
   console.log(`[phase2] Dated ${orphans.length} orphan aggregate DE(s) → ${today}.`);
 }
 
-async function phase3PositiveUndated(client, today) {
+export async function phase3PositiveUndated(client, today) {
   const { rowCount } = await client.query(`
     UPDATE stock SET date = $1, updated_at = NOW()
     WHERE current_quantity >= 0 AND date IS NULL AND deleted_at IS NULL
@@ -157,13 +155,7 @@ async function phase3PositiveUndated(client, today) {
   console.log(`[phase3] Dated ${rowCount} positive-qty undated row(s) → ${today}.`);
 }
 
-async function phase5SetNotNull(client) {
-  await client.query(`ALTER TABLE stock ALTER COLUMN date SET NOT NULL`);
-  await client.query(`ALTER TABLE stock ALTER COLUMN type_name SET NOT NULL`);
-  console.log('[phase5] Applied NOT NULL on stock.date and stock.type_name.');
-}
-
-async function phase4PremadeBackAdd(client) {
+export async function phase4PremadeBackAdd(client) {
   const { rows: sums } = await client.query(`
     SELECT stock_id, SUM(quantity)::int AS reserved
     FROM premade_bouquet_lines
@@ -181,7 +173,32 @@ async function phase4PremadeBackAdd(client) {
   console.log(`[phase4] Back-added premade reservations to ${sums.length} Batch(es).`);
 }
 
-async function alreadyMigrated(client) {
+// Phase 4b — back-fill soft-deleted (tombstone) rows so phase 5's
+// `SET NOT NULL` validates them. Phases 1-3 deliberately skip
+// `deleted_at IS NOT NULL`, and the #292 backfill UI only types active
+// rows, leaving deleted zombies undated/untyped. type_name falls back to
+// the first word of display_name (e.g. "Hydrangea Pink" → "Hydrangea"),
+// then 'Unknown'. We never DELETE: stock_purchases / stock_order_lines /
+// premade_bouquet_lines reference stock(id) with default RESTRICT.
+export async function phaseDeletedFill(client, today) {
+  const { rowCount } = await client.query(`
+    UPDATE stock
+    SET date = COALESCE(date, $1::date),
+        type_name = COALESCE(type_name, NULLIF(split_part(display_name, ' ', 1), ''), 'Unknown'),
+        updated_at = NOW()
+    WHERE deleted_at IS NOT NULL
+      AND (date IS NULL OR type_name IS NULL)
+  `, [today]);
+  console.log(`[phase4b] Back-filled date/type_name on ${rowCount} soft-deleted row(s) → date ${today}.`);
+}
+
+export async function phase5SetNotNull(client) {
+  await client.query(`ALTER TABLE stock ALTER COLUMN date SET NOT NULL`);
+  await client.query(`ALTER TABLE stock ALTER COLUMN type_name SET NOT NULL`);
+  console.log('[phase5] Applied NOT NULL on stock.date and stock.type_name.');
+}
+
+export async function alreadyMigrated(client) {
   const { rows } = await client.query(`
     SELECT is_nullable FROM information_schema.columns
     WHERE table_name = 'stock' AND column_name = 'date'
@@ -189,33 +206,61 @@ async function alreadyMigrated(client) {
   return rows[0]?.is_nullable === 'NO';
 }
 
-async function run() {
-  const client = await pool.connect();
+/**
+ * Run the full migration against any client exposing `.query(text, params)`
+ * (a pg pool client in production, the pglite handle in tests).
+ * Owns its own BEGIN/COMMIT/ROLLBACK. Throws on failure (CLI wrapper maps
+ * that to a non-zero exit code).
+ * @returns {Promise<{noop?:true, dryRun?:true, committed?:true}>}
+ */
+export async function runMigration(client, { dryRun = false, today = isoToday() } = {}) {
+  await client.query('BEGIN');
   try {
-    await client.query('BEGIN');
     await preCondition(client);
 
     if (await alreadyMigrated(client)) {
       console.log('[migrate] Stock.date already NOT NULL — migration already complete. No-op.');
       await client.query('ROLLBACK');
-      return;
+      return { noop: true };
     }
 
     await phase1Split(client);
     await phase2OrphanNegative(client, today);
     await phase3PositiveUndated(client, today);
     await phase4PremadeBackAdd(client);
+    await phaseDeletedFill(client, today);
     await phase5SetNotNull(client);
 
-    if (DRY_RUN) {
+    if (dryRun) {
       console.log('[migrate] DRY RUN — rolling back transaction.');
       await client.query('ROLLBACK');
-    } else {
-      await client.query('COMMIT');
-      console.log('[migrate] Done.');
+      return { dryRun: true };
     }
+
+    await client.query('COMMIT');
+    console.log('[migrate] Done.');
+    return { committed: true };
   } catch (err) {
     await client.query('ROLLBACK');
+    throw err;
+  }
+}
+
+async function main() {
+  await import('dotenv/config');
+  if (process.env.APPROVE !== 'yes') {
+    console.error('Set APPROVE=yes to confirm you want to run the Y-model migration.');
+    process.exit(1);
+  }
+  if (!process.env.DATABASE_URL) {
+    console.error('DATABASE_URL not set. Aborting.');
+    process.exit(1);
+  }
+  const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+  const client = await pool.connect();
+  try {
+    await runMigration(client, { dryRun: DRY_RUN });
+  } catch (err) {
     console.error('[migrate] FAILED:', err.message);
     process.exitCode = 1;
   } finally {
@@ -224,4 +269,6 @@ async function run() {
   }
 }
 
-run();
+// Only run the CLI side-effects when executed directly, not on import (tests).
+const isCli = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+if (isCli) main();

--- a/backend/src/__tests__/migrateStockYModel.integration.test.js
+++ b/backend/src/__tests__/migrateStockYModel.integration.test.js
@@ -1,0 +1,95 @@
+// Y-model cutover migration — integration test (pglite).
+//
+// Regression lock for the #291 cutover defect found 2026-06-29:
+// Phase 5 (`ALTER COLUMN date/type_name SET NOT NULL`) validates ALL
+// physical rows, including soft-deleted ones. Phases 1-3 only date
+// `deleted_at IS NULL` rows and the human backfill only types active
+// rows, so soft-deleted undated/untyped zombie rows (qty 0) on prod
+// would make Phase 5 FAIL. The fix adds `phaseDeletedFill` before
+// Phase 5 to fill date/type_name on soft-deleted rows (no deletes —
+// FK constraints from stock_purchases/stock_order_lines RESTRICT).
+//
+// We drive the ACTUAL script's exported `runMigration(client, opts)`
+// against the raw pglite handle (same query interface as a pg client).
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import { runMigration } from '../../scripts/migrate-stock-y-model.js';
+
+const TODAY = '2026-06-29';
+
+let harness, pg;
+beforeEach(async () => { harness = await setupPgHarness(); pg = harness.pg; });
+afterEach(async () => { await teardownPgHarness(harness); });
+
+async function ins(client, { name, qty = 0, date = null, type = null, deleted = false }) {
+  const { rows } = await client.query(
+    `INSERT INTO stock (display_name, current_quantity, date, type_name, active, deleted_at)
+     VALUES ($1, $2, $3, $4, true, $5) RETURNING id`,
+    [name, qty, date, type, deleted ? new Date().toISOString() : null]
+  );
+  return rows[0].id;
+}
+
+async function colNullable(client, col) {
+  const { rows } = await client.query(
+    `SELECT is_nullable FROM information_schema.columns
+     WHERE table_name = 'stock' AND column_name = $1`, [col]);
+  return rows[0]?.is_nullable === 'YES';
+}
+
+async function count(client, where) {
+  const { rows } = await client.query(`SELECT count(*)::int n FROM stock WHERE ${where}`);
+  return rows[0].n;
+}
+
+describe('migrate-stock-y-model (pglite)', () => {
+  it('fills NULLs on soft-deleted rows so Phase 5 SET NOT NULL succeeds (regression #291)', async () => {
+    // active undated positive — Phase 3 dates it to today
+    await ins(pg, { name: 'Rose Red', qty: 10, type: 'Rose' });
+    // soft-deleted, undated, untyped zombie (the prod state that broke Phase 5)
+    await ins(pg, { name: 'Hydrangea Pink', qty: 0, type: null, deleted: true });
+
+    await runMigration(pg, { today: TODAY }); // must not throw
+
+    // no NULLs left anywhere — the SET NOT NULL pre-state
+    expect(await count(pg, 'date IS NULL')).toBe(0);
+    expect(await count(pg, 'type_name IS NULL')).toBe(0);
+
+    // zombie row back-filled: today's date + type parsed from first word of display_name
+    const { rows: [z] } = await pg.query(
+      `SELECT date::text AS date, type_name FROM stock WHERE display_name = 'Hydrangea Pink'`);
+    expect(z.type_name).toBe('Hydrangea');
+    expect(z.date).toBe(TODAY);
+
+    // soft-delete preserved — fix fills attrs, never resurrects the tombstone
+    expect(await count(pg, "display_name = 'Hydrangea Pink' AND deleted_at IS NOT NULL")).toBe(1);
+
+    // NOT NULL constraints now applied
+    expect(await colNullable(pg, 'date')).toBe(false);
+    expect(await colNullable(pg, 'type_name')).toBe(false);
+  });
+
+  it('aborts when an ACTIVE row is missing type_name (pre-condition, #292 backfill gate)', async () => {
+    await ins(pg, { name: 'Mystery Flower', qty: 5, type: null }); // active + untyped
+    await expect(runMigration(pg, { today: TODAY })).rejects.toThrow(/Pre-condition failed/);
+  });
+
+  it('--dry-run rolls back: NOT NULL not applied, NULLs untouched', async () => {
+    await ins(pg, { name: 'Rose Red', qty: 10, type: 'Rose' });
+    await ins(pg, { name: 'Hydrangea Pink', qty: 0, type: null, deleted: true });
+
+    const res = await runMigration(pg, { dryRun: true, today: TODAY });
+    expect(res.dryRun).toBe(true);
+
+    expect(await colNullable(pg, 'date')).toBe(true);        // constraint NOT applied
+    expect(await count(pg, 'type_name IS NULL')).toBe(1);    // zombie still null (rolled back)
+  });
+
+  it('is idempotent — re-running after cutover is a no-op', async () => {
+    await ins(pg, { name: 'Rose Red', qty: 10, type: 'Rose' });
+    await runMigration(pg, { today: TODAY });                 // commits + applies NOT NULL
+    const res2 = await runMigration(pg, { today: TODAY });    // alreadyMigrated guard
+    expect(res2.noop).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Fixes a defect in the **Y-model cutover migration** (`backend/scripts/migrate-stock-y-model.js`) that would have made the live #291 cutover **fail**, found while prepping the rigorous pre-cutover dry-run against a prod read.

## The defect

Phase 5 runs `ALTER COLUMN date / type_name SET NOT NULL`. `SET NOT NULL` validates **every physical row, including soft-deleted ones**. But:
- Phases 1-3 only date rows where `deleted_at IS NULL`.
- The #292 backfill UI only types **active** rows.

So soft-deleted, undated/untyped tombstone rows (qty 0) are never touched → Phase 5 fails. **On prod right now: 150 soft-deleted rows are undated, 149 untyped.** The synthetic `y-model-guide` lab scenario has no such rows, so it never surfaced this.

## The fix

New **`phaseDeletedFill` (phase 4b)** runs before Phase 5 and back-fills soft-deleted rows:
- `date = COALESCE(date, today)`
- `type_name = COALESCE(type_name, first-word-of-display_name, 'Unknown')`

**Fills, never DELETEs** — `stock_purchases`, `stock_order_lines`, and `premade_bouquet_lines` FK-reference `stock(id)` with default `RESTRICT`, so hard-purging tombstones would throw FK violations. Active-row logic (phases 1-4 + the `type_name` pre-condition) is unchanged. Soft-delete is preserved (we fill attrs, never resurrect the tombstone).

Also refactored for testability: the script now exports `runMigration(client, {dryRun, today})` + each phase, with CLI side-effects (`APPROVE=yes` guard, pool, `process.exit`) gated behind `main()` so the module is import-safe.

## Verification

New `backend/src/__tests__/migrateStockYModel.integration.test.js` (pglite, **4/4 ✓** in isolation):
1. Regression — Phase 5 succeeds with a soft-deleted undated/untyped zombie present; no NULLs remain; tombstone keeps `deleted_at`; NOT NULL applied.
2. Pre-condition aborts on an **active** untyped row (#292 gate).
3. `--dry-run` rolls back — NOT NULL not applied, NULLs untouched.
4. Idempotent no-op on re-run (`alreadyMigrated` guard).

E2E is **N/A** — the migration is a standalone CLI script exercised by no API route; the integration test is the proof path per the verification gate.

> Note: the full backend suite showed 9 pglite-boot **hook timeouts** under local CPU contention (146s run, Docker up); the named one passes 10/10 in isolation. Not a regression from this change (the script is imported nowhere but the new test).

## Cutover (#291) status — still blocked, now by data + infra only

| Gate | Status |
|---|---|
| 1. type_name backfill | ❌ 23 active rows still `type_name IS NULL` — run #292 backfill UI before live migration |
| 2. migration Phase-5 defect | ✅ **this PR** |
| 3. snapshot infra | ❌ prod PG 18.3 vs lab PG 15 + no local `pg_dump` — bump lab to PG 18 for the real dry-run |

Refs #291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GXyzJmQiFgsAfECtoR8dB