### PR TITLE
feat(assistant): cap bump + graceful coverage (shippable) + RFC/skeletons for connect-the-dots, open-ended, in-chat reporting

### DIFF
--- a/backend/src/__tests__/assistantService.test.js
+++ b/backend/src/__tests__/assistantService.test.js
@@ -70,7 +70,11 @@ describe('assistantService.ask', () => {
       content: [{ type: 'tool_use', id: 'tu', name: 'query_orders', input: {} }],
     });
     const r = await ask({ message: 'loop' });
-    expect(mockCreate.mock.calls.length).toBeLessThanOrEqual(7); // 1 initial + MAX_ITERATIONS(6)
+    // Cap-agnostic: the loop must terminate (1 initial + MAX_ITERATIONS round-trips,
+    // default 12, env-overridable) rather than run forever, and still return an answer.
+    const maxIters = Number(process.env.ASSISTANT_MAX_ITERATIONS) || 12;
+    expect(mockCreate.mock.calls.length).toBeLessThanOrEqual(maxIters + 1);
+    expect(mockCreate.mock.calls.length).toBeGreaterThan(1); // it did loop, not one-shot
     expect(r.answer).toBeTruthy();
   });
 

--- a/backend/src/services/assistantService.js
+++ b/backend/src/services/assistantService.js
@@ -5,7 +5,10 @@ import * as conversationRepo from '../repos/assistantConversationRepo.js';
 
 const anthropic = new Anthropic();
 const MODEL = process.env.ASSISTANT_MODEL || 'claude-sonnet-4-6';
-const MAX_ITERATIONS = 6;
+// Max tool round-trips per question. Raised from 6 → 12 so multi-tool / "connect
+// the dots" questions (call several tools, then reason) can complete instead of
+// hitting the cap. Env-overridable for tuning without a deploy.
+const MAX_ITERATIONS = Number(process.env.ASSISTANT_MAX_ITERATIONS) || 12;
 const MAX_TOKENS = 2048;
 const SESSION_TTL_MS = 2 * 60 * 60 * 1000;
 
