### PR TITLE
fix(orders): terminal status button matches fulfillment type (CR-31)

### DIFF
--- a/apps/dashboard/src/components/OrderDetailPanel.jsx
+++ b/apps/dashboard/src/components/OrderDetailPanel.jsx
@@ -8,7 +8,7 @@ import t from '../translations.js';
 import Pills from './Pills.jsx';
 import InlineEdit from './InlineEdit.jsx';
 import useConfigLists from '../hooks/useConfigLists.js';
-import { DissolvePremadesDialog, computePremadeShortfalls, CallButton, BouquetImageEditor, useOrderTerminationFlow, OrderTerminationConfirm, resolveStockLinePrice, shouldShowBouquetSection } from '@flower-studio/shared';
+import { DissolvePremadesDialog, computePremadeShortfalls, CallButton, BouquetImageEditor, useOrderTerminationFlow, OrderTerminationConfirm, resolveStockLinePrice, shouldShowBouquetSection, isStatusAllowedForFulfillment } from '@flower-studio/shared';
 
 // Split "Rose Red (14.Mar.)" into { name: "Rose Red", batch: "14.Mar." }
 function parseBatchName(displayName) {
@@ -294,10 +294,14 @@ export default function OrderDetailPanel({ orderId, onUpdate, onNavigate }) {
         </Section>
       )}
 
-      {/* Status */}
+      {/* Status — CR-31: a delivery order can only terminate as "Delivered",
+          a pickup order only as "Picked Up". Strip the mismatched terminal for
+          the owner too (god-mode elsewhere; this pair is a domain truth). */}
       <Section label={t.status}>
         <Pills
-          options={STATUSES}
+          options={STATUSES.filter(s =>
+            isStatusAllowedForFulfillment(s.value, o['Delivery Type'] === 'Delivery'),
+          )}
           value={o.Status}
           onChange={v => patchOrder({ Status: v })}
           disabled={saving}

--- a/apps/florist/src/components/OrderCard.jsx
+++ b/apps/florist/src/components/OrderCard.jsx
@@ -854,6 +854,7 @@ function OrderCard({
                     role: isOwner ? 'owner' : 'florist',
                     currentStatus,
                     previousStatuses: prevStatuses,
+                    isDelivery,  // CR-31: a delivery order never offers "Picked Up" (and vice versa)
                   });
                   // Intercept the Cancelled pill — show inline confirm so the
                   // user picks return-stock vs status-only cancel.

--- a/apps/florist/src/pages/OrderDetailPage.jsx
+++ b/apps/florist/src/pages/OrderDetailPage.jsx
@@ -655,6 +655,7 @@ export default function OrderDetailPage() {
                     role,
                     currentStatus: current,
                     previousStatuses: prevStatuses,
+                    isDelivery,  // CR-31: a delivery order never offers "Picked Up" (and vice versa)
                   });
                   // Intercept Cancelled — show inline confirm so user picks
                   // return-stock vs status-only cancel. Same pattern as

