### PR TITLE
docs(ymodel): mark session-2 CR plans COMPLETE (all CR-01..34 shipped)

### DIFF
--- a/docs/superpowers/plans/2026-06-21-ymodel-session2-fixes-plan.md
+++ b/docs/superpowers/plans/2026-06-21-ymodel-session2-fixes-plan.md
@@ -1,5 +1,7 @@
 # Y-model Session-2 Fixes — Implementation Plan
 
+> ✅ **COMPLETE (2026-06-30).** All slices shipped to master: S0 null-date comparators (CR-02) #407; S1 availability model — On hand/Premade/Available + incoming (CR-03/04/06) #408; S2 new-demand flow — real DE row, sell price, over-allocation gate (CR-01/07/08) #409; S3 stock-panel column alignment + cards (CR-05) #410. Step checkboxes below left unchecked historically — work is done. Kept for history.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Resolve the 8 change-requests captured in the 2026-06-21 Y-model owner test session (`2026-06-21-ymodel-test-session-2-crs.md`) — fixing the availability-bucket semantics, the new-demand order-submit flow, and the stock-panel layout, plus re-landing the crash fix already hot-patched on the lab.

--- a/docs/superpowers/plans/2026-06-21-ymodel-test-session-2-crs.md
+++ b/docs/superpowers/plans/2026-06-21-ymodel-test-session-2-crs.md
@@ -1,5 +1,7 @@
 # Y-model Test Session 2 — Change Requests (2026-06-21)
 
+> ✅ **COMPLETE (2026-06-30).** Every CR captured here (CR-01 … CR-34) has shipped to master. Stock/new-demand cluster: #407 (CR-02), #408 (CR-03/04/06), #409 (CR-01/07/08), #410 (CR-05), #419 (CR-09), #435 (CR-28). Batch-2 copy/UX/trace (CR-10 … CR-18): see `2026-06-22-ymodel-crs-batch2-plan.md`. Flat-table density + waste-log + shortfall (CR-19 … CR-26): individual fix PRs. Session-2026-06-30 feature CRs: #467 (CR-29), #466 (CR-31), #465 (CR-34), #469 (CR-33), #470 (CR-32), #471 (CR-30). Nothing open. Kept for history.
+
 Live owner walkthrough of the Y-model on the lab dev server (`STOCK_Y_MODEL=true`, scenario `y-model-guide`), continuing the thread from the 2026-06-11/12 session. Owner provides feedback → captured here as CRs → later dissected into implementation slices (after compaction).
 
 ## Environment under test
@@ -226,7 +228,7 @@ All 8 CRs sliced into an implementation plan → **`2026-06-21-ymodel-session2-f
 - **Fix:** new pure helper `allocateLinesAgainstVariety(lines, resolve)` walks lines in order, tracks consumed per Variety key, returns each line's `remainingNet = max(0, varietyNet − earlierSiblings)`. `resolve` returns null to skip deferred/future-PO lines. Each badge surface feeds `remainingNet` into `{qty − available} not in stock`. Florist BouquetEditor nets by stockItemId (its single-item model). NEVER mutates the shared varietyAvail object.
 - **Verify:** shared 527/527 (new tests: exact 7→[7,10]→[0,10] case + drain/isolation/deferred/ordering/legacy); 3 apps build; verified live (Playwright) — line 2 now "10 not in stock". **PR #435. Owner-visible.**
 
-## Session 2026-06-30 (live lab test, y-model-guide self-anchored data) 📝 CAPTURED ONLY
+## Session 2026-06-30 (live lab test, y-model-guide self-anchored data) ✅ ALL SHIPPED (2026-06-30)
 
 ### CR-29 — Fixed-price (Price Override) field should PRE-FILL with the live sell total · UX
 - **App/surface:** order creation + premade creation, BOTH apps. Florist `pages/NewOrderPage.jsx` + `components/steps/Step2Bouquet.jsx` (priceOverride input ~line 905-911, placeholder=sellTotal but field empty); dashboard `NewOrderTab` + `steps/Step2Bouquet.jsx`; florist `PremadeBouquetCreatePage.jsx` (line 70) + dashboard `PremadeBouquetCreateModal.jsx`. Possibly edit surfaces too (OrderDetail / premade edit).
@@ -234,7 +236,7 @@ All 8 CRs sliced into an implementation plan → **`2026-06-21-ymodel-session2-f
 - **Current behavior (works, but implicit):** effective price already = `priceOverride ?? sellTotal` (`NewOrderPage.jsx:310`, `orderRepo.js:533`; premade `premadeBouquetService.js`). Lines snapshot sell price at submit so the total doesn't drift post-create. So this CR is about EXPLICITNESS/visibility, not a price-correctness bug.
 - **KEY DESIGN NUANCE (resolve before implementing):** a pre-filled value must still **track the sell total until the user manually edits it**, then detach (become a real override). Otherwise pre-filling early "locks" a stale number when lines are added/removed afterwards. Standard pattern: controlled default synced to sellTotal while `!userTouchedOverride`; on first manual edit, stop syncing. Decide whether to persist the synced value as a real `Price Override` number on save, or keep saving null when untouched (the latter keeps the existing `?? sellTotal` fallback and avoids stale overrides — but then the field is just visually pre-filled, not a saved override). Owner intent leans toward "the number sticks" → likely persist on save once shown. **Confirm at slice time.**
 - **Parity:** CLAUDE.md order-creation + premade parallel implementations — must land in florist AND dashboard for both order and premade.
