### PR TITLE
feat(assistant): search_text — open-ended free-text search

### DIFF
--- a/backend/src/__tests__/assistantTools.freeTextPack.integration.test.js
+++ b/backend/src/__tests__/assistantTools.freeTextPack.integration.test.js
@@ -1,0 +1,260 @@
+// backend/src/__tests__/assistantTools.freeTextPack.integration.test.js
+//
+// Integration tests for freeTextPack.searchTextHandler against a real pglite
+// in-memory Postgres. Follows the same pattern as assistantTools.ordersPack.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import { orders } from '../db/schema.js';
+
+const dbHolder = { db: null };
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+import { searchTextHandler } from '../services/assistantTools/freeTextPack.js';
+
+// Shared test fixture — seeded once per describe block via beforeEach.
+const SEED_ROWS = [
+  // Order 1: unique phrase in customer_request
+  {
+    appOrderId:      'FT-1',
+    customerId:      'cust-test',
+    orderDate:       '2026-06-10',
+    requiredBy:      '2026-06-11',
+    deliveryType:    'Delivery',
+    customerRequest: 'Please wrap with blue hydrangeas and a satin ribbon',
+    floristNote:     null,
+    greetingCardText: null,
+  },
+  // Order 2: phrase in florist_note
+  {
+    appOrderId:      'FT-2',
+    customerId:      'cust-test',
+    orderDate:       '2026-06-12',
+    requiredBy:      '2026-06-13',
+    deliveryType:    'Pickup',
+    customerRequest: null,
+    floristNote:     'Customer mentioned wedding anniversary — add extra greenery',
+    greetingCardText: null,
+  },
+  // Order 3: phrase in greeting_card_text (the "card message" field)
+  {
+    appOrderId:      'FT-3',
+    customerId:      'cust-test',
+    orderDate:       '2026-06-14',
+    requiredBy:      '2026-06-14',
+    deliveryType:    'Delivery',
+    customerRequest: null,
+    floristNote:     null,
+    greetingCardText: 'Happy wedding anniversary to my wonderful wife',
+  },
+  // Order 4: no free-text at all — should never appear in results
+  {
+    appOrderId:      'FT-4',
+    customerId:      'cust-test',
+    orderDate:       '2026-06-15',
+    requiredBy:      '2026-06-16',
+    deliveryType:    'Delivery',
+    customerRequest: null,
+    floristNote:     null,
+    greetingCardText: null,
+  },
+  // Order 5: matches in TWO columns (both customer_request and florist_note)
+  {
+    appOrderId:      'FT-5',
+    customerId:      'cust-test',
+    orderDate:       '2026-06-16',
+    requiredBy:      '2026-06-17',
+    deliveryType:    'Delivery',
+    customerRequest: 'wedding flowers please',
+    floristNote:     'confirmed: wedding bouquet',
+    greetingCardText: null,
+  },
+];
+
+let harness;
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+  await harness.db.insert(orders).values(SEED_ROWS);
+});
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+describe('freeTextPack.searchTextHandler — basic keyword search', () => {
+  it('finds an order by customer_request text', async () => {
+    const r = await searchTextHandler({ query: 'blue hydrangeas' });
+    expect(r.matchedCount).toBeGreaterThanOrEqual(1);
+    const match = r.results.find(x => x.appOrderId === 'FT-1');
+    expect(match).toBeDefined();
+    expect(match.entity).toBe('order');
+    expect(match.field).toBe('Customer request');
+    expect(match.snippet).toContain('blue hydrangeas');
+    expect(match.link).toMatch(/\/orders\//);
+  });
+
+  it('finds an order by florist_note text', async () => {
+    const r = await searchTextHandler({ query: 'extra greenery' });
+    const match = r.results.find(x => x.appOrderId === 'FT-2');
+    expect(match).toBeDefined();
+    expect(match.field).toBe('Florist note');
+    expect(match.snippet).toContain('extra greenery');
+  });
+
+  it('finds an order by greeting_card_text (card message)', async () => {
+    const r = await searchTextHandler({ query: 'wonderful wife' });
+    const match = r.results.find(x => x.appOrderId === 'FT-3');
+    expect(match).toBeDefined();
+    expect(match.field).toBe('Card message');
+    expect(match.snippet).toContain('wonderful wife');
+  });
+
+  it('returns multiple results when the query matches across different columns of the same order', async () => {
+    const r = await searchTextHandler({ query: 'wedding' });
+    // FT-2 (florist_note), FT-3 (greetingCardText), FT-5 (customerRequest + floristNote) should all match
+    const ft5Entries = r.results.filter(x => x.appOrderId === 'FT-5');
+    // FT-5 has "wedding" in BOTH customerRequest and floristNote → two entries
+    expect(ft5Entries.length).toBe(2);
+    const fields = ft5Entries.map(x => x.field).sort();
+    expect(fields).toContain('Customer request');
+    expect(fields).toContain('Florist note');
+  });
+
+  it('does not return orders with no matching text', async () => {
+    const r = await searchTextHandler({ query: 'blue hydrangeas' });
+    const noMatch = r.results.find(x => x.appOrderId === 'FT-4');
+    expect(noMatch).toBeUndefined();
+  });
+
+  it('is case-insensitive', async () => {
+    const lower = await searchTextHandler({ query: 'hydrangeas' });
+    const upper = await searchTextHandler({ query: 'HYDRANGEAS' });
+    expect(lower.matchedCount).toBe(upper.matchedCount);
+  });
+});
+
+describe('freeTextPack.searchTextHandler — snippet shape', () => {
+  it('snippet contains the query text', async () => {
+    const r = await searchTextHandler({ query: 'satin ribbon' });
+    expect(r.results.length).toBeGreaterThan(0);
+    expect(r.results[0].snippet).toContain('satin ribbon');
+  });
+
+  it('snippet is shorter than the full field text for long fields', async () => {
+    // FT-1 customerRequest is 51 chars — short enough that snippet == full text (no ellipsis needed)
+    // This test just verifies snippet is present and non-empty
+    const r = await searchTextHandler({ query: 'satin ribbon' });
+    expect(r.results[0].snippet.length).toBeGreaterThan(0);
+  });
+});
+
+describe('freeTextPack.searchTextHandler — link format', () => {
+  it('builds a /orders/<id> link', async () => {
+    const r = await searchTextHandler({ query: 'blue hydrangeas' });
+    const match = r.results.find(x => x.appOrderId === 'FT-1');
+    expect(match.link).toMatch(/^\/orders\/.+/);
+  });
+});
+
+describe('freeTextPack.searchTextHandler — scope filter', () => {
+  it('scope=orders returns order results', async () => {
+    const r = await searchTextHandler({ query: 'wedding', scope: 'orders' });
+    expect(r.scope).toBe('orders');
+    expect(r.results.length).toBeGreaterThan(0);
+    r.results.forEach(x => expect(x.entity).toBe('order'));
+  });
+
+  it('scope=customers returns empty (no notes column in Phase 5 schema)', async () => {
+    const r = await searchTextHandler({ query: 'wedding', scope: 'customers' });
+    expect(r.scope).toBe('customers');
+    expect(r.results).toHaveLength(0);
+    expect(r.matchedCount).toBe(0);
+  });
+
+  it('scope=all covers orders', async () => {
+    const r = await searchTextHandler({ query: 'wedding', scope: 'all' });
+    expect(r.scope).toBe('all');
+    expect(r.results.length).toBeGreaterThan(0);
+  });
+
+  it('invalid scope falls back to all', async () => {
+    const r = await searchTextHandler({ query: 'wedding', scope: 'bogus' });
+    expect(r.scope).toBe('all');
+    expect(r.results.length).toBeGreaterThan(0);
+  });
+});
+
+describe('freeTextPack.searchTextHandler — limit / cap', () => {
+  beforeEach(async () => {
+    // Insert 20 more orders all matching "cappedphrase" to test cap
+    const bulk = Array.from({ length: 20 }, (_, i) => ({
+      appOrderId:      `CAP-${i}`,
+      customerId:      'cust-test',
+      orderDate:       '2026-05-01',
+      deliveryType:    'Delivery',
+      customerRequest: `order with cappedphrase number ${i}`,
+    }));
+    await harness.db.insert(orders).values(bulk);
+  });
+
+  it('respects a low limit and sets truncated=true when more results exist', async () => {
+    const r = await searchTextHandler({ query: 'cappedphrase', limit: 5 });
+    expect(r.truncated).toBe(true);
+    // results may exceed limit because each row can produce multiple field entries,
+    // but the number of ROWS fetched from DB is capped
+    expect(r.results.length).toBeLessThanOrEqual(5 * 3); // at most 3 fields per row
+  });
+
+  it('does not exceed MAX_LIMIT (50) even with a huge limit param', async () => {
+    const r = await searchTextHandler({ query: 'cappedphrase', limit: 999 });
+    // 20 rows × 1 matching field each — stays under cap
+    expect(r.results.length).toBeLessThanOrEqual(50 * 3);
+  });
+});
+
+describe('freeTextPack.searchTextHandler — empty / missing query', () => {
+  it('empty string query returns empty results with no error', async () => {
+    const r = await searchTextHandler({ query: '' });
+    expect(r.matchedCount).toBe(0);
+    expect(r.results).toHaveLength(0);
+    expect(r.truncated).toBe(false);
+  });
+
+  it('whitespace-only query returns empty results', async () => {
+    const r = await searchTextHandler({ query: '   ' });
+    expect(r.matchedCount).toBe(0);
+    expect(r.results).toHaveLength(0);
+  });
+
+  it('omitted query returns empty results', async () => {
+    const r = await searchTextHandler({});
+    expect(r.matchedCount).toBe(0);
+  });
+
+  it('no match query returns empty results', async () => {
+    const r = await searchTextHandler({ query: 'zzznomatchxxx' });
+    expect(r.matchedCount).toBe(0);
+    expect(r.results).toHaveLength(0);
+  });
+});
+
+describe('freeTextPack.searchTextHandler — response shape', () => {
+  it('result object carries required fields', async () => {
+    const r = await searchTextHandler({ query: 'blue hydrangeas' });
+    expect(r).toHaveProperty('query', 'blue hydrangeas');
+    expect(r).toHaveProperty('scope');
+    expect(r).toHaveProperty('matchedCount');
+    expect(r).toHaveProperty('truncated');
+    expect(r).toHaveProperty('results');
+    const item = r.results[0];
+    expect(item).toHaveProperty('entity');
+    expect(item).toHaveProperty('id');
+    expect(item).toHaveProperty('field');
+    expect(item).toHaveProperty('snippet');
+    expect(item).toHaveProperty('link');
+  });
+});

--- a/backend/src/repos/orderRepo.js
+++ b/backend/src/repos/orderRepo.js
@@ -17,7 +17,7 @@ import { orders, orderLines, deliveries, stock, auditLog } from '../db/schema.js
 import { recordAudit } from '../db/audit.js';
 import { ORDER_STATUS, DELIVERY_STATUS, PAYMENT_STATUS } from '../constants/statuses.js';
 import { getStockYModelEnabled } from '../services/configService.js';
-import { and, or, eq, isNull, inArray, gte, lte, sql, desc, asc } from 'drizzle-orm';
+import { and, or, eq, isNull, inArray, gte, lte, sql, desc, asc, ilike } from 'drizzle-orm';
 
 // ── Backend mode stub ──
 // getBackendMode is always 'postgres' post-Phase-7. Kept until Tasks 3+4
@@ -1546,6 +1546,39 @@ export async function getLinesForOrders(orderIds) {
       inArray(orderLines.orderId, orderIds),
     ));
   return rows;
