### PR TITLE
feat(crm): recipient / key-person address book — phone + address + new-order pre-fill (CR-30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Review this entire file before flipping to production.
 
 ---
 
+## 2026-06-30 — Feature (CR-30): recipient phone + address as first-class key_people fields
+
+Y-model test-session CR. Each connected key person becomes a reusable address book: phone + delivery address are stored once and pre-fill every future delivery to that person. Plan: `docs/superpowers/plans/2026-06-30-ymodel-test-crs-features.md` (Feature C). Built slice-by-slice on branch `feat/recipient-key-person`.
+
+### C1 — schema + repo (this slice)
+- **Migration `0018_key_people_phone_address.sql`** — adds nullable `key_people.phone` + `key_people.address` (additive → safe on prod).
+- `customerRepo.createKeyPerson` / `listKeyPeople` read + write `phone` + `address` (empty string → null); `POST /api/customers/:id/key-people` accepts them.
+- Test: `customerRepo.keyPeople.integration.test.js` — phone/address round-trip, back-compat null, empty→null.
+
+_Remaining slices (same branch): C2 recipient step in the new-order wizard (both apps), C3 delivery pre-fill from the chosen recipient, C4 CRM surfacing (both apps)._
+
 ## 2026-06-30 — Feature (CR-32): courier time slots — client 2h window vs courier 1h slot
 
 Y-model test-session CR. The client picks a wide **2h delivery window**; the owner later assigns the courier a **1h slot within** that window; the **driver app shows only the courier slot**. Plan: `docs/superpowers/plans/2026-06-30-ymodel-test-crs-features.md` (Feature B).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,25 @@ Review this entire file before flipping to production.
 
 Y-model test-session CR. Each connected key person becomes a reusable address book: phone + delivery address are stored once and pre-fill every future delivery to that person. Plan: `docs/superpowers/plans/2026-06-30-ymodel-test-crs-features.md` (Feature C). Built slice-by-slice on branch `feat/recipient-key-person`.
 
-### C1 — schema + repo (this slice)
+### C1 — schema + repo
 - **Migration `0018_key_people_phone_address.sql`** — adds nullable `key_people.phone` + `key_people.address` (additive → safe on prod).
 - `customerRepo.createKeyPerson` / `listKeyPeople` read + write `phone` + `address` (empty string → null); `POST /api/customers/:id/key-people` accepts them.
-- Test: `customerRepo.keyPeople.integration.test.js` — phone/address round-trip, back-compat null, empty→null.
 
-_Remaining slices (same branch): C2 recipient step in the new-order wizard (both apps), C3 delivery pre-fill from the chosen recipient, C4 CRM surfacing (both apps)._
+### C2 — recipient step in the new-order wizard (both apps)
+- `apps/{dashboard,florist}/src/components/steps/Step1Customer.jsx` — the existing key-person selector (from #216) now also captures **phone + address**: picking a saved recipient carries their stored phone/address; the "add new recipient" branch (shown when a name is typed with no match) adds phone + address inputs and `POST`s `{ name, phone?, address? }` so the person is reusable. On Continue, sets `keyPersonId` + seeds `recipientName/recipientPhone/deliveryAddress` + a `keyPersonName/Phone/Address` snapshot on the wizard form. Failed `POST` now surfaces a toast (was a silent catch).
+- New form fields `keyPersonPhone` / `keyPersonAddress` (prefill snapshot — **not** sent in the order POST).
+
+### C3 — delivery pre-fill from the chosen recipient (both apps)
+- `apps/{dashboard,florist}/src/components/steps/Step3Details.jsx` — when a recipient is chosen and fulfilment is Delivery, an effect pre-fills `recipientName/recipientPhone/deliveryAddress` from the form snapshot, **empty-only** so manual edits are never clobbered. Derives from local form state (pitfall #1).
+
+### C4 — CRM surfacing (both apps)
+- New repo fn `customerRepo.updateKeyPerson(personId, changes)` (partial update; trims/validates `name`, ISO-validates `importantDate`, empty→null, scoped to non-deleted rows, 404 if missing) + route **`PATCH /api/customers/:id/key-people/:personId`**.
+- `apps/{dashboard,florist}/src/components/CustomerDetailView.jsx` + `KeyPersonChips.jsx` — phone + address shown and inline-editable per key person (persist on blur via the PATCH route, merge into local `_keyPeople`, toast on error). Florist additionally view-only displays them when `!canEdit`.
+
+### Tests / verification
+- `customerRepo.keyPeople.integration.test.js` (pglite, applies migration 0018) — create/list phone+address round-trip, back-compat null, empty→null, **plus** `updateKeyPerson` full update / partial update / 404.
+- Backend `vitest run`: 90 files / 810 passed. E2E suite: 220 passed / 0 failed. Dashboard + florist `vite build`: green.
+- Lab `lab-api` gate runs in CI (local run skipped to avoid a cross-session collision on the single shared `flower-lab-pg` container; migration 0018 is `ALTER TABLE ADD COLUMN text`, already proven to apply on real SQL via the pglite harness).
 
 ## 2026-06-30 — Feature (CR-32): courier time slots — client 2h window vs courier 1h slot
 

--- a/apps/dashboard/src/components/CustomerDetailView.jsx
+++ b/apps/dashboard/src/components/CustomerDetailView.jsx
@@ -67,6 +67,20 @@ export default function CustomerDetailView({ customerId, onLocalPatch, onNavigat
     }
   }
 
+  // CR-30 C4: phone/address per key person, persisted by personId (separate from
+  // the flat Key person N/date fields edited via patchField above).
+  async function patchKeyPerson(personId, changes) {
+    try {
+      const res = await client.patch(`/customers/${customerId}/key-people/${personId}`, changes);
+      setCust(prev => ({
+        ...prev,
+        _keyPeople: (prev._keyPeople || []).map(p => p.id === personId ? { ...p, ...res.data } : p),
+      }));
+    } catch (err) {
+      showToast(err.response?.data?.error || t.error, 'error');
+    }
+  }
+
   if (loading) {
     return (
       <div className="px-4 py-6 flex justify-center">
@@ -87,7 +101,7 @@ export default function CustomerDetailView({ customerId, onLocalPatch, onNavigat
 
       <ProfileGrid cust={cust} onPatch={patchField} onInvalid={msg => showToast(msg, 'error')} />
 
-      <KeyPersonChips cust={cust} onPatch={patchField} />
+      <KeyPersonChips cust={cust} onPatch={patchField} onPatchPerson={patchKeyPerson} />
 
       <NotesSection cust={cust} onPatch={patchField} />
 

--- a/apps/dashboard/src/components/KeyPersonChips.jsx
+++ b/apps/dashboard/src/components/KeyPersonChips.jsx
@@ -13,7 +13,7 @@ const SLOTS = [
   { nameField: 'Key person 2', dateField: 'Key person 2 (important DATE)' },
 ];
 
-export default function KeyPersonChips({ cust, onPatch }) {
+export default function KeyPersonChips({ cust, onPatch, onPatchPerson }) {
   // Index of the slot currently being filled via the "+ Add" button.
   const [addingSlot, setAddingSlot] = useState(null);
 
@@ -35,12 +35,15 @@ export default function KeyPersonChips({ cust, onPatch }) {
           const hasName = !!cust[slot.nameField];
           const isAdding = addingSlot === i;
           if (!hasName && !isAdding) return null;
+          const person = cust._keyPeople?.[i];
           return (
             <KeyPersonSlot
               key={i}
               slot={slot}
               cust={cust}
               onPatch={onPatch}
+              person={person}
+              onPatchPerson={onPatchPerson}
               autoFocus={isAdding}
               onDone={() => setAddingSlot(null)}
             />
@@ -64,7 +67,14 @@ export default function KeyPersonChips({ cust, onPatch }) {
   );
 }
 
-function KeyPersonSlot({ slot, cust, onPatch, autoFocus, onDone }) {
+// CR-30 C4 accepted limitation: a brand-new key person added inline via the
+// "+ Add" name field below creates the row server-side but does not refresh
+// `cust._keyPeople` locally (the flat-field `onPatch` only merges
+// `Key person N`), so its phone/address inputs appear only after the customer
+// view reloads. Editing phone/address for already-existing key people works
+// immediately. Adding a new recipient with phone+address up front is fully
+// supported in the New Order wizard (C2).
+function KeyPersonSlot({ slot, cust, onPatch, person, onPatchPerson, autoFocus, onDone }) {
   const name = cust[slot.nameField];
   const date = cust[slot.dateField];
 
@@ -109,6 +119,30 @@ function KeyPersonSlot({ slot, cust, onPatch, autoFocus, onDone }) {
             focus:border-brand-500 focus:outline-none py-0.5 cursor-pointer"
         />
       </div>
+      {person?.id && (
+        <>
+          <div className="mt-1">
+            <p className="text-[10px] text-ios-tertiary mb-0.5">{t.keyPersonPhone}</p>
+            <input
+              type="tel"
+              defaultValue={person.phone || ''}
+              onBlur={e => onPatchPerson(person.id, { phone: e.target.value || null })}
+              className="w-full text-sm text-ios-label bg-transparent border-b border-dashed border-gray-300
+                focus:border-brand-500 focus:outline-none py-0.5"
+            />
+          </div>
+          <div className="mt-1">
+            <p className="text-[10px] text-ios-tertiary mb-0.5">{t.keyPersonAddress}</p>
+            <input
+              type="text"
+              defaultValue={person.address || ''}
+              onBlur={e => onPatchPerson(person.id, { address: e.target.value || null })}
+              className="w-full text-sm text-ios-label bg-transparent border-b border-dashed border-gray-300
+                focus:border-brand-500 focus:outline-none py-0.5"
+            />
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/dashboard/src/components/NewOrderTab.jsx
+++ b/apps/dashboard/src/components/NewOrderTab.jsx
@@ -13,6 +13,7 @@ import Step4Review   from './steps/Step4Review.jsx';
 
 const emptyForm = {
   customerId: '', customerName: '', keyPersonId: null, keyPersonName: '',
+  keyPersonPhone: '', keyPersonAddress: '',
   customerRequest: '', orderLines: [], priceOverride: '',
   source: 'In-store', deliveryType: 'Pickup',
   recipientName: '', recipientPhone: '',

--- a/apps/dashboard/src/components/steps/Step1Customer.jsx
+++ b/apps/dashboard/src/components/steps/Step1Customer.jsx
@@ -3,9 +3,11 @@
 
 import { useState, useEffect, useRef } from 'react';
 import client from '../../api/client.js';
+import { useToast } from '../../context/ToastContext.jsx';
 import t from '../../translations.js';
 
 export default function Step1Customer({ customerId, customerName, onSelect, onChange }) {
+  const { showToast } = useToast();
   const [query, setQuery]           = useState('');
   const [results, setResults]       = useState([]);
   const [searching, setSearching]   = useState(false);
@@ -21,6 +23,8 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
   const [kpResults, setKpResults] = useState([]);
   const [kpId, setKpId]           = useState(null);
   const [kpName, setKpName]       = useState('');
+  const [kpPhone, setKpPhone]     = useState('');
+  const [kpAddress, setKpAddress] = useState('');
   const [kpCreating, setKpCreating] = useState(false);
   const kpDebounceRef               = useRef(null);
 
@@ -55,6 +59,8 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
     setKpQuery('');
     setKpId(null);
     setKpName('');
+    setKpPhone('');
+    setKpAddress('');
     setQuery('');
     setResults([]);
     setShowCreate(false);
@@ -72,13 +78,23 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
 
   async function handleContinue() {
     if (!chosenCustomer) return;
-    let resolvedKpId = kpId;
+    let resolvedKpId    = kpId;
+    let resolvedPhone   = kpPhone;
+    let resolvedAddress = kpAddress;
     if (!resolvedKpId && kpName.trim()) {
       setKpCreating(true);
       try {
-        const res = await client.post(`/customers/${chosenCustomer.id}/key-people`, { name: kpName.trim() });
-        resolvedKpId = res.data.id;
-      } catch { /* best-effort */ }
+        const reqBody = { name: kpName.trim() };
+        if (kpPhone.trim())   reqBody.phone   = kpPhone.trim();
+        if (kpAddress.trim()) reqBody.address = kpAddress.trim();
+        const res = await client.post(`/customers/${chosenCustomer.id}/key-people`, reqBody);
+        resolvedKpId    = res.data.id;
+        resolvedPhone   = res.data.phone   || '';
+        resolvedAddress = res.data.address || '';
+      } catch (err) {
+        console.error('Failed to create key person:', err);
+        showToast(err.response?.data?.error || t.error, 'error');
+      }
       finally { setKpCreating(false); }
     }
     onSelect({
@@ -87,6 +103,13 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
       customerCommMethod: chosenCustomer['Communication method'] || '',
       keyPersonId:        resolvedKpId || null,
       keyPersonName:      resolvedKpId ? (kpName || '') : '',
+      keyPersonPhone:     resolvedKpId ? (resolvedPhone   || '') : '',
+      keyPersonAddress:   resolvedKpId ? (resolvedAddress || '') : '',
+      ...(resolvedKpId ? {
+        recipientName:   kpName || '',
+        recipientPhone:  resolvedPhone   || '',
+        deliveryAddress: resolvedAddress || '',
+      } : {}),
     });
   }
 
@@ -345,6 +368,7 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
                 value={kpName}
                 onChange={e => {
                   setKpName(e.target.value);
+                  if (kpId) { setKpPhone(''); setKpAddress(''); }
                   setKpId(null);
                   setKpQuery(e.target.value);
                 }}
@@ -354,7 +378,7 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
               />
               {kpName && (
                 <button
-                  onClick={() => { setKpName(''); setKpId(null); setKpQuery(''); }}
+                  onClick={() => { setKpName(''); setKpId(null); setKpQuery(''); setKpPhone(''); setKpAddress(''); }}
                   className="text-ios-tertiary text-sm"
                 >&#10005;</button>
               )}
@@ -364,10 +388,17 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
                 {kpFiltered.map(p => (
                   <button
                     key={p.id}
-                    onClick={() => { setKpId(p.id); setKpName(p.name); setKpQuery(''); }}
+                    onClick={() => { setKpId(p.id); setKpName(p.name); setKpQuery(''); setKpPhone(p.phone || ''); setKpAddress(p.address || ''); }}
                     className={`w-full text-left px-4 py-3 flex items-center gap-2 active:bg-ios-fill ${kpId === p.id ? 'bg-brand-50' : ''}`}
                   >
-                    <span className="flex-1 text-ios-label text-sm">{p.name}</span>
+                    <div className="flex-1 min-w-0">
+                      <span className="block text-ios-label text-sm truncate">{p.name}</span>
+                      {(p.phone || p.address) && (
+                        <span className="block text-xs text-ios-tertiary truncate">
+                          {[p.phone, p.address].filter(Boolean).join(' · ')}
+                        </span>
+                      )}
+                    </div>
                     {kpId === p.id && <span className="text-brand-600 text-xs">✓</span>}
                   </button>
                 ))}
@@ -378,6 +409,35 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
             {t.keyPerson} — {t.optional || 'optional'}
           </p>
         </div>
+
+        {/* New recipient — phone/address, shown only while creating a new key person */}
+        {!kpId && kpName.trim() && (
+          <div>
+            <p className="ios-label">{t.addRecipient}</p>
+            <div className="ios-card overflow-hidden divide-y divide-ios-separator/40">
+              <div className="flex items-center px-4 py-3 gap-3">
+                <span className="text-sm text-ios-tertiary w-24 shrink-0">{t.recipientPhone}</span>
+                <input
+                  type="tel"
+                  value={kpPhone}
+                  onChange={e => setKpPhone(e.target.value)}
+                  placeholder="+48 000 000 000"
+                  className="flex-1 text-base bg-transparent outline-none text-ios-label placeholder-ios-tertiary/50"
+                />
+              </div>
+              <div className="flex items-center px-4 py-3 gap-3">
+                <span className="text-sm text-ios-tertiary w-24 shrink-0">{t.recipientAddress}</span>
+                <input
+                  type="text"
+                  value={kpAddress}
+                  onChange={e => setKpAddress(e.target.value)}
+                  placeholder="ul. Kwiatowa 1, Krakow"
+                  className="flex-1 text-base bg-transparent outline-none text-ios-label placeholder-ios-tertiary/50"
+                />
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Continue */}
         <button

--- a/apps/dashboard/src/components/steps/Step3Details.jsx
+++ b/apps/dashboard/src/components/steps/Step3Details.jsx
@@ -1,6 +1,7 @@
 // Step3Details — adapted for dashboard with full payment method list.
 // Uses server-configured delivery time slots (pill buttons) matching the florist app.
 
+import { useEffect } from 'react';
 import t from '../../translations.js';
 import DatePicker from '../DatePicker.jsx';
 import useConfigLists from '../../hooks/useConfigLists.js';
@@ -81,6 +82,18 @@ export default function Step3Details({ form, onChange }) {
   const { orderSources: SOURCES, paymentMethods: payMethods, timeSlots, slotLeadTimeMinutes } = useConfigLists();
   const smartSlots = getAvailableSlots(timeSlots, form.deliveryDate, slotLeadTimeMinutes);
   const set = key => val => onChange({ [key]: val });
+
+  // CR-30 C3: when a recipient (key person) is chosen and fulfilment is Delivery,
+  // pre-fill the editable recipient fields from the chosen person — empty-only so we
+  // never overwrite a manual edit. Derives from local form state (pitfall #1).
+  useEffect(() => {
+    if (form.deliveryType !== 'Delivery' || !form.keyPersonId) return;
+    const patch = {};
+    if (!form.recipientName   && form.keyPersonName)    patch.recipientName   = form.keyPersonName;
+    if (!form.recipientPhone  && form.keyPersonPhone)   patch.recipientPhone  = form.keyPersonPhone;
+    if (!form.deliveryAddress && form.keyPersonAddress) patch.deliveryAddress = form.keyPersonAddress;
+    if (Object.keys(patch).length) onChange(patch);
+  }, [form.deliveryType, form.keyPersonId]);
 
   // When date changes, clear time slot if it's no longer available
   function handleDateChange(val) {

--- a/apps/dashboard/src/translations.js
+++ b/apps/dashboard/src/translations.js
@@ -245,6 +245,8 @@ const en = {
   addKeyPerson:             'Add key person',
   keyPersonLimit:           'Both slots filled',
   keyPersonNamePlaceholder: 'Name + contact',
+  keyPersonPhone:           'Phone',
+  keyPersonAddress:         'Address',
   daysShort:                'd',
   monthsShort:              'mo',
   yearsShort:               'y',
@@ -380,6 +382,8 @@ const en = {
   labelRecipient:   'Recipient',
   optional:         'optional',
   deliveryFee:      'Delivery fee',
+  addRecipient:     'Add new recipient',
+  recipientAddress: 'Recipient address',
 
   // Step 4 — Review
   reviewTitle:      'Review order',
@@ -1401,6 +1405,8 @@ const ru = {
   addKeyPerson:             'Добавить контакт',
   keyPersonLimit:           'Оба слота заняты',
   keyPersonNamePlaceholder: 'Имя + контакты',
+  keyPersonPhone:           'Телефон',
+  keyPersonAddress:         'Адрес',
   daysShort:                'д',
   monthsShort:              'мес',
   yearsShort:               'г',
@@ -1536,6 +1542,8 @@ const ru = {
   labelRecipient:   'Получатель',
   optional:         'необязательно',
   deliveryFee:      'Стоимость доставки',
+  addRecipient:     'Новый получатель',
+  recipientAddress: 'Адрес получателя',
 
   // Step 4 — Review
   reviewTitle:      'Проверка заказа',

--- a/apps/florist/src/components/CustomerDetailView.jsx
+++ b/apps/florist/src/components/CustomerDetailView.jsx
@@ -82,6 +82,21 @@ export default function CustomerDetailView({
     }
   }
 
+  // C4: phone/address editing per key person — persisted by personId (independent
+  // of the flat `Key person N` fields handled by patchField above).
+  async function patchKeyPerson(personId, changes) {
+    if (!canEdit) return;
+    try {
+      const res = await client.patch(`/customers/${customerId}/key-people/${personId}`, changes);
+      setCust(prev => ({
+        ...prev,
+        _keyPeople: (prev._keyPeople || []).map(p => p.id === personId ? { ...p, ...res.data } : p),
+      }));
+    } catch (err) {
+      showToast(err.response?.data?.error || (t.updateError || 'Update failed'), 'error');
+    }
+  }
+
   if (loading) {
     return (
       <div className="px-4 py-6 flex justify-center">
@@ -107,7 +122,7 @@ export default function CustomerDetailView({
         canEdit={canEdit}
       />
 
-      <KeyPersonChips cust={cust} onPatch={patchField} canEdit={canEdit} />
+      <KeyPersonChips cust={cust} onPatch={patchField} onPatchPerson={patchKeyPerson} canEdit={canEdit} />
 
       <NotesSection cust={cust} onPatch={patchField} canEdit={canEdit} />
 

--- a/apps/florist/src/components/KeyPersonChips.jsx
+++ b/apps/florist/src/components/KeyPersonChips.jsx
@@ -22,7 +22,7 @@ const SLOTS = [
   { nameField: 'Key person 2', dateField: 'Key person 2 (important DATE)' },
 ];
 
-export default function KeyPersonChips({ cust, onPatch, canEdit = false }) {
+export default function KeyPersonChips({ cust, onPatch, onPatchPerson, canEdit = false }) {
   // Index of the slot currently being filled via the "+ Add" button.
   const [addingSlot, setAddingSlot] = useState(null);
 
@@ -49,12 +49,15 @@ export default function KeyPersonChips({ cust, onPatch, canEdit = false }) {
           const hasName = !!cust[slot.nameField];
           const isAdding = addingSlot === i;
           if (!hasName && !isAdding) return null;
+          const person = cust._keyPeople?.[i];
           return (
             <KeyPersonSlot
               key={i}
               slot={slot}
               cust={cust}
               onPatch={onPatch}
+              person={person}
+              onPatchPerson={onPatchPerson}
               canEdit={canEdit}
               autoFocus={isAdding}
               onDone={() => setAddingSlot(null)}
@@ -81,7 +84,7 @@ export default function KeyPersonChips({ cust, onPatch, canEdit = false }) {
   );
 }
 
-function KeyPersonSlot({ slot, cust, onPatch, canEdit, autoFocus, onDone }) {
+function KeyPersonSlot({ slot, cust, onPatch, person, onPatchPerson, canEdit, autoFocus, onDone }) {
   const name = cust[slot.nameField];
   const date = cust[slot.dateField];
 
@@ -102,6 +105,18 @@ function KeyPersonSlot({ slot, cust, onPatch, canEdit, autoFocus, onDone }) {
           <p className="text-[10px] text-ios-tertiary mb-0.5">{t.importantDate || 'Important date'}</p>
           <p className="text-xs text-ios-label">{date || '—'}</p>
         </div>
+        {person?.phone && (
+          <div className="mt-1">
+            <p className="text-[10px] text-ios-tertiary mb-0.5">{t.keyPersonPhone}</p>
+            <p className="text-xs text-ios-label">{person.phone}</p>
+          </div>
+        )}
+        {person?.address && (
+          <div className="mt-1">
+            <p className="text-[10px] text-ios-tertiary mb-0.5">{t.keyPersonAddress}</p>
+            <p className="text-xs text-ios-label">{person.address}</p>
+          </div>
+        )}
       </div>
     );
   }
@@ -142,6 +157,34 @@ function KeyPersonSlot({ slot, cust, onPatch, canEdit, autoFocus, onDone }) {
             focus:border-brand-500 focus:outline-none py-0.5 cursor-pointer"
         />
       </div>
+      {/* C4: phone/address — only once the key person row exists server-side
+          (a brand-new slot filled via the name field above won't have a
+          person row until the customer view reloads — see note in
+          CLAUDE.md parity spec / dashboard counterpart). */}
+      {person?.id && (
+        <>
+          <div className="mt-1">
+            <p className="text-[10px] text-ios-tertiary mb-0.5">{t.keyPersonPhone}</p>
+            <input
+              type="tel"
+              defaultValue={person.phone || ''}
+              onBlur={e => onPatchPerson(person.id, { phone: e.target.value || null })}
+              className="w-full text-sm text-ios-label bg-transparent border-b border-dashed border-gray-300
+                focus:border-brand-500 focus:outline-none py-0.5"
+            />
+          </div>
+          <div className="mt-1">
+            <p className="text-[10px] text-ios-tertiary mb-0.5">{t.keyPersonAddress}</p>
+            <input
+              type="text"
+              defaultValue={person.address || ''}
+              onBlur={e => onPatchPerson(person.id, { address: e.target.value || null })}
+              className="w-full text-sm text-ios-label bg-transparent border-b border-dashed border-gray-300
+                focus:border-brand-500 focus:outline-none py-0.5"
+            />
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/florist/src/components/steps/Step1Customer.jsx
+++ b/apps/florist/src/components/steps/Step1Customer.jsx
@@ -3,9 +3,11 @@
 
 import { useState, useEffect, useRef } from 'react';
 import client from '../../api/client.js';
+import { useToast } from '../../context/ToastContext.jsx';
 import t from '../../translations.js';
 
 export default function Step1Customer({ customerId, customerName, onSelect, onChange }) {
+  const { showToast } = useToast();
   const [query, setQuery]           = useState('');
   const [results, setResults]       = useState([]);
   const [searching, setSearching]   = useState(false);
@@ -21,6 +23,8 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
   const [kpResults, setKpResults] = useState([]);
   const [kpId, setKpId]           = useState(null);
   const [kpName, setKpName]       = useState('');
+  const [kpPhone, setKpPhone]     = useState('');
+  const [kpAddress, setKpAddress] = useState('');
   const [kpCreating, setKpCreating] = useState(false);
   const kpDebounceRef               = useRef(null);
 
@@ -57,6 +61,8 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
     setKpQuery('');
     setKpId(null);
     setKpName('');
+    setKpPhone('');
+    setKpAddress('');
     setQuery('');
     setResults([]);
     setShowCreate(false);
@@ -81,14 +87,24 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
   // Advance the wizard with the selected customer + optional key person
   async function handleContinue() {
     if (!chosenCustomer) return;
-    let resolvedKpId = kpId;
+    let resolvedKpId    = kpId;
+    let resolvedPhone   = kpPhone;
+    let resolvedAddress = kpAddress;
     // If user typed a name without picking a suggestion → create the key person
     if (!resolvedKpId && kpName.trim()) {
       setKpCreating(true);
       try {
-        const res = await client.post(`/customers/${chosenCustomer.id}/key-people`, { name: kpName.trim() });
-        resolvedKpId = res.data.id;
-      } catch { /* best-effort */ }
+        const reqBody = { name: kpName.trim() };
+        if (kpPhone.trim())   reqBody.phone   = kpPhone.trim();
+        if (kpAddress.trim()) reqBody.address = kpAddress.trim();
+        const res = await client.post(`/customers/${chosenCustomer.id}/key-people`, reqBody);
+        resolvedKpId    = res.data.id;
+        resolvedPhone   = res.data.phone   || '';
+        resolvedAddress = res.data.address || '';
+      } catch (err) {
+        console.error('Failed to create key person:', err);
+        showToast(err.response?.data?.error || t.error, 'error');
+      }
       finally { setKpCreating(false); }
     }
     onSelect({
@@ -97,6 +113,13 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
       customerCommMethod:  chosenCustomer['Communication method'] || '',
       keyPersonId:         resolvedKpId || null,
       keyPersonName:       resolvedKpId ? (kpName || '') : '',
+      keyPersonPhone:      resolvedKpId ? (resolvedPhone   || '') : '',
+      keyPersonAddress:    resolvedKpId ? (resolvedAddress || '') : '',
+      ...(resolvedKpId ? {
+        recipientName:   kpName || '',
+        recipientPhone:  resolvedPhone   || '',
+        deliveryAddress: resolvedAddress || '',
+      } : {}),
     });
   }
 
@@ -360,6 +383,7 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
                 value={kpName}
                 onChange={e => {
                   setKpName(e.target.value);
+                  if (kpId) { setKpPhone(''); setKpAddress(''); }
                   setKpId(null); // clear matched id when user edits
                   setKpQuery(e.target.value);
                 }}
@@ -369,7 +393,7 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
               />
               {kpName && (
                 <button
-                  onClick={() => { setKpName(''); setKpId(null); setKpQuery(''); }}
+                  onClick={() => { setKpName(''); setKpId(null); setKpQuery(''); setKpPhone(''); setKpAddress(''); }}
                   className="text-ios-tertiary text-sm"
                 >✕</button>
               )}
@@ -380,10 +404,17 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
                 {kpFiltered.map(p => (
                   <button
                     key={p.id}
-                    onClick={() => { setKpId(p.id); setKpName(p.name); setKpQuery(''); }}
+                    onClick={() => { setKpId(p.id); setKpName(p.name); setKpQuery(''); setKpPhone(p.phone || ''); setKpAddress(p.address || ''); }}
                     className={`w-full text-left px-4 py-3 flex items-center gap-2 active:bg-ios-fill ${kpId === p.id ? 'bg-brand-50 dark:bg-brand-900/20' : ''}`}
                   >
-                    <span className="flex-1 text-ios-label text-sm">{p.name}</span>
+                    <span className="flex-1 min-w-0 text-left">
+                      <span className="block text-ios-label text-sm">{p.name}</span>
+                      {(p.phone || p.address) && (
+                        <span className="block text-xs text-ios-tertiary truncate">
+                          {[p.phone, p.address].filter(Boolean).join(' · ')}
+                        </span>
+                      )}
+                    </span>
                     {kpId === p.id && <span className="text-brand-600 text-xs">✓</span>}
                   </button>
                 ))}
@@ -394,6 +425,35 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
             {t.keyPeople || 'Key people'} — {t.optional || 'optional'}
           </p>
         </div>
+
+        {/* New-recipient phone/address — only shown while creating a brand new key person */}
+        {!kpId && kpName.trim() && (
+          <div>
+            <p className="ios-label">{t.addRecipient}</p>
+            <div className="ios-card overflow-hidden divide-y divide-ios-separator/40">
+              <div className="flex items-center px-4 py-3 gap-3">
+                <span className="text-sm text-ios-tertiary w-24 shrink-0">{t.recipientPhone}</span>
+                <input
+                  type="tel"
+                  value={kpPhone}
+                  onChange={e => setKpPhone(e.target.value)}
+                  placeholder="+48 000 000 000"
+                  className="flex-1 text-base bg-transparent outline-none text-ios-label placeholder-ios-tertiary/50"
+                />
+              </div>
+              <div className="flex items-center px-4 py-3 gap-3">
+                <span className="text-sm text-ios-tertiary w-24 shrink-0">{t.recipientAddress}</span>
+                <input
+                  type="text"
+                  value={kpAddress}
+                  onChange={e => setKpAddress(e.target.value)}
+                  placeholder="ul. Kwiatowa 1, Krakow"
+                  className="flex-1 text-base bg-transparent outline-none text-ios-label placeholder-ios-tertiary/50"
+                />
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Continue */}
         <button

--- a/apps/florist/src/components/steps/Step3Details.jsx
+++ b/apps/florist/src/components/steps/Step3Details.jsx
@@ -1,5 +1,6 @@
 // Step3Details — consistent pill-button selectors throughout, matching Order Source style.
 
+import { useEffect } from 'react';
 import t from '../../translations.js';
 import DatePicker from '../DatePicker.jsx';
 import useConfigLists from '../../hooks/useConfigLists.js';
@@ -74,6 +75,18 @@ export default function Step3Details({ form, onChange }) {
   const { orderSources: SOURCES, paymentMethods: payMethods, timeSlots, slotLeadTimeMinutes } = useConfigLists();
   const smartSlots = getAvailableSlots(timeSlots, form.deliveryDate, slotLeadTimeMinutes);
   const set = key => val => onChange({ [key]: val });
+
+  // CR-30 C3: when a recipient (key person) is chosen and fulfilment is Delivery,
+  // pre-fill the editable recipient fields from the chosen person — empty-only so we
+  // never overwrite a manual edit. Derives from local form state (pitfall #1).
+  useEffect(() => {
+    if (form.deliveryType !== 'Delivery' || !form.keyPersonId) return;
+    const patch = {};
+    if (!form.recipientName   && form.keyPersonName)    patch.recipientName   = form.keyPersonName;
+    if (!form.recipientPhone  && form.keyPersonPhone)   patch.recipientPhone  = form.keyPersonPhone;
+    if (!form.deliveryAddress && form.keyPersonAddress) patch.deliveryAddress = form.keyPersonAddress;
+    if (Object.keys(patch).length) onChange(patch);
+  }, [form.deliveryType, form.keyPersonId]);
 
   // When date changes, clear time slot if it's no longer available
   function handleDateChange(val) {

--- a/apps/florist/src/pages/NewOrderPage.jsx
+++ b/apps/florist/src/pages/NewOrderPage.jsx
@@ -12,6 +12,7 @@ import Step4Review   from '../components/steps/Step4Review.jsx';
 
 const emptyForm = {
   customerId: '', customerName: '', keyPersonId: null, keyPersonName: '',
+  keyPersonPhone: '', keyPersonAddress: '',
   customerRequest: '', orderLines: [], priceOverride: '',
   source: 'In-store', deliveryType: 'Pickup',
   requiredBy: '', recipientName: '', recipientPhone: '',

--- a/apps/florist/src/translations.js
+++ b/apps/florist/src/translations.js
@@ -163,6 +163,8 @@ const en = {
   optional:         'optional',
   recipientName:    'Recipient name',
   recipientPhone:   'Recipient phone',
+  addRecipient:     'Add new recipient',
+  recipientAddress: 'Recipient address',
   deliveryAddress:  'Delivery address',
   cardText:         'Card message',
   cardTextPlaceholder: 'Card message for the recipient…',
@@ -778,6 +780,8 @@ const en = {
   keyPersonForOrder:         'Order for',
   keyPersonOrderPlaceholder: 'Who is this order for?',
   importantDate:             'Important date',
+  keyPersonPhone:            'Phone',
+  keyPersonAddress:          'Address',
 
   // Timeline
   timeline:                  'Timeline',
@@ -1056,6 +1060,8 @@ const ru = {
   optional:         'необязательно',
   recipientName:    'Имя получателя',
   recipientPhone:   'Телефон получателя',
+  addRecipient:     'Новый получатель',
+  recipientAddress: 'Адрес получателя',
   deliveryAddress:  'Адрес доставки',
   cardText:         'Текст открытки',
   cardTextPlaceholder: 'Текст открытки для получателя…',
@@ -1671,6 +1677,8 @@ const ru = {
   keyPersonForOrder:         'Заказ для',
   keyPersonOrderPlaceholder: 'Для кого этот заказ?',
   importantDate:             'Важная дата',
+  keyPersonPhone:            'Телефон',
+  keyPersonAddress:          'Адрес',
 
   // Timeline
   timeline:                  'История',

--- a/backend/src/__tests__/customerRepo.keyPeople.integration.test.js
+++ b/backend/src/__tests__/customerRepo.keyPeople.integration.test.js
@@ -11,7 +11,7 @@ vi.mock('../db/index.js', () => ({
   disconnectPostgres: async () => {},
 }));
 
-import { createKeyPerson, listKeyPeople } from '../repos/customerRepo.js';
+import { createKeyPerson, listKeyPeople, updateKeyPerson } from '../repos/customerRepo.js';
 
 let harness, customerId;
 
@@ -65,5 +65,67 @@ describe('key_people phone + address (CR-30 C1)', () => {
     const created = await createKeyPerson(customerId, { name: 'X', phone: '', address: '' });
     expect(created.phone).toBeNull();
     expect(created.address).toBeNull();
+  });
+});
+
+describe('updateKeyPerson (CR-30 C4)', () => {
+  it('updates name + phone + address and reflects the change in listKeyPeople', async () => {
+    const created = await createKeyPerson(customerId, {
+      name: 'Babcia Maria',
+      phone: '+48500100200',
+      address: 'ul. Kwiatowa 7, Kraków',
+      importantDate: '1950-03-08',
+      importantDateLabel: 'Birthday',
+    });
+
+    const updated = await updateKeyPerson(created.id, {
+      name: 'Babcia Maria Nowak',
+      phone: '+48500999888',
+      address: 'ul. Różana 12, Kraków',
+    });
+
+    expect(updated).toMatchObject({
+      id:      created.id,
+      name:    'Babcia Maria Nowak',
+      phone:   '+48500999888',
+      address: 'ul. Różana 12, Kraków',
+      importantDate: '1950-03-08',
+      importantDateLabel: 'Birthday',
+    });
+
+    const list = await listKeyPeople(customerId);
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      name:    'Babcia Maria Nowak',
+      phone:   '+48500999888',
+      address: 'ul. Różana 12, Kraków',
+    });
+  });
+
+  it('partial update of only phone leaves name + address intact', async () => {
+    const created = await createKeyPerson(customerId, {
+      name: 'Brat Piotr',
+      phone: '+48111222333',
+      address: 'ul. Lipowa 4, Kraków',
+    });
+
+    const updated = await updateKeyPerson(created.id, { phone: '+48999000111' });
+
+    expect(updated).toMatchObject({
+      name:    'Brat Piotr',
+      phone:   '+48999000111',
+      address: 'ul. Lipowa 4, Kraków',
+    });
+
+    const [row] = await listKeyPeople(customerId);
+    expect(row.name).toBe('Brat Piotr');
+    expect(row.phone).toBe('+48999000111');
+    expect(row.address).toBe('ul. Lipowa 4, Kraków');
+  });
+
+  it('throws statusCode 404 when updating a non-existent key person', async () => {
+    await expect(
+      updateKeyPerson('00000000-0000-0000-0000-000000000000', { phone: '+48000000000' }),
+    ).rejects.toMatchObject({ statusCode: 404 });
   });
 });

--- a/backend/src/__tests__/customerRepo.keyPeople.integration.test.js
+++ b/backend/src/__tests__/customerRepo.keyPeople.integration.test.js
@@ -1,0 +1,69 @@
+// Integration: key_people phone + address round-trip (CR-30 C1).
+// Boots pglite, applies migrations (incl. 0018), exercises the repo against real SQL.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import { customers } from '../db/schema.js';
+
+const dbHolder = { db: null };
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+import { createKeyPerson, listKeyPeople } from '../repos/customerRepo.js';
+
+let harness, customerId;
+
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+  const [c] = await harness.db.insert(customers).values({ name: 'Anna Test' }).returning();
+  customerId = c.id;
+});
+
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+describe('key_people phone + address (CR-30 C1)', () => {
+  it('persists phone + address on create and returns them from list', async () => {
+    const created = await createKeyPerson(customerId, {
+      name: 'Babcia Maria',
+      phone: '+48500100200',
+      address: 'ul. Kwiatowa 7, Kraków',
+      importantDate: '1950-03-08',
+      importantDateLabel: 'Birthday',
+    });
+
+    expect(created).toMatchObject({
+      name: 'Babcia Maria',
+      phone: '+48500100200',
+      address: 'ul. Kwiatowa 7, Kraków',
+    });
+
+    const list = await listKeyPeople(customerId);
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      name: 'Babcia Maria',
+      phone: '+48500100200',
+      address: 'ul. Kwiatowa 7, Kraków',
+      importantDateLabel: 'Birthday',
+    });
+  });
+
+  it('defaults phone + address to null when omitted (back-compat)', async () => {
+    await createKeyPerson(customerId, { name: 'Brat Piotr' });
+    const [row] = await listKeyPeople(customerId);
+    expect(row.name).toBe('Brat Piotr');
+    expect(row.phone).toBeNull();
+    expect(row.address).toBeNull();
+  });
+
+  it('treats empty-string phone/address as null', async () => {
+    const created = await createKeyPerson(customerId, { name: 'X', phone: '', address: '' });
+    expect(created.phone).toBeNull();
+    expect(created.address).toBeNull();
+  });
+});

--- a/backend/src/db/migrations/0018_key_people_phone_address.sql
+++ b/backend/src/db/migrations/0018_key_people_phone_address.sql
@@ -1,0 +1,8 @@
+-- Recipient phone + address as first-class key_people columns (CR-30).
+-- Makes each connected key person a reusable address book: phone + delivery
+-- address are stored once and pre-fill every future delivery to that person.
+-- Additive + nullable → safe on prod.
+
+ALTER TABLE "key_people" ADD COLUMN "phone" text;
+--> statement-breakpoint
+ALTER TABLE "key_people" ADD COLUMN "address" text;

--- a/backend/src/db/schema.js
+++ b/backend/src/db/schema.js
@@ -302,6 +302,8 @@ export const keyPeople = pgTable('key_people', {
   customerId:         uuid('customer_id').notNull().references(() => customers.id, { onDelete: 'cascade' }),
   name:               text('name').notNull(),
   contactDetails:     text('contact_details'),
+  phone:              text('phone'),      // recipient phone — reusable address book (CR-30)
+  address:            text('address'),    // recipient delivery address (CR-30)
   importantDate:      date('important_date'),
   importantDateLabel: text('important_date_label'),
   createdAt:          timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),

--- a/backend/src/repos/customerRepo.js
+++ b/backend/src/repos/customerRepo.js
@@ -393,6 +393,68 @@ export async function createKeyPerson(customerId, { name, contactDetails = null,
   };
 }
 
+export async function updateKeyPerson(personId, changes = {}) {
+  const set = {};
+
+  // Use `!== undefined` rather than `'key' in changes` so this is robust whether
+  // the caller passes a sparse literal (tests) or a destructured object where every
+  // key is an own-property but unset keys are `undefined` (the route handler).
+  if (changes.name !== undefined) {
+    if (!changes.name || !changes.name.trim()) {
+      const err = new Error('name is required');
+      err.statusCode = 400;
+      throw err;
+    }
+    set.name = changes.name.trim();
+  }
+  if (changes.contactDetails !== undefined) set.contactDetails = changes.contactDetails || null;
+  if (changes.phone !== undefined) set.phone = changes.phone || null;
+  if (changes.address !== undefined) set.address = changes.address || null;
+  if (changes.importantDate !== undefined) {
+    if (changes.importantDate != null && changes.importantDate !== '') {
+      if (!ISO_DATE_RE.test(changes.importantDate)) {
+        const err = new Error(
+          `important_date must be in YYYY-MM-DD format (received: "${changes.importantDate}").`,
+        );
+        err.statusCode = 400;
+        throw err;
+      }
+      set.importantDate = changes.importantDate;
+    } else {
+      set.importantDate = null;
+    }
+  }
+  if (changes.importantDateLabel !== undefined) set.importantDateLabel = changes.importantDateLabel || null;
+
+  if (Object.keys(set).length === 0) {
+    const err = new Error('No valid fields to update.');
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const [row] = await db.update(keyPeople)
+    .set(set)
+    .where(and(eq(keyPeople.id, personId), isNull(keyPeople.deletedAt)))
+    .returning();
+
+  if (!row) {
+    const err = new Error('Key person not found.');
+    err.statusCode = 404;
+    throw err;
+  }
+
+  return {
+    id:            row.id,
+    name:          row.name,
+    contactDetails: row.contactDetails ?? null,
+    phone:          row.phone ?? null,
+    address:        row.address ?? null,
+    importantDate:  row.importantDate ?? null,
+    importantDateLabel: row.importantDateLabel ?? null,
+    createdAt:     row.createdAt,
+  };
+}
+
 // Read-only: all key people with a set important date, joined to their customer.
 // Used by crmPack.upcomingOccasionsHandler to surface upcoming annual occasions.
 export async function listKeyPeopleWithDates() {

--- a/backend/src/repos/customerRepo.js
+++ b/backend/src/repos/customerRepo.js
@@ -358,13 +358,15 @@ export async function listKeyPeople(customerId) {
     id:            r.id,
     name:          r.name,
     contactDetails: r.contactDetails ?? null,
+    phone:          r.phone ?? null,
+    address:        r.address ?? null,
     importantDate:  r.importantDate ?? null,
     importantDateLabel: r.importantDateLabel ?? null,
     createdAt:     r.createdAt,
   }));
 }
 
-export async function createKeyPerson(customerId, { name, contactDetails = null, importantDate = null, importantDateLabel = null } = {}) {
+export async function createKeyPerson(customerId, { name, contactDetails = null, phone = null, address = null, importantDate = null, importantDateLabel = null } = {}) {
   if (!name || !name.trim()) {
     const err = new Error('name is required');
     err.statusCode = 400;
@@ -374,6 +376,8 @@ export async function createKeyPerson(customerId, { name, contactDetails = null,
     customerId,
     name: name.trim(),
     contactDetails: contactDetails || null,
+    phone: phone || null,
+    address: address || null,
     importantDate: importantDate || null,
     importantDateLabel: importantDateLabel || null,
   }).returning();
@@ -381,6 +385,8 @@ export async function createKeyPerson(customerId, { name, contactDetails = null,
     id:            row.id,
     name:          row.name,
     contactDetails: row.contactDetails ?? null,
+    phone:          row.phone ?? null,
+    address:        row.address ?? null,
     importantDate:  row.importantDate ?? null,
     importantDateLabel: row.importantDateLabel ?? null,
     createdAt:     row.createdAt,

--- a/backend/src/routes/customers.js
+++ b/backend/src/routes/customers.js
@@ -238,8 +238,8 @@ router.get('/:id/key-people', async (req, res, next) => {
 // POST /api/customers/:id/key-people — create a new key person for a customer
 router.post('/:id/key-people', async (req, res, next) => {
   try {
-    const { name, contactDetails, importantDate, importantDateLabel } = req.body;
-    const person = await customerRepo.createKeyPerson(req.params.id, { name, contactDetails, importantDate, importantDateLabel });
+    const { name, contactDetails, phone, address, importantDate, importantDateLabel } = req.body;
+    const person = await customerRepo.createKeyPerson(req.params.id, { name, contactDetails, phone, address, importantDate, importantDateLabel });
     res.status(201).json(person);
   } catch (err) {
     if (err.statusCode === 400) return res.status(400).json({ error: err.message });

--- a/backend/src/routes/customers.js
+++ b/backend/src/routes/customers.js
@@ -247,6 +247,18 @@ router.post('/:id/key-people', async (req, res, next) => {
   }
 });
 
+// PATCH /api/customers/:id/key-people/:personId — partial update of a key person
+router.patch('/:id/key-people/:personId', async (req, res, next) => {
+  try {
+    const { name, contactDetails, phone, address, importantDate, importantDateLabel } = req.body;
+    const person = await customerRepo.updateKeyPerson(req.params.personId, { name, contactDetails, phone, address, importantDate, importantDateLabel });
+    res.json(person);
+  } catch (err) {
+    if (err.statusCode === 400 || err.statusCode === 404) return res.status(err.statusCode).json({ error: err.message });
+    next(err);
+  }
+});
+
 // PATCH /api/customers/:id
 router.patch('/:id', async (req, res, next) => {
   try {


### PR DESCRIPTION
## CR-30 — recipient phone + address as a reusable address book

Y-model test-session feature. Each connected **key person** becomes a reusable address book: phone + delivery address are stored once and pre-fill every future delivery to that person, and are visible/editable in CRM.

Plan: `docs/superpowers/plans/2026-06-30-ymodel-test-crs-features.md` (Feature C). Closes #471's tracked work.

### Slices
- **C1 — schema + repo.** Migration `0018_key_people_phone_address.sql` (additive nullable `key_people.phone` + `address`); `createKeyPerson`/`listKeyPeople` read+write them; `POST /customers/:id/key-people` accepts them.
- **C2 — new-order wizard, both apps** (`Step1Customer.jsx`). The existing key-person selector (#216) now captures phone + address. Picking a saved recipient carries their stored contact; "add new recipient" POSTs `{name,phone?,address?}` so it's reusable. Continue sets `keyPersonId` + seeds recipient fields + a snapshot on the form. POST failure toasts (was a silent catch).
- **C3 — delivery pre-fill, both apps** (`Step3Details.jsx`). Recipient chosen + fulfilment=Delivery → pre-fills `recipientName/recipientPhone/deliveryAddress`, **empty-only** (never clobbers manual edits), from local form state (pitfall #1).
- **C4 — CRM, both apps.** New `customerRepo.updateKeyPerson` + route **`PATCH /customers/:id/key-people/:personId`**. `CustomerDetailView`/`KeyPersonChips` show + inline-edit phone/address per key person (persist on blur, toast on error). Florist view-only displays when `!canEdit`.

Parity-locked across florist + dashboard (identical UX, state keys, translation keys). New keys `addRecipient` / `recipientAddress` / `keyPersonPhone` / `keyPersonAddress` in ru + en for both apps.

### Verification
- **Backend** `vitest run` — 90 files / **810 passed**, 0 failed (incl. `customerRepo.keyPeople.integration.test.js`: phone/address round-trip + `updateKeyPerson` full/partial/404, applies migration 0018 on real SQL via pglite).
- **E2E** API suite — **220 passed / 0 failed** (incl. §26 Customer CRUD 18/18).
- **Builds** — dashboard + florist `vite build` green. (No `packages/shared` or delivery change.)
- **Lab `lab-api`** — runs in CI. Local run intentionally skipped: the single shared `flower-lab-pg` container was in use by a parallel session, and 0018 is `ALTER TABLE ADD COLUMN text` already proven on real SQL by the pglite harness — no PG-version risk.

Migration `0018` is additive nullable → safe on prod (deploys on merge via Railway preDeploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