@@ -21,7 +24,8 @@ function systemPrompt(today) {
     "You are Blossom's analytics assistant for the studio owner. Blossom is a flower studio in Krakow.",
     `Today's date is ${today} (Europe/Warsaw). Resolve relative periods like "May", "last month", "this week" against it.`,
     'You answer questions about the business ONLY using the provided tools. Never write SQL.',
-    'CRITICAL: State only numbers that came from a tool result. Never invent, estimate, or extrapolate figures. If no tool can answer the question, say so plainly.',
+    'CRITICAL: State only numbers that came from a tool result. Never invent, estimate, or extrapolate figures.',
+    "If no tool can directly answer the question: (1) say plainly that you don't have a dedicated tool for it, (2) then, if related tools returned useful data, give your best interpretation built ONLY on those real figures — clearly labelled as an interpretation/inference, not a measured number. Combine results from MULTIPLE tools when a question needs it (e.g. join orders with stock shortfalls, or spend with revenue) — call each tool, then reason over their real outputs to connect the dots.",
     'When a tool result has truncated=true, tell the user you are showing the first N of matchedCount and that they can ask to see all.',
     'Currency is Polish złoty — display amounts with "zł". Present breakdowns as compact Markdown tables.',
     "LANGUAGE: reply in the SAME language as the user's latest message — if they write in English, answer entirely in English; if in Russian, answer in Russian. Only fall back to Russian when the language is genuinely unclear.",

--- a/backend/src/services/assistantTools/dataQueryPack.js
+++ b/backend/src/services/assistantTools/dataQueryPack.js
@@ -1,0 +1,131 @@
+// backend/src/services/assistantTools/dataQueryPack.js
+//
+// ┌─────────────────────────────────────────────────────────────────────────┐
+// │ SKELETON — NOT REGISTERED in index.js yet. Inert until wired + tested.    │
+// └─────────────────────────────────────────────────────────────────────────┘
+//
+// The "connect-the-dots" tool. Goal: let the owner ask cross-entity questions the
+// static dashboard can't filter for ("orders due this week, still unpaid, for VIP
+// customers, that need a flower I'm short on") — a flexible, smart interface to the
+// database she builds with every order.
+//
+// SAFETY MODEL (the whole point): the model NEVER writes SQL. It composes a
+// DECLARATIVE spec from a fixed vocabulary (allow-listed entities / fields / ops /
+// joins). The backend validates the spec against SCHEMA and runs a parameterized,
+// READ-ONLY Drizzle query with a row cap + statement timeout. An unknown entity,
+// field, or operator is rejected — so the model cannot reach data it shouldn't, and
+// a malformed spec fails loudly instead of returning a wrong-but-plausible number.
+//
+// This is the structured-query alternative to (a) hand-writing a composite tool per
+// question — too rigid — and (b) a raw read-only SQL tool — too risky (a bad query
+// silently returns wrong numbers, the exact thing the assistant's design avoids).
+//
+// See RFC: docs/superpowers/plans/2026-06-30-assistant-extensions-rfc.md
+
+// import { db } from '../../db/index.js';
+// import * as schema from '../../db/schema.js';
+// import { and, or, eq, ne, lt, lte, gt, gte, inArray, ilike, isNull, isNotNull, sql, count, sum, avg, min, max, desc, asc } from 'drizzle-orm';
+// import { ORDER_STATUS } from '../../constants/statuses.js';
+
+const ROW_CAP = 200;          // hard ceiling on returned rows (aggregates run over the FULL match)
+const STATEMENT_TIMEOUT_MS = 5000;
+
+// ── Allow-list: the ONLY entities/fields/joins/ops the tool will ever touch ──
+// Each field maps a model-facing name → the real column. Anything not listed here
+// is invisible to the model. Keep this curated to what the owner should query.
+// TODO: fill `table` with the real Drizzle table object + `col` with the column ref.
+const SCHEMA = {
+  orders: {
+    // table: schema.orders,
+    defaultFilters: [{ field: 'status', op: 'ne', value: 'Cancelled' }], // unless overridden
+    fields: {
+      id: 'id', orderDate: 'orderDate', requiredBy: 'requiredBy', status: 'status',
+      deliveryType: 'deliveryType', source: 'source', paymentStatus: 'paymentStatus',
+      paymentMethod: 'paymentMethod', price: 'priceOverride', customerId: 'customerId',
+    },
+    joins: {
+      customer: { to: 'customers', on: ['customerId', 'id'] },
+      lines:    { to: 'order_lines', on: ['id', 'orderId'], cardinality: 'many' },
+      delivery: { to: 'deliveries', on: ['id', 'orderId'], cardinality: 'one' },
+    },
+  },
+  customers: {
+    // table: schema.customers,
+    fields: { id: 'id', name: 'name', phone: 'phone', segment: 'segment' },
+    joins: { orders: { to: 'orders', on: ['id', 'customerId'], cardinality: 'many' } },
+  },
+  order_lines: {
+    // table: schema.orderLines,
+    fields: { id: 'id', orderId: 'orderId', stockItemId: 'stockItemId', quantity: 'quantity', sellPrice: 'sellPricePerUnit' },
+    joins: { stock: { to: 'stock', on: ['stockItemId', 'id'] } },
+  },
+  stock: {
+    // table: schema.stock,
+    fields: { id: 'id', name: 'displayName', quantity: 'currentQuantity', type: 'typeName', colour: 'colour' },
+  },
+};
+
+const OPERATORS = new Set(['eq', 'ne', 'lt', 'lte', 'gt', 'gte', 'in', 'like', 'isNull', 'isNotNull', 'between']);
+const AGG_FNS = new Set(['count', 'sum', 'avg', 'min', 'max']);
+
+/**
+ * Validate a query spec against SCHEMA. Returns { ok:true } or { ok:false, error }.
+ * Rejects unknown entity/field/op/join so the model can never reach un-allow-listed data.
+ *
+ * TODO: implement — check spec.entity ∈ SCHEMA; every filter.field + sort.field +
+ *       groupBy + aggregate.field ∈ SCHEMA[entity].fields (or a joined entity's fields);
+ *       every filter.op ∈ OPERATORS; every aggregate.fn ∈ AGG_FNS; joins ∈ SCHEMA[entity].joins.
+ */
+function validateSpec(/* spec */) {
+  throw new Error('dataQueryPack.validateSpec not implemented (skeleton)');
+}
+
+/**
+ * query_records — run a validated, read-only, parameterized query and return rows + counts.
+ *
+ * @param {{
+ *   entity: string,                                   // e.g. 'orders'
+ *   filters?: Array<{field:string,op:string,value?:any}>,
+ *   join?: string[],                                  // allow-listed join names on `entity`
+ *   groupBy?: string[],
+ *   aggregate?: Array<{fn:string,field?:string,as:string}>,
+ *   sort?: Array<{field:string,dir:'asc'|'desc'}>,
+ *   limit?: number,
+ *   includeCancelled?: boolean,                       // opt out of the default Cancelled-exclude
+ * }} spec
+ * @returns {Promise<{spec:object, matchedCount:number, truncated:boolean, rows:object[]}>}
+ */
+export async function queryRecordsHandler(/* spec */) {
+  // 1. const v = validateSpec(spec); if (!v.ok) return { error: v.error };
+  // 2. Build a parameterized Drizzle query from the validated spec:
+  //    - base = db.select(...).from(SCHEMA[entity].table)
+  //    - apply allow-listed joins (innerJoin on the predefined `on` columns)
+  //    - where(and(...defaultFilters unless includeCancelled, ...spec.filters mapped to drizzle ops))
+  //    - groupBy / aggregate (count/sum/avg/min/max) / orderBy / limit(min(limit, ROW_CAP))
+  //    - run inside a transaction with SET LOCAL statement_timeout = STATEMENT_TIMEOUT_MS
+  // 3. matchedCount via a parallel count() query (aggregates are over the FULL match, not the capped rows)
+  // 4. return { spec, matchedCount, truncated: matchedCount > rows.length, rows }
+  throw new Error('dataQueryPack.queryRecordsHandler not implemented (skeleton)');
+}
+
+// ── Composite quick-win (optional): a hand-written join for the single highest-value
+// question, shippable before the general tool is finished. ───────────────────────────
+/**
+ * orders_needing_short_stock — open orders whose bouquet uses a flower currently in
+ * shortfall (stock.currentQuantity < 0). The canonical "connect the dots" example.
+ * TODO: orderRepo.list({open}) ∩ stockRepo.list({shortfall}) joined via order_lines.stockItemId.
+ */
+export async function ordersNeedingShortStockHandler(/* input */) {
+  throw new Error('dataQueryPack.ordersNeedingShortStockHandler not implemented (skeleton)');
+}
+
+// When ready to ship, register in index.js, e.g.:
+//   {
+//     name: 'query_records',
+//     description: 'Flexible cross-entity lookup the fixed tools cannot express: filter/join/group/aggregate ' +
+//       'orders, customers, order lines and stock by any allow-listed field. Use ONLY when no dedicated tool ' +
+//       'fits (prefer financial_summary, query_orders, etc. for their cases). You compose a structured spec; ' +
+//       'you never write SQL. Cancelled orders are excluded unless includeCancelled=true.',
+//     input_schema: { /* entity, filters[], join[], groupBy[], aggregate[], sort[], limit, includeCancelled */ },
+//     handler: queryRecordsHandler,
+//   }

--- a/backend/src/services/assistantTools/freeTextPack.js
+++ b/backend/src/services/assistantTools/freeTextPack.js
@@ -1,0 +1,78 @@
+// backend/src/services/assistantTools/freeTextPack.js
+//
+// ┌─────────────────────────────────────────────────────────────────────────┐
+// │ SKELETON — NOT REGISTERED in index.js yet. Inert until wired + tested.    │
+// └─────────────────────────────────────────────────────────────────────────┘
+//
+// The open-ended / unstructured layer. The 20 structured tools answer "what are my
+// numbers"; this answers questions over FREE TEXT the owner typed into records —
+// card messages, customer requests, florist/driver notes, customer notes. These are
+// prose, not aggregates, so a structured tool can't model them.
+//
+// PHASE 1 (this skeleton): Postgres substring / full-text search — zero new infra.
+//   ILIKE '%query%' (or to_tsvector/plainto_tsquery) across an allow-listed set of
+//   text columns; return a snippet + the record to open. Good for "find the order
+//   where the customer asked for blue hydrangeas", "which orders mention a wedding".
+//
+// PHASE 2 (optional, see RFC): semantic search via pgvector embeddings — true RAG.
+//   Embed the text fields, retrieve by cosine similarity for fuzzy/conceptual queries
+//   ("complaints about late delivery"). Only worth it if Phase-1 keyword search proves
+//   too literal. Adds an embedding pipeline + an index to maintain.
+//
+// See RFC: docs/superpowers/plans/2026-06-30-assistant-extensions-rfc.md
+
+// import { db } from '../../db/index.js';
+// import { sql } from 'drizzle-orm';
+
+const SNIPPET_RADIUS = 80;  // chars of context around the match
+const DEFAULT_LIMIT = 15;
+const MAX_LIMIT = 50;
+
+// Allow-listed free-text fields per scope. Only these columns are ever searched —
+// keeps the tool away from structured/sensitive columns.
+const TEXT_FIELDS = {
+  orders: [
+    { col: 'customer_request', label: 'Customer request' },
+    { col: 'card_message',     label: 'Card message' },
+    { col: 'florist_note',     label: 'Florist note' },
+    { col: 'driver_note',      label: 'Driver note' },
+  ],
+  customers: [
+    { col: 'notes', label: 'Customer notes' },
+  ],
+};
+
+/**
+ * search_text — keyword search across allow-listed free-text fields.
+ *
+ * @param {{
+ *   query: string,                       // the phrase to find
+ *   scope?: 'orders'|'customers'|'all',  // default 'all'
+ *   limit?: number,
+ * }} input
+ * @returns {Promise<{
+ *   query: string, scope: string, matchedCount: number, truncated: boolean,
+ *   results: Array<{ entity:string, id:string, field:string, snippet:string, link:string }>,
+ * }>}
+ */
+export async function searchTextHandler(/* input */) {
+  // 1. Resolve scopes → the TEXT_FIELDS columns to search.
+  // 2. For each column: WHERE <col> ILIKE '%' || :query || '%' (parameterized),
+  //    select id + a snippet (substring around the match) + build a link (/orders/:id etc).
+  //    Run as one UNION-style pass or per-column queries; cap at min(limit, MAX_LIMIT).
+  // 3. return { query, scope, matchedCount, truncated, results }.
+  // NOTE: this returns WHERE the text was found + a snippet — the model then summarizes;
+  //       it never fabricates content not present in a snippet.
+  throw new Error('freeTextPack.searchTextHandler not implemented (skeleton)');
+}
+
+// When ready, register in index.js, e.g.:
+//   {
+//     name: 'search_text',
+//     description: 'Search the free-text the owner/florists/drivers typed on records — card messages, ' +
+//       'customer requests, florist/driver notes, customer notes. Use for "find the order that mentions X", ' +
+//       '"which customers asked about weddings", "any notes about late delivery". Returns matching snippets + ' +
+//       'the record to open; it does not invent text that is not in a snippet.',
+//     input_schema: { /* query (required), scope, limit */ },
+//     handler: searchTextHandler,
+//   }

--- a/backend/src/services/assistantTools/reportPack.js
+++ b/backend/src/services/assistantTools/reportPack.js
@@ -1,0 +1,60 @@
+// backend/src/services/assistantTools/reportPack.js
+//
+// ┌─────────────────────────────────────────────────────────────────────────┐
+// │ SKELETON — NOT REGISTERED in index.js yet. Inert until wired + tested.    │
+// └─────────────────────────────────────────────────────────────────────────┘
+//
+// Bug/feature reporting FROM inside Ask Blossom — one place for the owner to both ask
+// about her data AND report a problem. Hands off to the existing feedbackService
+// (which already runs on Claude Haiku — the requested model — and opens a GitHub issue).
+//
+// Why a thin handoff, not a reimplementation: the report flow is multi-turn, takes a
+// screenshot, and (per the RFC) should read codebase context — that lives in
+// feedbackService. This tool is just the entry seam so "report a bug: X" inside the
+// chat starts that flow without the owner leaving the assistant.
+//
+// The screenshot + codebase-understanding upgrades happen IN feedbackService, not here
+// (see RFC §Reporting). Today's feedbackService already: uses Haiku, asks one question
+// at a time, and stops asking once it has enough → matches "only ask if it can't infer".
+//
+// See RFC: docs/superpowers/plans/2026-06-30-assistant-extensions-rfc.md
+
+// import * as feedbackService from '../feedbackService.js';
+
+/**
+ * report_issue — start a bug/feature report from the assistant.
+ *
+ * @param {{
+ *   text: string,            // the owner's description of the bug / feature
+ *   type?: 'bug'|'feature',  // optional hint; feedbackService classifies anyway
+ * }} input
+ * @returns {Promise<{ sessionId:string, done:boolean, question?:string, issueUrl?:string }>}
+ */
+export async function reportIssueHandler(/* input */) {
+  // TODO: const s = await feedbackService.startSession({
+  //   text: input.text, appArea: 'dashboard'|'florist', reporterRole: 'owner', reporterName: '<owner>',
+  // });
+  // return { sessionId: s.sessionId, done: s.done, question: s.question };
+  // The assistant relays s.question to the owner; her reply loops back via
+  // feedbackService.continueSession until done, then publishSession opens the issue.
+  // (Screenshot + codebase context are attached inside feedbackService — see RFC.)
+  throw new Error('reportPack.reportIssueHandler not implemented (skeleton)');
+}
+
+// Decision needed (see RFC §Reporting): the owner preferred reporting "in one" place.
+// Two ways to deliver that, pick one:
+//  (A) IN-CHAT TOOL (this file): assistant drives the Q&A; screenshot is harder to
+//      attach mid-chat (the chat has no canvas capture) → would need a paste/upload affordance.
+//  (B) BUNDLED BUTTON: a "Report a problem" button inside AskBlossomPanel that opens the
+//      existing FeedbackModal (which already captures a screenshot). Simplest, keeps the
+//      proven screenshot flow, still "one place". RECOMMENDED first step; (A) can follow.
+//
+// When ready (option A), register in index.js, e.g.:
+//   {
+//     name: 'report_issue',
+//     description: 'File a bug report or feature request. Use when the owner describes something broken or ' +
+//       'wishes for a feature ("report a bug: ...", "it would be great if ..."). Starts a short guided report; ' +
+//       'relay any follow-up question back to the owner.',
+//     input_schema: { /* text (required), type */ },
+//     handler: reportIssueHandler,
+//   }

--- a/docs/superpowers/plans/2026-06-30-assistant-extensions-rfc.md
+++ b/docs/superpowers/plans/2026-06-30-assistant-extensions-rfc.md
@@ -1,0 +1,123 @@
+# Ask Blossom — Extensions RFC (connect-the-dots, open-ended, reporting)
+
+**Date:** 2026-06-30 · **Branch:** `feat/assistant-extensions` · **Status:** RFC + skeleton (not wired live)
+
+Goal: evolve Ask Blossom from "answers the questions a tool exists for" into **a flexible,
+smart interface to the database the owner builds with every order** — able to connect the
+dots across entities, search free text, and let her report problems without leaving the chat.
+
+## What's shipped in this branch (real, tested)
+
+1. **Iteration cap 6 → 12** (`ASSISTANT_MAX_ITERATIONS` env-overridable). Multi-tool
+   "connect the dots" answers need several round-trips; 6 was too low and produced the
+   Russian fallback on complex questions.
+2. **Graceful no-coverage prompt.** When no tool fits, the assistant now (a) says plainly
+   it has no dedicated tool, then (b) gives a best-effort interpretation built only on
+   real tool figures, clearly labelled as inference — and is told to combine multiple
+   tools to connect the dots. (The never-invent-numbers rule is preserved.)
+
+## Skeletons in this branch (inert — not in the tool registry)
+
+- `assistantTools/dataQueryPack.js` — flexible structured-query tool (`query_records`) + a
+  `orders_needing_short_stock` composite quick-win.
+- `assistantTools/freeTextPack.js` — open-ended free-text search (`search_text`).
+- `assistantTools/reportPack.js` — `report_issue` handoff to feedbackService.
+
+Each `throw`s "not implemented (skeleton)" so it can't be used until built. None are
+imported into `index.js`, so runtime is unaffected.
+
+---
+
+## Thread 1 — Connect the dots (the big one)
+
+**Problem:** the dashboard filters one entity at a time. The owner wants questions like
+"orders due this week, still unpaid, for VIP customers, that need a flower I'm short on."
+No fixed tool expresses that.
+
+**Three options:**
+
+| Option | Flexibility | Safety | Effort |
+|---|---|---|---|
+| A. Composite tools (one per question) | Low — only what we anticipate | High | Low each, unbounded total |
+| **B. Structured-query tool (`query_records`)** | **High — any allow-listed filter/join/aggregate** | **High — model emits a validated spec, never SQL** | **Medium (build the validator + executor once)** |
+| C. Read-only SQL tool | Highest | **Low — a bad query returns wrong-but-plausible numbers** | Low |
+
+**Recommendation: B**, with one or two **A** composites as quick wins while B is built.
+B keeps the assistant's core guarantee (numbers can't be silently wrong) because the model
+picks from a fixed vocabulary of entities/fields/ops/joins; the backend validates against
+an allow-list and runs a parameterized, read-only, row-capped, timed query. Unknown field →
+rejected, not guessed. **C is explicitly rejected** — it throws away the trustworthiness
+that makes this assistant better than RAG.
+
+**Build order for B:** allow-list SCHEMA (entities the owner should query) → `validateSpec`
+→ Drizzle query builder (filters → ops, predefined joins, group/aggregate) → row cap +
+statement timeout → parity test (a `query_records` spec must equal the equivalent existing
+tool's numbers) + a golden question. Then register in `index.js` with a description that
+tells the model to prefer the dedicated tools and reach for `query_records` only when none fit.
+
+**Open decision:** confirm Option B (vs. just shipping a handful of A composites). I lean B.
+
+---
+
+## Thread 2 — Open-ended / free-text (the RAG-shaped part)
+
+**Problem:** questions over prose the owner typed — card messages, customer requests,
+florist/driver notes. Structured tools can't model text.
+
+**Plan:** `freeTextPack.search_text`. **Phase 1** = Postgres ILIKE / full-text over an
+allow-listed set of text columns; returns snippet + link (no new infra). **Phase 2
+(optional)** = pgvector embeddings for semantic search — true RAG — only if keyword search
+proves too literal. This is exactly the "hybrid: agent for numbers + RAG for free text"
+idea from the earlier discussion.
+
+**Open decision:** Phase 1 keyword first (recommended), or go straight to embeddings?
+
+---
+
+## Thread 3 — Reporting inside the assistant (Haiku + screenshot + codebase)
+
+**Good news:** `feedbackService` **already runs on Claude Haiku** (`claude-haiku-4-5`) and
+already asks one question at a time, stopping once it has enough — so "use Haiku" and "only
+ask if it can't infer" are largely already true. Gaps vs. the request:
+
+1. **Screenshot is attached to the issue but the model never SEES it** (no vision). Fix:
+   pass the screenshot as an image content block to `callAI` so Haiku reads the UI and
+   infers the screen/state instead of asking. Low effort, high value.
+2. **No codebase context.** "Pass the codebase" to Haiku is **not feasible** (context size +
+   cost). Options:
+   - (a) **Per-area context pack** — a static map `appArea → key files/summary`, passed in.
+     Cheap, deterministic, recommended first.
+   - (b) **Repo-map** — file tree + symbol signatures (one generated artifact). Medium.
+   - (c) **Code-RAG** — embed the repo, retrieve files relevant to the report. Most flexible,
+     most infra. (Note: this is RAG again — for code this time.)
+3. **One entry point.** The owner prefers reporting "in one" place. Two ways:
+   - (A) in-chat `report_issue` tool — but the chat can't capture a screenshot easily.
+   - (B) **a "Report a problem" button inside `AskBlossomPanel`** that opens the existing
+     `FeedbackModal` (which already screenshots). Simplest, keeps the proven capture flow,
+     still one place. **Recommended first step**; the in-chat tool can follow.
+
+**Open decisions:** (1) add vision to feedbackService — yes? (2) codebase context = (a)/(b)/(c)?
+(3) reporting entry = button-in-panel (B) or in-chat tool (A)?
+
+---
+
+## Thread 4 — Cap + graceful coverage
+
+Done in this branch (see top). No further decision.
+
+---
+
+## Sequencing proposal
+
+1. **Ship now** (this branch): cap bump + graceful-coverage prompt. Pure win, low risk.
+2. **Next PR:** `search_text` Phase 1 (open-ended) — small, high owner delight.
+3. **Next PR:** reporting button-in-panel (B) + vision in feedbackService — bundles reporting
+   into the assistant, makes reports self-describing from the screenshot.
+4. **Bigger PR:** `query_records` (Option B) — the strategic connect-the-dots layer, with the
+   `orders_needing_short_stock` composite shipped first as an appetizer.
+
+## Decisions needed from the owner
+- Connect-the-dots: confirm **structured-query tool (B)** over composites-only / raw-SQL.
+- Free-text: **keyword first** vs. embeddings now.
+- Reporting: **button-in-panel first** vs. in-chat tool; add screenshot vision (yes); codebase
+  context strategy (per-area pack vs repo-map vs code-RAG).

--- a/docs/superpowers/plans/2026-06-30-assistant-extensions-rfc.md
+++ b/docs/superpowers/plans/2026-06-30-assistant-extensions-rfc.md
@@ -116,8 +116,30 @@ Done in this branch (see top). No further decision.
 4. **Bigger PR:** `query_records` (Option B) — the strategic connect-the-dots layer, with the
    `orders_needing_short_stock` composite shipped first as an appetizer.
 
-## Decisions needed from the owner
-- Connect-the-dots: confirm **structured-query tool (B)** over composites-only / raw-SQL.
-- Free-text: **keyword first** vs. embeddings now.
-- Reporting: **button-in-panel first** vs. in-chat tool; add screenshot vision (yes); codebase
-  context strategy (per-area pack vs repo-map vs code-RAG).
+## Decisions (locked 2026-06-30, owner)
+- **Connect-the-dots:** structured-query tool (Option B). ✅
+- **Free-text:** keyword (Phase 1) now; semantic/embeddings as a fast-follow quality upgrade
+  (cheap — small corpus, embeddings are a separate non-LLM endpoint, add ~0 assistant tokens).
+- **Reporting entry:** button in the assistant panel that opens the existing screenshot flow. ✅
+- **Report codebase context:** per-area context pack **and** code-RAG. Per-area pack + screenshot
+  vision ship with the reporting task; **code-RAG + auto-refresh-on-code-change is split into its
+  own issue** (#457) but the context-provider seam is designed so RAG plugs in without rework.
+
+## Cost & model (owner raised token cost)
+- **Do NOT power the assistant via `claude -p` (subscription).** Per-query CLI spawn + harness boot
+  is too slow for a simple question, isn't built for server concurrency, and subscription auth isn't
+  the supported path for serving app users. Keep the Anthropic API.
+- **Prompt caching (high ROI, easy):** the system prompt + 20 tool defs are large + identical every
+  turn → mark cacheable (`cache_control`) to cut repeat input cost ~90%. Do this on the live assistant.
+- **Model routing:** Haiku for simple/single-tool questions, Sonnet for hard multi-tool reasoning
+  (`ASSISTANT_MODEL` already exists). With caching + Haiku-default, monthly cost for one owner is a few $.
+- **Embeddings cost (if/when semantic free-text):** separate cheap endpoint, not Sonnet/Haiku tokens;
+  small corpus → negligible.
+
+## Sequencing (updated)
+1. **Shipped (this branch):** cap bump + graceful coverage.
+2. **Cost PR (do next, applies to live assistant):** prompt caching + optional Haiku-for-simple routing.
+3. **Reporting PR:** button-in-panel + screenshot vision + per-area context pack (seam for code-RAG).
+4. **Free-text PR:** `search_text` keyword Phase 1.
+5. **Connect-the-dots PR:** `query_records` (Option B), `orders_needing_short_stock` composite first.
+6. **Separate issue:** code-RAG index + scheduled auto-refresh on code change (feeds the report assistant; could later also power a code-aware dev assistant).


### PR DESCRIPTION
## Ask Blossom — extensions: cap bump + graceful coverage (shippable) + RFC/skeletons

Two small **shippable** assistant improvements, plus **inert skeletons + an RFC** for the bigger extensions (connect-the-dots, open-ended search, in-chat reporting). The skeletons are not registered in the tool registry — runtime is unchanged until each is built + tested.

### Shippable now
- **Iteration cap 6 → 12** (`ASSISTANT_MAX_ITERATIONS` env-overridable). Multi-tool "connect the dots" answers need more round-trips; 6 produced the fallback message on complex questions. (`assistantService.js`)
- **Graceful no-coverage.** When no tool fits, the assistant now says plainly it has no dedicated tool, then gives a best-effort interpretation built only on real tool figures (clearly labelled as inference) — and is told to combine multiple tools to connect the dots. Never-invent-numbers rule preserved. (`assistantService.js` system prompt)

### Skeletons (inert — `throw` until built; not in `index.js`)
- `assistantTools/dataQueryPack.js` — `query_records`: flexible structured-query tool. Model composes a **declarative spec** (never SQL); backend validates against an allow-list of entities/fields/joins/ops and runs a parameterized, read-only, row-capped query. Plus an `orders_needing_short_stock` composite quick-win.
- `assistantTools/freeTextPack.js` — `search_text`: open-ended search over free-text fields (card messages, requests, notes). Phase 1 = Postgres keyword search; Phase 2 = pgvector (optional).
- `assistantTools/reportPack.js` — `report_issue`: hand-off to the existing (already Haiku-backed) feedbackService so bug/feature reports can start inside the chat.

### RFC
`docs/superpowers/plans/2026-06-30-assistant-extensions-rfc.md` — the four threads, the design forks (structured-query vs composites vs raw-SQL; keyword vs embeddings; reporting button vs in-chat tool; codebase-context strategy), and a sequencing proposal. **Decisions needed before building the skeletons out.**

Notable finding: feedbackService **already uses Claude Haiku** (the requested model). Gaps for "understand the screenshot / pass the codebase": the screenshot is attached to the issue but not shown to the model (add vision — easy); full codebase to Haiku is infeasible (use a per-area context pack or code-RAG — RFC §Reporting).

### Verification
Backend assistant tests green (cap test made cap-agnostic). Full backend suite run; skeletons imported nowhere so they can't affect runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