+}
+
+// ── Free-text search for the Ask Blossom assistant ──
+//
+// Returns raw PG rows (minimal columns) whose allow-listed text columns
+// ILIKE the given query. The pack handler computes snippets and shapes the
+// result; the repo stays thin. `limit` controls the DB row cap — not the
+// final result count (one row can match multiple columns).
+export async function searchFreeText({ query, limit = 15 }) {
+  if (!db || !query) return [];
+  const pattern = `%${query}%`;
+  return db
+    .select({
+      id:               orders.id,
+      airtableId:       orders.airtableId,
+      appOrderId:       orders.appOrderId,
+      orderDate:        orders.orderDate,
+      status:           orders.status,
+      customerRequest:  orders.customerRequest,
+      floristNote:      orders.floristNote,
+      greetingCardText: orders.greetingCardText,
+    })
+    .from(orders)
+    .where(and(
+      isNull(orders.deletedAt),
+      or(
+        ilike(orders.customerRequest,  pattern),
+        ilike(orders.floristNote,      pattern),
+        ilike(orders.greetingCardText, pattern),
+      )
+    ))
+    .orderBy(desc(orders.orderDate))
+    .limit(limit);
 }
 
 // ── Internal exports for tests ──

--- a/backend/src/services/assistantTools/freeTextPack.js
+++ b/backend/src/services/assistantTools/freeTextPack.js
@@ -1,46 +1,49 @@
 // backend/src/services/assistantTools/freeTextPack.js
 //
