### PR TITLE
fix(florist): assistant FAB hidden behind New-Order FAB on /orders

### DIFF
--- a/apps/florist/CLAUDE.md
+++ b/apps/florist/CLAUDE.md
@@ -24,7 +24,7 @@ The florist should see all relevant information at a glance — what to prepare 
 | CustomerDetailPage | /customers/:id | all | Customer profile + order history |
 | WasteLogPage | /waste | owner | Stock-loss entry log by reason |
 | SubstituteReconciliationPage | /reconcile | owner | Reconcile substitutions made during PO shopping |
-| ~~AssistantPage~~ | ~~`/assistant`~~ | owner | Removed — replaced by the shared `AskBlossomLauncher` FAB (`bottom-20 right-4`) rendered owner-only in `App.jsx` `Layout`, clearing the bottom nav. Opens the same `AskBlossomPanel` as the dashboard. |
+| ~~AssistantPage~~ | ~~`/assistant`~~ | owner | Removed — replaced by the shared `AskBlossomLauncher` FAB (`bottom-36 right-4`) rendered owner-only in `App.jsx` `Layout`. Sits at `bottom-36` (not `bottom-20`) to stack **above** the OrderListPage "Новый заказ" FAB (`bottom-20 right-5 z-50`), which would otherwise paint over it on `/orders`. Opens the same `AskBlossomPanel` as the dashboard. |
 
 ## Key Components (src/components/)
 | Component | Purpose |

--- a/apps/florist/src/App.jsx
+++ b/apps/florist/src/App.jsx
@@ -65,7 +65,10 @@ function Layout({ children }) {
     <>
       {children}
       <BottomNav />
-      {role === 'owner' && <AskBlossomLauncher t={t} fabClassName="bottom-20 right-4" />}
+      {/* bottom-36 (not bottom-20): the OrderListPage "Новый заказ" FAB sits at
+          bottom-20 right-5 z-50 and would paint over the assistant FAB (z-40) on
+          /orders. Stack the assistant above it so both stay tappable. */}
+      {role === 'owner' && <AskBlossomLauncher t={t} fabClassName="bottom-36 right-4" />}
     </>
   );
 }


### PR DESCRIPTION
## Bug

Owner reported the Ask Blossom assistant button was missing on the **florist app** (it shows fine on the dashboard).

## Root cause — a FAB collision, not cache or role

Diagnosed with a live browser repro (florist dev server + harness, logged in as owner). The assistant FAB **is** rendered for an owner session, but on the `/orders` landing screen:

| FAB | Position | z-index |
|-----|----------|---------|
| Ask Blossom (✨) | `bottom-20 right-4` | **40** |
| OrderListPage "Новый заказ" (+) | `bottom-20 right-5` | **50** |

Same corner, and the New-Order wrapper's `z-50` beats the assistant's `z-40`, so the **"+" paints directly over the sparkle**. `document.elementFromPoint` at the FAB centre returned the "Новый заказ" button (`isOnTop: false` for the assistant). The dashboard has no such button — which is why it looked role/deploy-related but wasn't.

## Fix

Mount the assistant FAB at **`bottom-36 right-4`** (9rem) on the florist app so it stacks **above** the New-Order FAB. Both stay visible + tappable.

## Verification

- Live browser repro: after the offset, `elementFromPoint` at the FAB centre returns the assistant button (`nowOnTop: true`); screenshot shows both FABs stacked (✨ above +).
- Florist `vite build` ✓ — `.bottom-36{bottom:9rem}` emitted in the CSS.
- No backend / shared change. No good unit seam for a fixed-position layout bug — the browser repro is the verification.

## Docs

`apps/florist/CLAUDE.md` updated to record why the FAB sits at `bottom-36` (so a future tidy-up doesn't move it back into the collision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Q85Nscp6hSQzw5ddLAs6w