--- a/packages/shared/index.js
+++ b/packages/shared/index.js
@@ -47,7 +47,7 @@ export {
 export { getEffectiveStock, hasStockShortfall, getVarietyTotals, getVarietyAvailability, arrivalsForVariety, allocateVarietyCoverage, allocateLinesAgainstVariety } from './utils/stockMath.js';
 export { resolveStockLinePrice, resolveVarietySell } from './utils/stockLinePrice.js';
 export { shouldShowBouquetSection } from './utils/bouquetVisibility.js';
-export { getStatusOptions, ALL_ORDER_STATUSES } from './utils/orderStatusOptions.js';
+export { getStatusOptions, ALL_ORDER_STATUSES, isStatusAllowedForFulfillment } from './utils/orderStatusOptions.js';
 export {
   matchesSearch,
   matchesFilters,

--- a/packages/shared/test/orderStatusOptions.test.js
+++ b/packages/shared/test/orderStatusOptions.test.js
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { getStatusOptions, ALL_ORDER_STATUSES } from '../utils/orderStatusOptions.js';
+import {
+  getStatusOptions,
+  ALL_ORDER_STATUSES,
+  isStatusAllowedForFulfillment,
+} from '../utils/orderStatusOptions.js';
 
 describe('getStatusOptions', () => {
   describe('owner (any → any)', () => {
@@ -89,6 +93,76 @@ describe('getStatusOptions', () => {
         previousStatuses: ['New', 'Ready'], // OOD never held
       });
       expect(all).not.toContain('Out for Delivery');
+    });
+  });
+
+  // CR-31: a delivery order can only terminate as 'Delivered'; a pickup order
+  // only as 'Picked Up'. They are mutually exclusive by fulfillment type — a
+  // domain truth, not a permission — so the mismatched terminal is stripped for
+  // EVERY role (owner god-mode included). isDelivery omitted → no filtering
+  // (back-compat with every call site that predates this).
+  describe('isStatusAllowedForFulfillment', () => {
+    it('delivery order forbids "Picked Up", allows "Delivered"', () => {
+      expect(isStatusAllowedForFulfillment('Picked Up', true)).toBe(false);
+      expect(isStatusAllowedForFulfillment('Delivered', true)).toBe(true);
+      expect(isStatusAllowedForFulfillment('Out for Delivery', true)).toBe(true);
+      expect(isStatusAllowedForFulfillment('Ready', true)).toBe(true);
+    });
+
+    it('pickup order forbids "Delivered", allows "Picked Up"', () => {
+      expect(isStatusAllowedForFulfillment('Delivered', false)).toBe(false);
+      expect(isStatusAllowedForFulfillment('Picked Up', false)).toBe(true);
+      expect(isStatusAllowedForFulfillment('Ready', false)).toBe(true);
+    });
+
+    it('unknown fulfillment (null/undefined) allows both terminals — never over-filters', () => {
+      expect(isStatusAllowedForFulfillment('Picked Up', undefined)).toBe(true);
+      expect(isStatusAllowedForFulfillment('Delivered', undefined)).toBe(true);
+      expect(isStatusAllowedForFulfillment('Picked Up', null)).toBe(true);
+    });
+  });
+
+  describe('fulfillment-type filtering (CR-31)', () => {
+    it('florist Ready + delivery → forward drops "Picked Up"', () => {
+      const { forward } = getStatusOptions({
+        role: 'florist', currentStatus: 'Ready', isDelivery: true,
+      });
+      expect(forward).toEqual(['Delivered', 'Cancelled']);
+      expect(forward).not.toContain('Picked Up');
+    });
+
+    it('florist Ready + pickup → forward drops "Delivered"', () => {
+      const { forward } = getStatusOptions({
+        role: 'florist', currentStatus: 'Ready', isDelivery: false,
+      });
+      expect(forward).toEqual(['Picked Up', 'Cancelled']);
+      expect(forward).not.toContain('Delivered');
+    });
+
+    it('owner god-mode is still filtered by fulfillment (the reporter is owner)', () => {
+      const delivery = getStatusOptions({ role: 'owner', currentStatus: 'Ready', isDelivery: true });
+      expect(delivery.all).toContain('Delivered');
+      expect(delivery.all).not.toContain('Picked Up');
+
+      const pickup = getStatusOptions({ role: 'owner', currentStatus: 'New', isDelivery: false });
+      expect(pickup.all).toContain('Picked Up');
+      expect(pickup.all).not.toContain('Delivered');
+    });
+
+    it('revert set is filtered too (a delivery order never reverts to "Picked Up")', () => {
+      const { revert } = getStatusOptions({
+        role: 'florist',
+        currentStatus: 'Cancelled',
+        previousStatuses: ['New', 'Ready', 'Picked Up'],
+        isDelivery: true,
+      });
+      expect(revert).toContain('Ready');
+      expect(revert).not.toContain('Picked Up');
+    });
+
+    it('omitting isDelivery keeps the legacy both-terminals behaviour', () => {
+      const { forward } = getStatusOptions({ role: 'florist', currentStatus: 'Ready' });
+      expect(forward).toEqual(['Delivered', 'Picked Up', 'Cancelled']);
     });
   });
 });

