### PR TITLE
fix(assistant): phone chat layout — history drawer + full-width chat

### DIFF
--- a/packages/shared/components/AskBlossomPanel.jsx
+++ b/packages/shared/components/AskBlossomPanel.jsx
@@ -12,6 +12,7 @@ export default function AskBlossomPanel({ t }) {
   const [editingId, setEditingId] = useState(null);
   const [editTitle, setEditTitle] = useState('');
   const [confirmDeleteId, setConfirmDeleteId] = useState(null);
+  const [historyOpen, setHistoryOpen] = useState(false); // mobile: history slide-over drawer
   const endRef = useRef(null);
 
   useEffect(() => { endRef.current?.scrollIntoView?.({ behavior: 'smooth' }); }, [messages, loading]);
@@ -32,6 +33,7 @@ export default function AskBlossomPanel({ t }) {
     setInput('');
     setConfirmDeleteId(null);
     setEditingId(null);
+    setHistoryOpen(false);
   }
 
   async function loadConversation(id) {
@@ -41,6 +43,7 @@ export default function AskBlossomPanel({ t }) {
       setSessionId(data.id);
       setConfirmDeleteId(null);
       setEditingId(null);
+      setHistoryOpen(false);
     } catch (err) {
       setMessages((m) => [...m, { role: 'assistant', text: err.response?.data?.error || t.assistantError }]);
     }
@@ -97,8 +100,15 @@ export default function AskBlossomPanel({ t }) {
   }
 
   return (
-    <div className="flex h-full gap-3">
-      <aside className="w-48 shrink-0 border-r flex flex-col">
+    <div className="relative flex h-full gap-0 sm:gap-3 overflow-hidden">
+      {/* History: a static side column on desktop; a slide-over drawer on phones
+          (where a permanent column would squeeze the chat into a cramped half). */}
+      <aside
+        className={`flex flex-col bg-white border-r shrink-0
+                    absolute inset-y-0 left-0 z-30 w-64 shadow-xl transition-transform duration-200
+                    ${historyOpen ? 'translate-x-0' : '-translate-x-full'}
+                    sm:relative sm:inset-auto sm:z-auto sm:w-48 sm:shadow-none sm:translate-x-0`}
+      >
         <button
           className="m-2 bg-brand-600 text-white rounded-lg px-3 py-2 text-sm"
           onClick={newChat}
@@ -140,7 +150,29 @@ export default function AskBlossomPanel({ t }) {
         </div>
       </aside>
 
+      {/* Mobile-only backdrop behind the open history drawer */}
+      {historyOpen && (
+        <div className="sm:hidden absolute inset-0 z-20 bg-black/20" onClick={() => setHistoryOpen(false)} />
+      )}
+
       <div className="flex-1 flex flex-col min-w-0">
+        {/* Mobile-only toolbar: open history drawer + quick new chat (desktop has the side column) */}
+        <div className="sm:hidden flex items-center gap-2 px-2 py-1.5 border-b">
+          <button
+            className="flex items-center gap-1.5 text-sm text-gray-700 px-2 py-1 rounded-lg hover:bg-gray-100"
+            onClick={() => setHistoryOpen(true)}
+            aria-label={t.assistantHistory}
+          >
+            <span className="text-lg leading-none">☰</span>
+            <span>{t.assistantHistory}</span>
+          </button>
+          <button
+            className="ml-auto text-sm font-medium text-brand-600 px-2 py-1 rounded-lg hover:bg-brand-50"
+            onClick={newChat}
+          >
+            {t.assistantNewChat}
+          </button>
+        </div>
         <div className="flex-1 overflow-y-auto space-y-3 p-2">
           {messages.length === 0 && (
             <div className="mt-8 flex flex-col items-center gap-3">

--- a/packages/shared/test/AskBlossomPanel.test.jsx
+++ b/packages/shared/test/AskBlossomPanel.test.jsx
@@ -78,7 +78,9 @@ describe('AskBlossomPanel', () => {
     fireEvent.change(screen.getByPlaceholderText('Спросите…'), { target: { value: 'q' } });
     fireEvent.click(screen.getByText('Спросить'));
     await screen.findByText('a');
-    fireEvent.click(screen.getByText('+ Новый чат'));
+    // Two "New chat" buttons exist by design: the desktop sidebar + the mobile
+    // toolbar (CSS-toggled via sm: — jsdom renders both). Either clears the chat.
+    fireEvent.click(screen.getAllByText('+ Новый чат')[0]);
     expect(screen.queryByText('a')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Problem

On phones the Ask Blossom panel showed the conversation history as a **permanent `w-48` left column** next to the chat, squeezing both into cramped half-widths on a ~390px screen (per owner screenshot — chat unreadable).

## Fix

Responsive layout in `packages/shared/components/AskBlossomPanel.jsx`:
- **Phone:** chat is full-width; history is a **slide-over drawer** opened by a `☰ Чаты` button in a new top toolbar (with a quick `+ New chat`). A backdrop dims the chat; selecting a conversation or New chat closes the drawer.
- **Desktop:** unchanged — the static side column stays via `sm:` variants.

Reuses the existing `assistantHistory` translation key ('Chats' / 'Чаты') — no new strings.

## Verification

- Live browser repro at 390×844 (logged in as owner): full-width chat with toolbar; ☰ opens the history drawer over a backdrop. Screenshots attached in chat.
- Shared vitest **556 passing** (updated one test: two "New chat" buttons now exist by design — sidebar + mobile toolbar — so `getAllByText[0]`).
- All three apps build ✓.
- No backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Q85Nscp6hSQzw5ddLAs6w