### PR TITLE
feat(assistant): maximize/restore toggle on Ask Blossom drawer

### DIFF
--- a/packages/shared/components/AskBlossomLauncher.jsx
+++ b/packages/shared/components/AskBlossomLauncher.jsx
@@ -9,6 +9,7 @@ const SPARKLE = "M12 2l1.8 4.9L19 8.7l-4.2 2.6L13.5 16 12 11.6 10.5 16 9.2 11.3 
 
 export default function AskBlossomLauncher({ t, fabClassName = 'bottom-6 right-6' }) {
   const [open, setOpen] = useState(false);
+  const [maximized, setMaximized] = useState(false);
   return (
     <>
       <style>{`
@@ -33,13 +34,27 @@ export default function AskBlossomLauncher({ t, fabClassName = 'bottom-6 right-6
           <div
             role="dialog"
             aria-label={t.tabAssistant}
-            className="fixed z-50 bg-white shadow-2xl flex flex-col overflow-hidden
-                       inset-x-0 bottom-0 top-[12%] rounded-t-2xl animate-[alb-up_0.22s_ease-out]
-                       sm:inset-y-0 sm:left-auto sm:right-0 sm:top-0 sm:w-[440px] sm:max-w-[92vw] sm:rounded-none sm:animate-[alb-right_0.22s_ease-out]"
+            className={`fixed z-50 bg-white shadow-2xl flex flex-col overflow-hidden
+                       transition-[top,width] duration-200 ease-out
+                       animate-[alb-up_0.22s_ease-out] sm:animate-[alb-right_0.22s_ease-out]
+                       ${maximized
+                         ? 'inset-0 rounded-none sm:w-full sm:max-w-none'
+                         : 'inset-x-0 bottom-0 top-[12%] rounded-t-2xl sm:inset-y-0 sm:left-auto sm:right-0 sm:top-0 sm:w-[440px] sm:max-w-[92vw] sm:rounded-none'}`}
           >
             <div className="flex items-center gap-2 px-3 py-2 border-b bg-brand-600 text-white shrink-0">
               <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d={SPARKLE} /></svg>
               <span className="font-semibold text-sm flex-1">Ask Blossom</span>
+              <button
+                aria-label={maximized ? 'Restore' : 'Maximize'}
+                onClick={() => setMaximized(m => !m)}
+                className="w-7 h-7 rounded hover:bg-white/20 flex items-center justify-center"
+              >
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                  {maximized
+                    ? <path d="M9 4v5H4M15 4v5h5M9 20v-5H4M15 20v-5h5" />
+                    : <path d="M4 9V4h5M15 4h5v5M20 15v5h-5M9 20H4v-5" />}
+                </svg>
+              </button>
               <button aria-label="Close" onClick={() => setOpen(false)} className="w-7 h-7 rounded hover:bg-white/20 leading-none text-lg">✕</button>
             </div>
             <div className="flex-1 min-h-0">


### PR DESCRIPTION
## What

Adds a **maximize / restore** button to the Ask Blossom chat header (the FAB drawer shipped in #448).

- **Phone:** maximized fills the full screen (`inset-0`); restore returns to the docked bottom sheet (`top-[12%]`).
- **Desktop:** maximized expands the right-side drawer to full width (`sm:w-full`); restore returns to the 440px drawer.
- Smooth `transition-[top,width]`. Defaults to docked on open; toggle state is per-session.

## Why

Owner wanted to be able to make the assistant window bigger for reading longer answers / tables.

## Files

- `packages/shared/components/AskBlossomLauncher.jsx` — `maximized` state + header toggle button (inline expand/collapse SVG), responsive class swap.

## Verification

- `packages/shared` vitest: **556/556 pass**
- Built all three apps locally (dashboard / florist / delivery) ✓ — shared `index.js` re-exports reach every app.
- No backend / schema / env change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Q85Nscp6hSQzw5ddLAs6w