-- **Status:** 📝 captured, no code yet (owner in collect-feedback mode).
+- **Status:** ✅ SHIPPED → PR #467 (2026-06-30). Fixed-price field pre-fills the live sell total in `Step2Bouquet` (both apps; new-order + premade), tracks sell until manually edited.
 
 ### CR-30 — Recipient/"for whom" step → pre-fill delivery from the chosen key person · FEATURE
 - **Owner ask:** after choosing the customer, the flow should ask "for whom is the bouquet?" → pick an existing/connected **key person** (e.g. his wife) OR add a **new** key person with phone + address. Then in the delivery step, that key person's name/phone/address are **pre-filled** into the delivery info, **editable** (e.g. wife's home is on file, but this time deliver to her office → change just the address).
@@ -245,7 +247,7 @@ All 8 CRs sliced into an implementation plan → **`2026-06-21-ymodel-session2-f
   2. **Inline add-new-key-person** with phone+address during the order flow (today add-key-person lives in CRM).
   3. **Step3 prefill** `recipientName`/`recipientPhone`/`deliveryAddress` from the selected key person's record; keep fully editable; per-order edits do NOT mutate the key person's stored address (this-time-only override). Optional: "save this address back to the key person?" prompt — confirm at slice time.
 - **Scope flag:** this is a **FEATURE** (schema migration + CRM UI + order-flow wiring across 2 apps), not a quick tweak → run via `/feature`, not a one-shot CR fix. Parity mandatory (florist + dashboard order-creation + CRM).
-- **Status:** 📝 captured, no code yet (owner in collect-feedback mode).
+- **Status:** ✅ SHIPPED → PR #471 (2026-06-30). `key_people.phone`+`address` (migration 0018) + reusable address book: recipient picker in the new-order wizard (both apps), delivery pre-fill from the chosen key person, phone/address inline-editable in CRM. Built per plan `2026-06-30-ymodel-test-crs-features.md`.
 
 ### CR-31 — Florist terminal-status button must match delivery type (Delivery → only "Delivered"; Pickup → only "Picked Up") · bug
 - **Owner ask:** when an order is a **Delivery**, after the florist delivers it she should see ONLY the **Delivered** button (not Picked Up). When it's a **Pickup**, after the client collects it she should see ONLY the **Picked Up** button (not Delivered). No mixing. (Driver→Delivered already cascades automatically — this is about the florist's manual buttons.)

--- a/docs/superpowers/plans/2026-06-22-ymodel-crs-batch2-plan.md
+++ b/docs/superpowers/plans/2026-06-22-ymodel-crs-batch2-plan.md
@@ -1,5 +1,7 @@
 # Y-model Test-Session Batch-2 CRs (CR-10 … CR-17) — Implementation Plan
 
+> ✅ **COMPLETE (2026-06-30).** All slices S1–S7 shipped to master: S1 copy/i18n (CR-10/14-label/15) `9793f85`; S2 premade-subset (CR-17) `3ff38e8`; S3 ·mix logic (CR-14) `3b77d26`; S4 row spacing (CR-11) `13d7f56`; S5 dotted underline (CR-13) `72cf967`; S6 trace graph-button + absorbed-row (CR-12/16) `ffba2c5`; S7 balance graph (CR-18) `954e160`. Ledger below left unchecked historically — work is done. Kept for history.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) tracking. **One branch** `fix/ymodel-crs-batch2` off master, **commit per slice**, **one PR** at the end (the slices share files heavily — per-slice branches would conflict). CRs sourced from `docs/superpowers/plans/2026-06-21-ymodel-test-session-2-crs.md` (CR-10 … CR-17, captured 2026-06-22 afternoon).
 
 **Goal:** Land the seven display/UX fixes the owner raised live-testing the Y-model trace + stock screens.

--- a/docs/superpowers/plans/2026-06-30-ymodel-test-crs-features.md
+++ b/docs/superpowers/plans/2026-06-30-ymodel-test-crs-features.md
@@ -1,5 +1,7 @@
 # Plan — Y-model test-session feature CRs (CR-30 / CR-32 / CR-33)
 
+> ✅ **COMPLETE (2026-06-30).** All three features shipped: Feature A CR-33 delivery margin → #469; Feature B CR-32 courier time slots → #470 (migration 0017); Feature C CR-30 recipient address book → #471 (migration 0018, slices C1–C4). Plus the small fixes CR-29 #467 / CR-31 #466 / CR-34 #465. Nothing open. Kept for history.
+
 **Date:** 2026-06-30
 **Origin:** Y-model test session 2 CR cluster (`docs/superpowers/plans/2026-06-21-ymodel-test-session-2-crs.md`).
 **Status:** design locked (owner grill 2026-06-30); ready to slice + build.


### PR DESCRIPTION
Stale-doc sync. Every Y-model test-session CR (CR-01…CR-34) has shipped to master, but the planning docs still read as in-progress (unchecked ledgers, "captured, no code yet" status lines) — which would mislead a future session into re-executing finished work.

**Docs touched (all under `docs/superpowers/plans/`):**
- `2026-06-21-ymodel-test-session-2-crs.md` — top COMPLETE banner mapping every CR to its PR; CR-29 + CR-30 status lines flipped to SHIPPED (#467 / #471); section header → ALL SHIPPED.
- `2026-06-21-ymodel-session2-fixes-plan.md` — COMPLETE banner (S0-S3 → #407/#408/#409/#410).
- `2026-06-22-ymodel-crs-batch2-plan.md` — COMPLETE banner (S1-S7).
- `2026-06-30-ymodel-test-crs-features.md` — COMPLETE banner (CR-30/32/33 → #471/#470/#469 + small fixes #467/#466/#465).

**Docs only — no code change.** (Vercel checks may show rate-limited red — account build-quota from today's deploy burst, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)