### PR TITLE
fix(orders): fixed-price field pre-fills with the live sell total (CR-29)

### DIFF
--- a/apps/dashboard/src/components/steps/Step2Bouquet.jsx
+++ b/apps/dashboard/src/components/steps/Step2Bouquet.jsx
@@ -713,8 +713,15 @@ export default function Step2Bouquet({
         <div className="ios-card flex items-center px-4">
           <input
             type="number"
-            value={priceOverride}
+            // CR-29: pre-fill the fixed price with the live sell total so the
+            // owner SEES (and the order keeps) that total when she doesn't set a
+            // custom one. State stays empty until she types — clearing reverts to
+            // the suggestion, and the value tracks line edits while untouched.
+            // (Submit sends null when blank; the backend already falls back to
+            // the computed flower total — orderRepo finalPriceAtCreate.)
+            value={priceOverride !== '' ? priceOverride : (sellTotal > 0 ? String(Math.round(sellTotal)) : '')}
             onChange={e => onChange({ priceOverride: e.target.value })}
+            onFocus={e => e.target.select()}
             placeholder={sellTotal > 0 ? String(Math.round(sellTotal)) : '0'}
             className="flex-1 py-3.5 text-base text-ios-label bg-transparent outline-none placeholder-ios-tertiary/50"
           />

--- a/apps/florist/src/components/steps/Step2Bouquet.jsx
+++ b/apps/florist/src/components/steps/Step2Bouquet.jsx
@@ -906,8 +906,15 @@ export default function Step2Bouquet({
         <div className="ios-card flex items-center px-4">
           <input
             type="number"
-            value={priceOverride}
+            // CR-29: pre-fill the fixed price with the live sell total so the
+            // owner SEES (and the order keeps) that total when she doesn't set a
+            // custom one. State stays empty until she types — clearing reverts to
+            // the suggestion, and the value tracks line edits while untouched.
+            // (Submit sends null when blank; the backend already falls back to
+            // the computed flower total — orderRepo finalPriceAtCreate.)
+            value={priceOverride !== '' ? priceOverride : (sellTotal > 0 ? String(Math.round(sellTotal)) : '')}
             onChange={e => onChange({ priceOverride: e.target.value })}
+            onFocus={e => e.target.select()}
             placeholder={sellTotal > 0 ? String(Math.round(sellTotal)) : '0'}
             className="flex-1 py-3.5 text-base text-ios-label bg-transparent outline-none placeholder-ios-tertiary/50"
           />


### PR DESCRIPTION
## What
The optional **Fixed price** field on the bouquet step now shows the computed **sell total** as a real, pre-filled (editable) value when the user hasn't set a custom one — instead of only a faint placeholder. CR-29 from the Y-model test session.

## Why
The owner reported that leaving the fixed price blank made it unclear whether the order would keep the sell total. It always did numerically (the backend falls back), but the blank field hid that. Now the number is visible and editable.

## Behaviour
- Empty field → displays `round(sellTotal)`; **tracks line edits live** while untouched.
- Typing → overrides; **clearing** → reverts to the suggestion (`onFocus` selects-all so editing is clean).
- **Nothing stored differently:** a blank field still submits `priceOverride: null`, and `orderRepo.createOrder` already computes `finalPriceAtCreate = (Number(priceOverride) || flowerTotal) + deliveryFee`. This is a visibility fix, not a pricing change.

## Coverage / parity
One change in the shared `steps/Step2Bouquet.jsx` of **each** app — and because both `PremadeBouquetCreatePage` (florist) and `PremadeBouquetCreateModal` (dashboard) reuse `Step2Bouquet`, this covers **both** surfaces CR-29 named: new-order wizard **and** premade-bouquet creation.

## Verification
- Built florist + dashboard apps — green. (No shared/backend change; pure UI wiring.)
- CI gate: `.github/workflows/test.yml`.

CR-29 — tracked in `docs/superpowers/plans/2026-06-21-ymodel-test-session-2-crs.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)