-// ┌─────────────────────────────────────────────────────────────────────────┐
-// │ SKELETON — NOT REGISTERED in index.js yet. Inert until wired + tested.    │
-// └─────────────────────────────────────────────────────────────────────────┘
+// Open-ended free-text search across allow-listed prose fields on orders.
 //
-// The open-ended / unstructured layer. The 20 structured tools answer "what are my
-// numbers"; this answers questions over FREE TEXT the owner typed into records —
-// card messages, customer requests, florist/driver notes, customer notes. These are
-// prose, not aggregates, so a structured tool can't model them.
+// Phase 1: Postgres ILIKE keyword search — zero new infra.
+//   Searches customer_request / florist_note / greeting_card_text on orders.
+//   Returns a snippet around the match + a link to open the record.
+//   The model summarises; it never invents text not present in a snippet.
 //
-// PHASE 1 (this skeleton): Postgres substring / full-text search — zero new infra.
-//   ILIKE '%query%' (or to_tsvector/plainto_tsquery) across an allow-listed set of
-//   text columns; return a snippet + the record to open. Good for "find the order
-//   where the customer asked for blue hydrangeas", "which orders mention a wedding".
+// Phase 2 (optional): pgvector semantic search if keyword search proves too
+//   literal. See RFC: docs/superpowers/plans/2026-06-30-assistant-extensions-rfc.md
 //
