### PR TITLE
fix(assistant): surface florist pay rates in hours_summary

### DIFF
--- a/backend/src/__tests__/assistantTools.hoursPack.test.js
+++ b/backend/src/__tests__/assistantTools.hoursPack.test.js
@@ -29,4 +29,53 @@ describe('hoursPack.hours_summary', () => {
     expect(mockHoursList).toHaveBeenCalledWith({ dateFrom: '2026-05-01', dateTo: '2026-05-31', name: undefined });
     expect(mockBuildPayroll).toHaveBeenCalledWith([{ Name: 'Anna' }, { Name: 'Bob' }], { Anna: 30 });
   });
+
+  it('surfaces configured per-florist pay rates (top-level + per florist)', async () => {
+    const RATES = {
+      Masha: { Wedding: 25, Holidays: 25, Standard: 25 },
+      Sasha: { Wedding: 50, Holidays: 40, Standard: 33 },
+    };
+    mockGetConfig.mockReturnValue(RATES);
+    mockHoursList.mockResolvedValueOnce([{ Name: 'Sasha' }]);
+    mockBuildPayroll.mockReturnValue({
+      days: [{ name: 'Sasha', hours: 8, earnings: 264, deliveryCount: 0 }],
+      totals: { hours: 8, earnings: 264, deliveries: 0, days: 1 },
+    });
+    const r = await hoursSummaryHandler({ from: '2026-05-01', to: '2026-05-31' });
+    // Top-level rates map carries the full configured rate model.
+    expect(r.rates).toEqual(RATES);
+    // The florist who logged hours carries their own rate(s).
+    const sasha = r.florists.find(f => f.name === 'Sasha');
+    expect(sasha.rates).toEqual({ Wedding: 50, Holidays: 40, Standard: 33 });
+    // Masha has configured rates but no logged hours — still surfaced (zeroed hours).
+    const masha = r.florists.find(f => f.name === 'Masha');
+    expect(masha).toBeDefined();
+    expect(masha.rates).toEqual({ Wedding: 25, Holidays: 25, Standard: 25 });
+    expect(masha).toMatchObject({ hours: 0, earnings: 0, days: 0 });
+  });
+
+  it('answers a rate question with no date range and no logged hours', async () => {
+    mockGetConfig.mockReturnValue({ Sasha: { Standard: 33 } });
+    mockHoursList.mockResolvedValueOnce([]);
+    mockBuildPayroll.mockReturnValue({ days: [], totals: { hours: 0, earnings: 0, deliveries: 0, days: 0 } });
+    const r = await hoursSummaryHandler({});
+    expect(mockHoursList).toHaveBeenCalledWith({ dateFrom: undefined, dateTo: undefined, name: undefined });
+    expect(r.rates).toEqual({ Sasha: { Standard: 33 } });
+    expect(r.florists.find(f => f.name === 'Sasha').rates).toEqual({ Standard: 33 });
+  });
+
+  it('scopes rates to one florist when name is given', async () => {
+    mockGetConfig.mockReturnValue({
+      Masha: { Standard: 25 },
+      Sasha: { Wedding: 50, Standard: 33 },
+    });
+    mockHoursList.mockResolvedValueOnce([{ Name: 'Sasha' }]);
+    mockBuildPayroll.mockReturnValue({
+      days: [{ name: 'Sasha', hours: 5, earnings: 165, deliveryCount: 0 }],
+      totals: { hours: 5, earnings: 165, deliveries: 0, days: 1 },
+    });
+    const r = await hoursSummaryHandler({ name: 'Sasha' });
+    expect(r.rates).toEqual({ Sasha: { Wedding: 50, Standard: 33 } });
+    expect(r.florists.map(f => f.name)).toEqual(['Sasha']);
+  });
 });