--- a/packages/shared/utils/orderStatusOptions.js
+++ b/packages/shared/utils/orderStatusOptions.js
@@ -36,6 +36,27 @@ const FORWARD_TRANSITIONS = {
 };
 
 /**
+ * Whether a status may be offered given the order's fulfillment type.
+ *
+ * A delivery order can only terminate as 'Delivered'; a pickup order only as
+ * 'Picked Up'. These two terminals are mutually exclusive by fulfillment type
+ * — a domain truth, not a permission — so the mismatched one is hidden for
+ * EVERY role, owner god-mode included (the owner who taps "Picked Up" on a
+ * delivery would otherwise leave the order in a contradictory terminal state).
+ * CR-31.
+ *
+ * @param {string}  status      one of ALL_ORDER_STATUSES
+ * @param {boolean} [isDelivery] true = delivery order, false = pickup.
+ *        undefined/null → don't filter (unknown fulfillment never over-filters).
+ * @returns {boolean}
+ */
+export function isStatusAllowedForFulfillment(status, isDelivery) {
+  if (isDelivery == null) return true;
+  if (isDelivery === true) return status !== 'Picked Up';
+  return status !== 'Delivered';
+}
+
+/**
  * Compute the status options a user may move an order to.
  *
  * @param {Object}   params
@@ -43,24 +64,28 @@ const FORWARD_TRANSITIONS = {
  * @param {string}   params.currentStatus      the order's current status
  * @param {string[]} [params.previousStatuses] statuses the order has previously
  *        held (from GET /orders/:id/status-history). Ignored for owners.
+ * @param {boolean}  [params.isDelivery]        true = delivery order, false =
+ *        pickup. Strips the mismatched terminal (CR-31). Omit → no filtering.
  * @returns {{ forward: string[], revert: string[], all: string[] }}
  *   forward — happy-path next steps (owners: every other status)
  *   revert  — previously-held statuses NOT already in forward (the undo set)
  *   all     — forward followed by revert, de-duplicated, current excluded
  */
-export function getStatusOptions({ role, currentStatus, previousStatuses = [] }) {
+export function getStatusOptions({ role, currentStatus, previousStatuses = [], isDelivery }) {
+  const keep = s => isStatusAllowedForFulfillment(s, isDelivery);
+
   if (role === 'owner') {
-    const all = ALL_ORDER_STATUSES.filter(s => s !== currentStatus);
+    const all = ALL_ORDER_STATUSES.filter(s => s !== currentStatus && keep(s));
     return { forward: all, revert: [], all };
   }
 
   const forward = (FORWARD_TRANSITIONS[currentStatus] || []).filter(
-    s => s !== currentStatus,
+    s => s !== currentStatus && keep(s),
   );
   const seen = new Set([currentStatus, ...forward]);
   const revert = [];
   for (const s of previousStatuses) {
-    if (!seen.has(s)) {
+    if (!seen.has(s) && keep(s)) {
       seen.add(s);
       revert.push(s);
     }


### PR DESCRIPTION
## What
A delivery order can only terminate as **Delivered**; a pickup order only as **Picked Up**. Before this, the `Ready` state offered *both* terminal pills to everyone, so a florist (or the owner on her mobile florist app, where she is `role=owner` → god-mode) could mark a delivery order "Picked Up" and leave it in a contradictory terminal state. CR-31 from the Y-model test session.

## Why this framing
The two terminals are mutually exclusive **by fulfillment type — a domain truth, not a permission**. So the mismatched terminal is stripped for **every** role, owner god-mode included. (The reporter is the owner; a role-scoped fix would not have fixed it on her own surface.)

## How
- `packages/shared/utils/orderStatusOptions.js`: new `isStatusAllowedForFulfillment(status, isDelivery)` + an `isDelivery` param on `getStatusOptions`. **`isDelivery` omitted/null → no filtering** (back-compat with every existing caller — the 10 prior tests pass untouched).
- Wired at all three per-order status surfaces (parity):
  - florist `OrderCard.jsx` + `OrderDetailPage.jsx` (shared util)
  - dashboard `OrderDetailPanel.jsx` (static `STATUSES` pill row, filtered via the helper)

## Verification
- `packages/shared` vitest: **568 passed** (7 new CR-31 cases incl. owner-god-mode + revert-set filtering + back-compat).
- Built all three apps (florist / dashboard / delivery) — green. CI gate: `.github/workflows/test.yml` (Vitest + E2E + lab-api).

Closes #N/A (CR-31 — tracked in `docs/superpowers/plans/2026-06-21-ymodel-test-session-2-crs.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)