-// PHASE 2 (optional, see RFC): semantic search via pgvector embeddings — true RAG.
-//   Embed the text fields, retrieve by cosine similarity for fuzzy/conceptual queries
-//   ("complaints about late delivery"). Only worth it if Phase-1 keyword search proves
-//   too literal. Adds an embedding pipeline + an index to maintain.
-//
-// See RFC: docs/superpowers/plans/2026-06-30-assistant-extensions-rfc.md
+// CUSTOMERS NOTE: the customers table (Phase 5) has no free-text notes column.
+//   When one lands (e.g. a `notes` column), add a customerRepo.searchNotes call
+//   here and uncomment the customers entry in TEXT_FIELDS.
 
-// import { db } from '../../db/index.js';
-// import { sql } from 'drizzle-orm';
+import * as orderRepo from '../../repos/orderRepo.js';
 
 const SNIPPET_RADIUS = 80;  // chars of context around the match
-const DEFAULT_LIMIT = 15;
-const MAX_LIMIT = 50;
+const DEFAULT_LIMIT  = 15;
+const MAX_LIMIT      = 50;
 
-// Allow-listed free-text fields per scope. Only these columns are ever searched —
-// keeps the tool away from structured/sensitive columns.
+// Allow-listed free-text fields per scope. Only these columns are ever searched.
+// Must match columns that ACTUALLY exist in backend/src/db/schema.js.
 const TEXT_FIELDS = {
   orders: [
-    { col: 'customer_request', label: 'Customer request' },
-    { col: 'card_message',     label: 'Card message' },
-    { col: 'florist_note',     label: 'Florist note' },
-    { col: 'driver_note',      label: 'Driver note' },
+    { col: 'customerRequest',  label: 'Customer request' },
+    { col: 'floristNote',      label: 'Florist note'     },
+    { col: 'greetingCardText', label: 'Card message'     },
   ],
-  customers: [
-    { col: 'notes', label: 'Customer notes' },
-  ],
+  // customers: (no notes column in Phase 5 schema — add here when it lands)
 };
