### PR TITLE
chore(lab): bump lab Postgres 15 → 18 to match prod

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,7 @@ jobs:
     timeout-minutes: 12
     services:
       postgres:
-        image: postgres:15-alpine
+        image: postgres:18-alpine
         env:
           POSTGRES_USER: lab
           POSTGRES_PASSWORD: lab

--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -1,10 +1,12 @@
 # docker-compose.lab.yml
-# Local Postgres 15 for the lab harness. Port 5433 to avoid colliding with
-# any other Postgres on :5432. Volume persists across `compose down/up` so
-# the template DB survives between sessions.
+# Local Postgres 18 for the lab harness (matches prod PG 18.x). Port 5433 to
+# avoid colliding with any other Postgres on :5432. Volume persists across
+# `compose down/up` so the template DB survives between sessions.
+# NOTE: bumping the major version requires recreating the volume:
+#   docker compose -f docker-compose.lab.yml down -v && npm run lab:db:up
 services:
   postgres:
-    image: postgres:15-alpine
+    image: postgres:18-alpine
     container_name: flower-lab-pg
     environment:
       POSTGRES_USER: lab
@@ -13,7 +15,8 @@ services:
     ports:
       - "5433:5432"
     volumes:
-      - lab-pg-data:/var/lib/postgresql/data
+      # PG18 image places data in a subdir of /var/lib/postgresql (not /data).
+      - lab-pg-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U lab -d lab"]
       interval: 2s

--- a/lab/README.md
+++ b/lab/README.md
@@ -47,7 +47,7 @@ npm run lab:test:ui     # Playwright: UI smoke + flow tests
 ## CI
 
 The `lab-api` GitHub Actions job runs on every PR and push to master. It:
-1. Spins up a Postgres 15 service container (matches local Docker config).
+1. Spins up a Postgres 18 service container (matches local Docker config + prod).
 2. Runs `npm run lab:test:unit` (factory + scenario tests).
 3. Rebuilds `lab_template` with baseline scenario.
 4. Runs `npm run lab:test:api` (API integration tests).


### PR DESCRIPTION
## Why

Prod runs **PG 18.3**; the lab harness ran **PG 15**. That mismatch blocked the #291 cutover dry-run against a real prod snapshot — a v15 client can't `pg_dump` a v18 server, and v18 dumps don't restore into v15. Bumping the lab to 18 lets the lab faithfully mirror prod (and was needed to run the cutover migration dry-run this session).

## Changes

- **`docker-compose.lab.yml`**: `postgres:15-alpine` → `18-alpine`. PG18's official image places data in a subdir of `/var/lib/postgresql`, so the named volume now mounts at `/var/lib/postgresql` (not `/data`) — without this the container exits on boot with an "unused mount/volume" error. A major-version bump requires recreating the volume:
  ```
  docker compose -f docker-compose.lab.yml down -v && npm run lab:db:up
  ```
- **`.github/workflows/test.yml`**: `lab-api` service container → `postgres:18-alpine` (GH Actions service containers use the image default PGDATA, so no mount change needed there).
- **`lab/README.md`**: reflect PG18.

## Verification

The `lab-api` CI job on this PR exercises the bump (it boots the PG18 service + runs the factory/scenario/api tests). Locally: lab recreated on PG18.4, a full prod snapshot restored + the Y-model cutover migration dry-run ran clean against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GXyzJmQiFgsAfECtoR8dB