--- a/backend/src/services/assistantTools/hoursPack.js
+++ b/backend/src/services/assistantTools/hoursPack.js
@@ -11,8 +11,12 @@ const round = (n) => Math.round(n * 100) / 100;
 export async function hoursSummaryHandler(input = {}) {
   const { from, to, name } = input;
   const records = await hoursRepo.list({ dateFrom: from, dateTo: to, name });
-  const rates = getConfig('floristRates') || {};
-  const { days, totals } = buildPayroll(records, rates);
+  const allRates = getConfig('floristRates') || {};
+  // Scope the rate model to one florist when the caller asked about a specific person.
+  const rates = name
+    ? (allRates[name] != null ? { [name]: allRates[name] } : {})
+    : allRates;
+  const { days, totals } = buildPayroll(records, allRates);
   const byFlorist = {};
   for (const d of days) {
     const f = byFlorist[d.name] || (byFlorist[d.name] = { name: d.name, hours: 0, earnings: 0, deliveries: 0, days: 0 });
@@ -21,9 +25,22 @@ export async function hoursSummaryHandler(input = {}) {
     f.deliveries += d.deliveryCount || 0;
     f.days += 1;
   }
-  const florists = Object.values(byFlorist).map(f => ({ ...f, hours: round(f.hours), earnings: round(f.earnings) }));
+  // Surface configured pay rates so "what are the florist pay rates" / "what is
+  // Sasha's rate" is answerable even for florists with no logged hours in range.
+  // A florist's rate is either a flat number or a per-Rate-Type map
+  // ({ Standard, Wedding, Holidays, ... }) — see floristHoursService.resolveHourlyRate.
+  for (const n of Object.keys(rates)) {
+    if (!byFlorist[n]) byFlorist[n] = { name: n, hours: 0, earnings: 0, deliveries: 0, days: 0 };
+  }
+  const florists = Object.values(byFlorist).map(f => ({
+    ...f,
+    hours: round(f.hours),
+    earnings: round(f.earnings),
+    rates: allRates[f.name] ?? null,
+  }));
   return {
     period: { from: from || null, to: to || null },
+    rates,
     florists,
     totals: {
       hours: round(totals?.hours || 0),

--- a/backend/src/services/assistantTools/index.js
+++ b/backend/src/services/assistantTools/index.js
@@ -149,15 +149,14 @@ export const TOOLS = [
   },
   {
     name: 'hours_summary',
-    description: 'Florist hours + payroll over a date range: hours, earnings (złoty), and delivery counts per florist plus grand totals. Use for "how many hours did each florist work", payroll / labor-cost questions.',
+    description: "Florist hours, pay rates + payroll. Returns each florist's configured hourly pay rate(s) — a flat number or a per-Rate-Type map (Standard / Wedding / Holidays), e.g. Sasha may earn more for weddings — plus hours, earnings (złoty), and delivery counts per florist and grand totals. Florists with configured rates but no logged hours are still listed (rates only). Use for \"what are the florist pay rates\", \"what is Sasha's rate\", \"how many hours did each florist work\", payroll / labor-cost questions. Omit from/to for current rates / all-time; pass them to scope hours + earnings to a period.",
     input_schema: {
       type: 'object',
       properties: {
-        from: { type: 'string', description: 'Start date YYYY-MM-DD' },
-        to: { type: 'string', description: 'End date YYYY-MM-DD' },
+        from: { type: 'string', description: 'Start date YYYY-MM-DD (optional — omit for current rates / all-time)' },
+        to: { type: 'string', description: 'End date YYYY-MM-DD (optional — omit for current rates / all-time)' },
         name: { type: 'string', description: 'Filter to one florist name (optional)' },
       },
-      required: ['from', 'to'],
     },
     handler: hoursSummaryHandler,
   },


### PR DESCRIPTION
## Bug

Owner asked Ask Blossom about individual florist pay rates + total paid sums. The assistant replied it had no data and that there were no differing rates — but **Sasha has per-Rate-Type rates** (Wedding 50 / Holidays 40 / Standard 33 zł) and Masha a flat 25 (confirmed against prod via `claude_ro`).

## Root cause

`hours_summary` (`backend/src/services/assistantTools/hoursPack.js`) read the `floristRates` config **only to compute earnings**, then discarded the rate values. Earnings + totals were exposed; the rate values never were, and no tool surfaced the rate config. So rate questions had no data path. This was a missing-data-in-tool bug, **not** a deploy failure — the tool was live but incomplete.

## Fix

- `hours_summary` now returns a top-level `rates` map **and** each florist's `rates` (a flat number or a per-Rate-Type object).
- Florists with configured rates but **no logged hours** in range are still listed (rates only), so "what are the rates" works without shift data.
- `from`/`to` made **optional** (rates are date-independent config); `name` scopes the rate map to that florist.
- Tool description updated so the model routes "what are the florist pay rates / what is Sasha's rate" to this tool.

## Verification

- 3 regression tests added in `assistantTools.hoursPack.test.js` (top-level + per-florist rates; rate-only with no hours / no date range; `name` scoping).
- Backend vitest: **670 passing** (was 667 + 3 new).
- E2E harness suite: **220 passing, 0 failed**.
- No schema / env change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Q85Nscp6hSQzw5ddLAs6w