+
+/**
+ * Extract a short snippet around the first occurrence of `query` in `text`.
+ * Adds ellipsis when the snippet doesn't start/end at the string boundaries.
+ */
+function makeSnippet(text, query, radius = SNIPPET_RADIUS) {
+  const idx = text.toLowerCase().indexOf(query.toLowerCase());
+  if (idx === -1) return text.slice(0, radius * 2);
+  const start  = Math.max(0, idx - radius);
+  const end    = Math.min(text.length, idx + query.length + radius);
+  const prefix = start > 0 ? '…' : '';
+  const suffix = end < text.length ? '…' : '';
+  return prefix + text.slice(start, end) + suffix;
+}
 
 /**
  * search_text — keyword search across allow-listed free-text fields.
@@ -52,27 +55,66 @@ const TEXT_FIELDS = {
  * }} input
  * @returns {Promise<{
  *   query: string, scope: string, matchedCount: number, truncated: boolean,
- *   results: Array<{ entity:string, id:string, field:string, snippet:string, link:string }>,
+ *   results: Array<{ entity:string, id:string, appOrderId?:string, field:string, snippet:string, link:string }>,
  * }>}
  */
-export async function searchTextHandler(/* input */) {
-  // 1. Resolve scopes → the TEXT_FIELDS columns to search.
-  // 2. For each column: WHERE <col> ILIKE '%' || :query || '%' (parameterized),
-  //    select id + a snippet (substring around the match) + build a link (/orders/:id etc).
-  //    Run as one UNION-style pass or per-column queries; cap at min(limit, MAX_LIMIT).
-  // 3. return { query, scope, matchedCount, truncated, results }.
-  // NOTE: this returns WHERE the text was found + a snippet — the model then summarizes;
-  //       it never fabricates content not present in a snippet.
-  throw new Error('freeTextPack.searchTextHandler not implemented (skeleton)');
-}
+export async function searchTextHandler({ query, scope, limit } = {}) {
+  const q = (query ?? '').trim();
 
-// When ready, register in index.js, e.g.:
-//   {
-//     name: 'search_text',
-//     description: 'Search the free-text the owner/florists/drivers typed on records — card messages, ' +
-//       'customer requests, florist/driver notes, customer notes. Use for "find the order that mentions X", ' +
-//       '"which customers asked about weddings", "any notes about late delivery". Returns matching snippets + ' +
-//       'the record to open; it does not invent text that is not in a snippet.',
-//     input_schema: { /* query (required), scope, limit */ },
-//     handler: searchTextHandler,
-//   }
+  // Empty query → empty result (no error).
+  if (!q) {
+    return { query: q, scope: scope ?? 'all', matchedCount: 0, truncated: false, results: [] };
+  }
+
+  const normalizedScope = ['orders', 'customers', 'all'].includes(scope) ? scope : 'all';
+  const cap = Math.min(limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+
+  const results = [];
+
+  // ── Orders scope ──
+  if (normalizedScope === 'orders' || normalizedScope === 'all') {
+    // Fetch cap+1 rows so we can detect whether there are more results in the DB.
+    const rows = await orderRepo.searchFreeText({ query: q, limit: cap + 1 });
+    const truncated = rows.length > cap;
+    const sliced = truncated ? rows.slice(0, cap) : rows;
+
+    for (const row of sliced) {
+      const orderId = row.airtableId || row.id;
+      for (const { col, label } of TEXT_FIELDS.orders) {
+        const text = row[col];
+        if (text && text.toLowerCase().includes(q.toLowerCase())) {
+          results.push({
+            entity:     'order',
+            id:         orderId,
+            appOrderId: row.appOrderId,
+            field:      label,
+            snippet:    makeSnippet(text, q),
+            link:       `/orders/${orderId}`,
+          });
+        }
+      }
+    }
+
+    if (truncated) {
+      return {
+        query: q,
+        scope: normalizedScope,
+        matchedCount: results.length,
+        truncated: true,
+        results,
+      };
+    }
+  }
+
+  // ── Customers scope ──
+  // No free-text notes column in Phase 5 — always returns empty.
+  // Future: add customerRepo.searchNotes({ query: q, limit: cap }) here.
+
+  return {
+    query:        q,
+    scope:        normalizedScope,
+    matchedCount: results.length,
+    truncated:    false,
+    results,
+  };
+}

--- a/backend/src/services/assistantTools/index.js
+++ b/backend/src/services/assistantTools/index.js
@@ -12,6 +12,7 @@ import { supplierScorecardHandler } from './supplierPack.js';
 import { marketingSpendHandler } from './marketingPack.js';
 import { stockVelocityHandler } from './velocityPack.js';
 import { lapsedCustomersHandler, upcomingOccasionsHandler } from './crmPack.js';
+import { searchTextHandler } from './freeTextPack.js';
 
 // Each pack pushes { name, description, input_schema, handler }. Adding a domain = add a file + import + push here.
 export const TOOLS = [
@@ -284,6 +285,36 @@ export const TOOLS = [
       },
     },
     handler: upcomingOccasionsHandler,
+  },
+  {
+    name: 'search_text',
+    description:
+      'Search the free-text the owner/florists typed on records — card messages, ' +
+      'customer requests, and florist notes. Use for "find the order that mentions X", ' +
+      '"which orders talk about a wedding", "any order where the customer asked for blue hydrangeas", ' +
+      '"find all notes about late delivery". Returns matching snippets + the record to open; ' +
+      'it does not invent text that is not in a snippet. ' +
+      'scope="orders" (default "all") to restrict to orders.',
+    input_schema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Word or phrase to search for (case-insensitive substring match).',
+        },
+        scope: {
+          type: 'string',
+          enum: ['orders', 'customers', 'all'],
+          description: "Which records to search. 'orders' (default) searches order free-text fields. 'customers' has no text fields yet. 'all' covers both.",
+        },
+        limit: {
+          type: 'number',
+          description: `Max order rows to inspect (default ${15}, max ${50}).`,
+        },
+      },
+      required: ['query'],
+    },
+    handler: searchTextHandler,
   },
 ];
 


