### PR TITLE
feat(assistant): report a problem from the chat + screenshot vision + per-area context

### DIFF
--- a/apps/dashboard/src/pages/DashboardPage.jsx
+++ b/apps/dashboard/src/pages/DashboardPage.jsx
@@ -218,7 +218,7 @@ export default function DashboardPage() {
           onClose={() => setReportOpen(false)}
         />
       )}
-      <AskBlossomLauncher t={t} />
+      <AskBlossomLauncher t={t} reporterRole="owner" reporterName="Owner" appArea="dashboard" />
     </div>
   );
 }

--- a/apps/dashboard/src/translations.js
+++ b/apps/dashboard/src/translations.js
@@ -1140,6 +1140,7 @@ const en = {
   assistantRename:      'Rename',
   assistantDelete:      'Delete',
   assistantDeleteConfirm: 'Delete?',
+  assistantReport:      'Report a problem',
   assistantStarters: [
     'Orders today',
     'Revenue this month',
@@ -2291,6 +2292,7 @@ const ru = {
   assistantRename:      'Переименовать',
   assistantDelete:      'Удалить',
   assistantDeleteConfirm: 'Удалить?',
+  assistantReport:      'Сообщить о проблеме',
   assistantStarters: [
     'Заказы сегодня',
     'Выручка в этом месяце',

--- a/apps/florist/src/App.jsx
+++ b/apps/florist/src/App.jsx
@@ -60,7 +60,8 @@ function OwnerRoute({ children }) {
 // Layout — wraps authenticated pages with the bottom tab bar.
 // Like mounting the factory floor signage above every workstation.
 function Layout({ children }) {
-  const { role } = useAuth();
+  const { role, driverName } = useAuth();
+  const reporterName = driverName || (role === 'owner' ? 'Owner' : 'Florist');
   return (
     <>
       {children}
@@ -68,7 +69,15 @@ function Layout({ children }) {
       {/* bottom-36 (not bottom-20): the OrderListPage "Новый заказ" FAB sits at
           bottom-20 right-5 z-50 and would paint over the assistant FAB (z-40) on
           /orders. Stack the assistant above it so both stay tappable. */}
-      {role === 'owner' && <AskBlossomLauncher t={t} fabClassName="bottom-36 right-4" />}
+      {role === 'owner' && (
+        <AskBlossomLauncher
+          t={t}
+          fabClassName="bottom-36 right-4"
+          reporterRole={role}
+          reporterName={reporterName}
+          appArea="florist"
+        />
+      )}
     </>
   );
 }

--- a/apps/florist/src/translations.js
+++ b/apps/florist/src/translations.js
@@ -549,6 +549,7 @@ const en = {
   assistantRename:        'Rename',
   assistantDelete:        'Delete',
   assistantDeleteConfirm: 'Delete?',
+  assistantReport:        'Report a problem',
   assistantStarters: [
     'Orders today',
     'Revenue this month',
@@ -1438,6 +1439,7 @@ const ru = {
   assistantRename:        'Переименовать',
   assistantDelete:        'Удалить',
   assistantDeleteConfirm: 'Удалить?',
+  assistantReport:        'Сообщить о проблеме',
   assistantStarters: [
     'Заказы сегодня',
     'Выручка в этом месяце',

--- a/backend/src/__tests__/feedbackContext.test.js
+++ b/backend/src/__tests__/feedbackContext.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { getAreaContext } from '../services/feedbackContext.js';
+
+describe('getAreaContext', () => {
+  it('returns dashboard context for "dashboard"', () => {
+    const ctx = getAreaContext('dashboard');
+    expect(ctx).toContain('Dashboard');
+    expect(ctx.length).toBeGreaterThan(20);
+  });
+
+  it('returns florist context for "florist"', () => {
+    const ctx = getAreaContext('florist');
+    expect(ctx).toContain('Florist');
+    expect(ctx.length).toBeGreaterThan(20);
+  });
+
+  it('returns delivery context for "delivery"', () => {
+    const ctx = getAreaContext('delivery');
+    expect(ctx).toContain('Delivery');
+    expect(ctx.length).toBeGreaterThan(20);
+  });
+
+  it('returns fallback for unknown area', () => {
+    const ctx = getAreaContext('unknown');
+    expect(ctx.length).toBeGreaterThan(0);
+  });
+
+  it('returns fallback for null', () => {
+    const ctx = getAreaContext(null);
+    expect(ctx.length).toBeGreaterThan(0);
+  });
+
+  it('returns fallback for undefined', () => {
+    const ctx = getAreaContext(undefined);
+    expect(ctx.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/src/__tests__/feedbackService.test.js
+++ b/backend/src/__tests__/feedbackService.test.js
@@ -31,6 +31,9 @@ vi.mock('../db/index.js', () => ({
   },
 }));
 vi.mock('../db/schema.js', () => ({ feedbackReports: {}, feedbackSessions: {} }));
+vi.mock('../services/feedbackContext.js', () => ({
+  getAreaContext: (appArea) => `context-for-${appArea ?? 'unknown'}`,
+}));
 
 global.fetch = vi.fn();
 process.env.GITHUB_TOKEN = 'test-token';
@@ -61,6 +64,7 @@ function questionResponse(question) {
 // ── Imports ───────────────────────────────────────────────────────────────────
 
 import { startSession, publishSession, continueSession, previewSession, sessions } from '../services/feedbackService.js';
+import { getAreaContext } from '../services/feedbackContext.js';
 import { db } from '../db/index.js';
 
 // ── Setup ─────────────────────────────────────────────────────────────────────
@@ -323,5 +327,75 @@ describe('publishSession', () => {
     const result = await publishSession(sessionId, Buffer.from('img'), 'test.png');
 
     expect(result.issueNumber).toBe(100); // issue still created
+  });
+});
+
+// ── startSession with image (Part B — screenshot vision) ─────────────────────
+
+describe('startSession — screenshot vision', () => {
+  it('sends image content block to Haiku when image is provided', async () => {
+    await startSession({
+      text: 'кнопка не работает',
+      reporterRole: 'owner',
+      reporterName: 'Owner',
+      image: { dataBase64: 'abc123', mediaType: 'image/jpeg' },
+    });
+
+    const callArgs = mockCreate.mock.calls[0][0];
+    const firstMsg = callArgs.messages[0];
+    expect(Array.isArray(firstMsg.content)).toBe(true);
+    expect(firstMsg.content).toContainEqual({ type: 'text', text: 'кнопка не работает' });
+    expect(firstMsg.content).toContainEqual({
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/jpeg', data: 'abc123' },
+    });
+  });
+
+  it('sends text-only message when no image is provided (existing behavior preserved)', async () => {
+    await startSession({
+      text: 'кнопка не работает',
+      reporterRole: 'florist',
+      reporterName: 'Анна',
+    });
+
+    const callArgs = mockCreate.mock.calls[0][0];
+    const firstMsg = callArgs.messages[0];
+    expect(firstMsg.content).toBe('кнопка не работает');
+  });
+
+  it('does not persist image data in the stored session messages', async () => {
+    const { sessionId } = await startSession({
+      text: 'кнопка не работает',
+      reporterRole: 'owner',
+      reporterName: 'Owner',
+      image: { dataBase64: 'bigbase64data', mediaType: 'image/png' },
+    });
+
+    const session = sessions.get(sessionId);
+    expect(session.messages[0].content).toBe('кнопка не работает');
+  });
+});
+
+// Note: getAreaContext unit tests live in feedbackContext.test.js (tested against the real module).
+
+describe('startSession — per-area context in system prompt', () => {
+  it('includes getAreaContext output in the system prompt sent to Haiku', async () => {
+    await startSession({
+      text: 'test',
+      reporterRole: 'owner',
+      reporterName: 'Owner',
+      appArea: 'dashboard',
+    });
+
+    const callArgs = mockCreate.mock.calls[0][0];
+    // The mock returns "context-for-dashboard" for appArea='dashboard'
+    expect(callArgs.system).toContain('context-for-dashboard');
+  });
+
+  it('includes fallback context when appArea is not provided', async () => {
+    await startSession({ text: 'test', reporterRole: 'owner', reporterName: 'Owner' });
+
+    const callArgs = mockCreate.mock.calls[0][0];
+    expect(callArgs.system).toContain('context-for-unknown');
   });
 });

--- a/backend/src/routes/feedback.js
+++ b/backend/src/routes/feedback.js
@@ -18,14 +18,16 @@ const upload = multer({
 router.use(authorize('feedback'));
 
 // POST /feedback/start — begin a Report session
+// Accepts optional `image: { dataBase64, mediaType }` (JSON, client-resized) so Haiku
+// gets vision context and asks fewer questions. image is not persisted to the session row.
 router.post('/start', async (req, res) => {
   try {
-    const { text, appArea, reporterRole, reporterName } = req.body;
+    const { text, appArea, reporterRole, reporterName, image } = req.body;
     if (!text?.trim()) return res.status(400).json({ error: 'text is required' });
     if (!reporterRole) return res.status(400).json({ error: 'reporterRole is required' });
     if (!reporterName) return res.status(400).json({ error: 'reporterName is required' });
 
-    const result = await feedbackService.startSession({ text, appArea, reporterRole, reporterName });
+    const result = await feedbackService.startSession({ text, appArea, reporterRole, reporterName, image: image || null });
     res.json(result);
   } catch (err) {
     console.error('[FEEDBACK] start error:', err);

--- a/backend/src/services/feedbackContext.js
+++ b/backend/src/services/feedbackContext.js
@@ -1,0 +1,38 @@
+// backend/src/services/feedbackContext.js
+//
+// Static per-area context pack for the feedback assistant.
+// Gives Haiku a short domain summary so it can infer the screen and terminology
+// instead of asking the reporter. Code-RAG (issue #457) is the deeper version —
+// the seam is designed so RAG plugs in here without rework.
+
+const AREA_CONTEXTS = {
+  dashboard: `App: Dashboard (desktop, owner-only).
+Key screens: Today (Kanban board), Orders (list + column filters + inline edit + margin %), New Order (4-step wizard), Stock (inventory + Variety view), Customers (CRM + RFM), Financial (analytics, Recharts), Products (Wix push/pull), Settings, Admin, Issues (GitHub proxy).
+Key concepts: Order (delivery or pickup), Delivery (physical run), Stock Item / Batch / Demand Entry, Stock Order (procurement), Write-off, Florist (builds bouquets), Driver (delivers), Owner (full access), Margin dot (green ≥55% / amber 40–54% / red <40%).
+Common issues: order status transitions, stock adjustments, Wix product sync, payment status display, delivery assignment, margin calculations, filter state.`,
+
+  florist: `App: Florist app (tablet/phone — owner + florists).
+Key screens: Order List (today's worklist, active/completed tabs), Order Detail (edit/status/bouquet), New Order (4-step wizard), Stock Panel (inventory), Purchase Orders (PO lifecycle), Bouquets (Wix catalog), Hours, Day Summary.
+Key concepts: Order, Delivery, Bouquet Editor, Stock Item / Batch, Stock Order (Draft→Sent→Shopping→Reviewing→Evaluating→Complete), Write-off, Florist, Driver, BottomNav tabs.
+Common issues: order creation, bouquet composition, stock receive, PO evaluation, florist hours logging, status revert, missing fields after Pickup→Delivery conversion.`,
+
+  delivery: `App: Delivery app (phone — drivers only).
+Key screens: Deliveries list, PO shopping runs, address navigation.
+Key concepts: Delivery (physical run assigned to a driver), PO Shopping Run, Google Maps / Waze navigation links, delivery status (Out for Delivery → Delivered).
+Common issues: delivery status updates, navigation not opening, assigned order details missing.`,
+};
+
+const FALLBACK_CONTEXT = `App: Blossom — flower studio operational platform (Krakow, Poland).
+Roles: Owner (full access — dashboard + florist app), Florist (orders + stock), Driver (deliveries).
+Key concepts: Order, Delivery, Stock Item / Batch, Stock Order (PO), Bouquet, Write-off.`;
+
+/**
+ * Returns a short domain-context string for the given appArea.
+ * Appended to the feedback assistant system prompt so Haiku infers screen/state
+ * instead of asking the reporter. issue #457 (code-RAG) will plug in here later.
+ * @param {string|null|undefined} appArea
+ * @returns {string}
+ */
+export function getAreaContext(appArea) {
+  return AREA_CONTEXTS[appArea] ?? FALLBACK_CONTEXT;
+}

--- a/backend/src/services/feedbackService.js
+++ b/backend/src/services/feedbackService.js
@@ -3,6 +3,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { eq, lt } from 'drizzle-orm';
 import { db } from '../db/index.js';
 import { feedbackReports, feedbackSessions } from '../db/schema.js';
+import { getAreaContext } from './feedbackContext.js';
 
 const GITHUB_OWNER = 'OliwerO';
 const GITHUB_REPO  = 'flower-studio';
@@ -73,11 +74,11 @@ function tryParseAIResponse(raw) {
   return null;
 }
 
-async function callAI(messages) {
+async function callAI(messages, systemPrompt = SYSTEM_PROMPT) {
   const res = await anthropic.messages.create({
     model: MODEL,
     max_tokens: 2048,
-    system: SYSTEM_PROMPT,
+    system: systemPrompt,
     messages,
   });
 
@@ -90,7 +91,7 @@ async function callAI(messages) {
   const res2 = await anthropic.messages.create({
     model: MODEL,
     max_tokens: 2048,
-    system: SYSTEM_PROMPT,
+    system: systemPrompt,
     messages: [
       ...messages,
       { role: 'assistant', content: raw },
@@ -156,13 +157,32 @@ async function persistSession(sessionId, session) {
 
 /**
  * Start a new Report session. Calls Claude Haiku to classify and format the report.
- * Returns { sessionId, done: true } if AI has enough info, or { sessionId, done: false, question } if more info needed.
+ * @param {{ text: string, appArea?: string, reporterRole: string, reporterName: string,
+ *           telegramChatId?: string|null, image?: { dataBase64: string, mediaType: string } }} opts
+ *   image — optional screenshot captured client-side; included as a vision content block so
+ *   Haiku can see the UI and ask fewer clarifying questions. Not persisted to the DB session.
+ * Returns { sessionId, done: true } if AI has enough info, or { sessionId, done: false, question }.
  */
-export async function startSession({ text, appArea, reporterRole, reporterName, telegramChatId = null }) {
+export async function startSession({ text, appArea, reporterRole, reporterName, telegramChatId = null, image = null }) {
   const sessionId = newSessionId();
-  const messages = [{ role: 'user', content: text }];
 
-  const aiResult = await callAI(messages);
+  // Build the first user message — include screenshot vision block when provided.
+  const userContent = (image?.dataBase64 && image?.mediaType)
+    ? [
+        { type: 'text', text },
+        { type: 'image', source: { type: 'base64', media_type: image.mediaType, data: image.dataBase64 } },
+      ]
+    : text;
+
+  // For storage we only keep the text (image data would bloat the 2h session row).
+  const messages = [{ role: 'user', content: text }];
+  const messagesForAI = [{ role: 'user', content: userContent }];
+
+  // Append per-area context so Haiku infers screen/terminology instead of asking.
+  const areaContext = getAreaContext(appArea);
+  const systemPrompt = `${SYSTEM_PROMPT}\n\n## App context\n\n${areaContext}`;
+
+  const aiResult = await callAI(messagesForAI, systemPrompt);
 
   const session = {
     reporterRole,

--- a/packages/shared/components/AskBlossomLauncher.jsx
+++ b/packages/shared/components/AskBlossomLauncher.jsx
@@ -7,7 +7,13 @@ import AskBlossomPanel from './AskBlossomPanel.jsx';
 // `fabClassName` lets a host nudge the button (e.g. above the florist bottom nav).
 const SPARKLE = "M12 2l1.8 4.9L19 8.7l-4.2 2.6L13.5 16 12 11.6 10.5 16 9.2 11.3 5 8.7l5.2-1.8L12 2z";
 
-export default function AskBlossomLauncher({ t, fabClassName = 'bottom-6 right-6' }) {
+export default function AskBlossomLauncher({
+  t,
+  fabClassName = 'bottom-6 right-6',
+  reporterRole,
+  reporterName,
+  appArea,
+}) {
   const [open, setOpen] = useState(false);
   const [maximized, setMaximized] = useState(false);
   return (
@@ -58,7 +64,12 @@ export default function AskBlossomLauncher({ t, fabClassName = 'bottom-6 right-6
               <button aria-label="Close" onClick={() => setOpen(false)} className="w-7 h-7 rounded hover:bg-white/20 leading-none text-lg">✕</button>
             </div>
             <div className="flex-1 min-h-0">
-              <AskBlossomPanel t={t} />
+              <AskBlossomPanel
+                t={t}
+                reporterRole={reporterRole}
+                reporterName={reporterName}
+                appArea={appArea}
+              />
             </div>
           </div>
         </>

--- a/packages/shared/components/AskBlossomPanel.jsx
+++ b/packages/shared/components/AskBlossomPanel.jsx
@@ -2,8 +2,9 @@ import { useState, useRef, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import client from '../api/client.js';
+import FeedbackModal from './FeedbackModal.jsx';
 
-export default function AskBlossomPanel({ t }) {
+export default function AskBlossomPanel({ t, reporterRole, reporterName, appArea }) {
   const [messages, setMessages] = useState([]); // { role: 'user'|'assistant', text }
   const [input, setInput] = useState('');
   const [sessionId, setSessionId] = useState(null);
@@ -13,6 +14,7 @@ export default function AskBlossomPanel({ t }) {
   const [editTitle, setEditTitle] = useState('');
   const [confirmDeleteId, setConfirmDeleteId] = useState(null);
   const [historyOpen, setHistoryOpen] = useState(false); // mobile: history slide-over drawer
+  const [showReport, setShowReport] = useState(false);
   const endRef = useRef(null);
 
   useEffect(() => { endRef.current?.scrollIntoView?.({ behavior: 'smooth' }); }, [messages, loading]);
@@ -218,7 +220,27 @@ export default function AskBlossomPanel({ t }) {
             {t.assistantSend}
           </button>
         </div>
+        {reporterRole && (
+          <div className="px-2 pb-2 flex justify-end">
+            <button
+              onClick={() => setShowReport(true)}
+              className="text-xs text-gray-400 hover:text-brand-600 px-2 py-1 rounded-lg hover:bg-brand-50 transition-colors"
+            >
+              {t.assistantReport || 'Сообщить о проблеме'}
+            </button>
+          </div>
+        )}
       </div>
+
+      {showReport && (
+        <FeedbackModal
+          t={t}
+          reporterRole={reporterRole}
+          reporterName={reporterName}
+          appArea={appArea}
+          onClose={() => setShowReport(false)}
+        />
+      )}
     </div>
   );
 }

--- a/packages/shared/components/FeedbackModal.jsx
+++ b/packages/shared/components/FeedbackModal.jsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback } from 'react';
 import client from '../api/client.js';
 import { publishFeedback } from '../api/feedback.js';
+import { resizeImageBlob } from '../utils/imageResize.js';
 
 /*
  * FeedbackModal — drives the full AI-assisted Report conversation.
@@ -81,12 +82,29 @@ export default function FeedbackModal({ t, reporterRole, reporterName, appArea, 
     if (!text.trim()) return;
     setLoading(true);
     try {
-      const { data } = await client.post('/feedback/start', {
+      const body = {
         text: text.trim(),
         appArea,
         reporterRole,
         reporterName,
-      });
+      };
+      // If the user already attached a screenshot, send it to the start call so
+      // Haiku can see the UI and ask fewer questions. Resize first (same 1600px cap as publish).
+      if (imageFile) {
+        try {
+          const resized = await resizeImageBlob(imageFile, { maxEdge: 1600, quality: 0.85 });
+          const b64 = await new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result.split(',')[1]);
+            reader.onerror = reject;
+            reader.readAsDataURL(resized);
+          });
+          body.image = { dataBase64: b64, mediaType: 'image/jpeg' };
+        } catch {
+          // Resize or encode failed — start without image; Haiku will ask about the screen.
+        }
+      }
+      const { data } = await client.post('/feedback/start', body);
       setSessionId(data.sessionId);
       if (data.done) {
         await loadPreview(data.sessionId);

--- a/packages/shared/test/AskBlossomPanel.test.jsx
+++ b/packages/shared/test/AskBlossomPanel.test.jsx
@@ -3,9 +3,23 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import AskBlossomPanel from '../components/AskBlossomPanel.jsx';
 
 vi.mock('../api/client.js', () => ({ default: { post: vi.fn(), get: vi.fn(), patch: vi.fn(), delete: vi.fn() } }));
+// FeedbackModal uses resizeImageBlob; mock it so jsdom canvas is not needed.
+vi.mock('../utils/imageResize.js', () => ({ resizeImageBlob: vi.fn().mockResolvedValue(new Blob()) }));
 import client from '../api/client.js';
 
-const t = { assistantPlaceholder: 'Спросите…', assistantSend: 'Спросить', assistantThinking: 'Думаю…', assistantError: 'Ошибка', assistantEmpty: 'Задайте вопрос о ваших данных', assistantHistory: 'Чаты', assistantNewChat: '+ Новый чат', assistantNoHistory: 'Нет чатов', assistantUntitled: 'Без названия', assistantRename: 'Переименовать', assistantDelete: 'Удалить', assistantDeleteConfirm: 'Удалить?' };
+const t = {
+  assistantPlaceholder: 'Спросите…', assistantSend: 'Спросить', assistantThinking: 'Думаю…',
+  assistantError: 'Ошибка', assistantEmpty: 'Задайте вопрос о ваших данных',
+  assistantHistory: 'Чаты', assistantNewChat: '+ Новый чат', assistantNoHistory: 'Нет чатов',
+  assistantUntitled: 'Без названия', assistantRename: 'Переименовать', assistantDelete: 'Удалить',
+  assistantDeleteConfirm: 'Удалить?', assistantReport: 'Сообщить о проблеме',
+  // FeedbackModal keys
+  reportTitle: 'Отчёт', reportPlaceholder: 'Опишите…', reportSend: 'Отправить',
+  reportThinking: 'Думаю…', reportAddScreenshot: 'Добавить скриншот',
+  reportPreviewTitle: 'Предпросмотр', reportCorrect: 'Исправить', reportConfirm: 'Опубликовать',
+  reportSuccess: 'Готово!', reportError: 'Ошибка', reportRetry: 'Попробовать снова',
+  reportExpired: 'Сессия устарела',
+};
 
 beforeEach(() => { vi.clearAllMocks(); client.get.mockResolvedValue({ data: [] }); });
 
@@ -102,5 +116,37 @@ describe('AskBlossomPanel', () => {
     fireEvent.click(screen.getByLabelText('Удалить')); // trash → arms confirm
     fireEvent.click(screen.getByText('Удалить?'));      // confirm
     await waitFor(() => expect(client.delete).toHaveBeenCalledWith('/assistant/conversations/c1'));
+  });
+});
+
+// ── Report button (Part A) ────────────────────────────────────────────────────
+
+describe('AskBlossomPanel — report button', () => {
+  it('shows "Сообщить о проблеме" button when reporterRole is provided', () => {
+    render(<AskBlossomPanel t={t} reporterRole="owner" reporterName="Owner" appArea="dashboard" />);
+    expect(screen.getByText('Сообщить о проблеме')).toBeInTheDocument();
+  });
+
+  it('does not show the report button when reporterRole is absent', () => {
+    render(<AskBlossomPanel t={t} />);
+    expect(screen.queryByText('Сообщить о проблеме')).not.toBeInTheDocument();
+  });
+
+  it('clicking report button opens FeedbackModal', async () => {
+    render(<AskBlossomPanel t={t} reporterRole="owner" reporterName="Owner" appArea="dashboard" />);
+    fireEvent.click(screen.getByText('Сообщить о проблеме'));
+    expect(await screen.findByText('Отчёт')).toBeInTheDocument(); // FeedbackModal header (reportTitle)
+  });
+
+  it('closing FeedbackModal hides it', async () => {
+    render(<AskBlossomPanel t={t} reporterRole="owner" reporterName="Owner" appArea="dashboard" />);
+    fireEvent.click(screen.getByText('Сообщить о проблеме'));
+    await screen.findByText('Отчёт');
+    // Click the close (✕) button inside the FeedbackModal
+    const closeBtn = screen.getAllByRole('button').find(b => b.getAttribute('aria-label') === null && b.textContent === '');
+    // FeedbackModal renders a close button; click the backdrop instead (simpler)
+    const backdrop = document.querySelector('.fixed.inset-0.z-50 > .absolute');
+    fireEvent.click(backdrop);
+    await waitFor(() => expect(screen.queryByText('Отчёт')).not.toBeInTheDocument());
   });
 });


### PR DESCRIPTION
## Summary

- **A. Report button in assistant panel** — AskBlossomPanel now has a small "Сообщить о проблеме" link visible when reporter props are provided. Clicking it opens the existing FeedbackModal inside the drawer (no new report flow — reuses the proven screenshot + AI Q&A flow). AskBlossomLauncher threads `reporterRole`/`reporterName`/`appArea` through; both dashboard and florist mounts pass them.
- **B. Screenshot vision** — FeedbackModal sends the already-attached screenshot to `POST /feedback/start` as a base64 image block (resized 1600px). feedbackService passes it as an Anthropic vision content block so Haiku sees the UI on the first turn and asks fewer clarifying questions. Image data is not stored in the session row (would bloat 2h TTL rows). `POST /feedback/publish` image flow is unchanged.
- **C. Per-area context pack** — new `feedbackContext.js` exports `getAreaContext(appArea)`. feedbackService appends it to the Haiku system prompt every session. Code-RAG (issue #457) will plug in here later.

## Test plan

- [ ] Backend: `cd backend && npx vitest run` — 745 tests pass (includes 11 new feedback tests)
- [ ] Shared: `cd packages/shared && vitest run` — 560 tests pass (includes 4 new AskBlossomPanel tests)
- [ ] `apps/dashboard` vite build ✓
- [ ] `apps/florist` vite build ✓
- [ ] `apps/delivery` vite build ✓
- [ ] Owner smoke: open Ask Blossom → click "Сообщить о проблеме" → FeedbackModal opens
- [ ] Owner smoke: attach screenshot in FeedbackModal → click Send → Haiku responds with fewer screen-identifying questions

Note: CHANGELOG and CLAUDE.md docs updated in a follow-up commit per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)