### PR DESCRIPTION
## What

Adds **`search_text`** as the 21st Ask Blossom tool — keyword search across the prose the owner/florists typed on order records (customer requests, florist notes, card messages). Phase 1 = Postgres ILIKE, zero new infrastructure.

## Changes

- `backend/src/repos/orderRepo.js` — new `searchFreeText({ query, limit })`: ILIKE across `customer_request` / `florist_note` / `greeting_card_text`, returns minimal projection, ordered by `order_date DESC`.
- `backend/src/services/assistantTools/freeTextPack.js` — `searchTextHandler({ query, scope, limit })`: calls the repo, expands each matched row to one result entry per matched column, extracts an 80-char snippet around the hit, builds a `/orders/:id` link. Scope `orders|customers|all`; cap `DEFAULT_LIMIT=15`, `MAX_LIMIT=50`. Empty/whitespace query → empty result, no error.
- `backend/src/services/assistantTools/index.js` — imports + registers `search_text`.
- `backend/src/__tests__/assistantTools.freeTextPack.integration.test.js` — 20 pglite integration tests.

## Columns searched

Schema cross-checked: `driver_note` and `card_message` from the skeleton **do not exist** on `orders`. Actual columns: `customer_request`, `florist_note`, `greeting_card_text` (relabelled "Card message"). Customers table has no notes column in Phase 5 — `scope=customers` returns empty with a clear comment for when one lands.

## Tests

754 backend tests pass (87 files). New suite: 20 tests covering all three field hits, multi-column matches per row, case-insensitivity, snippet shape, scope filter, limit/truncation, empty/no-match, response shape.

## Docs

CHANGELOG + CLAUDE.md tool-pack description update follow as a separate doc commit per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)