### PR TITLE
feat(dashboard): new-order speed-dial FAB matching florist app

### DIFF
--- a/apps/dashboard/CLAUDE.md
+++ b/apps/dashboard/CLAUDE.md
@@ -10,7 +10,7 @@ The owner needs two things: (1) daily operational control — same visibility as
 |-----|-----------|---------|
 | Today | DayToDayTab.jsx | Kanban board of today's orders, pending deliveries, low stock alerts, unpaid orders. Cross-tab navigation to drill into details. |
 | Orders | OrdersTab.jsx | Full order list. **Click a column header to sort** by it (asc ⇄ desc on repeat click; brand ▲/▼ on the active column, faint ⇅ on hover for idle sortable columns); a **funnel button** beside each header opens that column's filter popover (# / Order date / Customer / Bouquet / Status+Payment / Type / Fulfilment date / Total). Fulfilment column split into Type (🚗/🏪) + date cells. A **Маржа** column shows each order's profit margin as a coloured dot + % (green ≥55% / amber 40–54% / red <40% / gray = no flower cost) — profit health, NOT payment status. Date inputs use custom DatePicker (day-month-year). Shared `orderFilters` util drives filter state; only server fields refetch — client text/price filters apply in memory (no per-keystroke fetch). Ticking orders shows a selection-totals bar (Sales / Paid / Outstanding / Profit+margin% / Avg). Opens OrderDetailPanel for inline editing. |
-| New Order | NewOrderTab.jsx | 4-step order creation wizard (same steps as florist: Customer → Bouquet → Details → Review). |
+| New Order | NewOrderTab.jsx | 4-step order creation wizard (same steps as florist: Customer → Bouquet → Details → Review). **No top nav pill** — launched from the bottom-right speed-dial FAB in `DashboardPage.jsx` (matches the florist `OrderListPage` FAB): 📋 paste-import (→ `TextImportModal` → AI parse → prefill via `initialFilter.importDraft`) / 💐 premade (→ `PremadeBouquetCreateModal`) / ✏️ manual (→ `navigateTo({tab:'newOrder'})`). The `newOrder` tab content is still rendered; only its pill was removed. |
 | Stock | StockTab.jsx | Inventory management with optimistic qty adjustments, write-off, visibility toggles, stock receive form. Uses `getEffectiveStock` from shared. Y-model collapsed Variety list under `STOCK_Y_MODEL` (TypeGroupHeader + VarietyListItem + BatchTracePanel inline from shared); legacy flat list when flag off. |
 | Customers | CustomersTab.jsx | CRM — customer list with segmentation (RFM scoring), detail panel with order history, editable fields. |
 | Financial | FinancialTab.jsx | Recharts-powered analytics: revenue, margins, top products, waste, source ROI, supplier scorecard. Lazy-loaded. |
@@ -19,7 +19,7 @@ The owner needs two things: (1) daily operational control — same visibility as
 | Admin | AdminTab.jsx | Owner-only — Postgres migration health, parity dashboards (stock, soon orders), audit log viewer. Powers the shadow-week verification. |
 | Variety Backfill | VarietyBackfillTab.jsx | Owner-only pre-cutover UI: fills Type/Colour/Size/Cultivar on stock rows where type_name IS NULL. Status banner, autocomplete inputs, cultivar prefill, bulk-edit panel. |
 | Issues | IssuesTab.jsx | In-app GitHub issue tracker (owner-only). Browse open/closed issues, set priority (`priority:*` labels), manage labels, comment, close/reopen, create new issues. Backed by `GET/POST/PATCH /api/issues` (proxy over GitHub REST). Dashboard-only — not in the florist app (owner's strategic-oversight surface, like Financial/Admin). |
-| ~~Assistant~~ | ~~AssistantTab.jsx~~ | Removed — replaced by the shared `AskBlossomLauncher` FAB mounted in `DashboardPage.jsx` (bottom-right floating button → opens full right-side drawer on desktop / bottom sheet on mobile). |
+| ~~Assistant~~ | ~~AssistantTab.jsx~~ | Removed — replaced by the shared `AskBlossomLauncher` FAB mounted in `DashboardPage.jsx`. Stacked at `bottom-24 right-6` (above the new-order FAB at `bottom-6 right-6`, same as the florist app) → opens full right-side drawer on desktop / bottom sheet on mobile. |
 
 ## Key Components
 | Component | Purpose |
@@ -34,6 +34,7 @@ The owner needs two things: (1) daily operational control — same visibility as
 | StockReceiveForm.jsx | Record incoming supplier deliveries with batch tracking. |
 | BouquetSection.jsx / DeliverySection.jsx | Sub-sections of OrderDetailPanel for bouquet editing and delivery info. |
 | PremadeBouquetCreateModal.jsx / PremadeBouquetList.jsx | Premade bouquet template editor + listing. |
+| TextImportModal.jsx | AI paste-import (mirror of florist's) — opened from the new-order FAB; `POST /intake/parse` → draft → `NewOrderTab` prefill. |
 | TopProductsWidget.jsx / SourceChart.jsx / SummaryCard.jsx / Pills.jsx | Financial-tab building blocks. |
 | InlineEdit.jsx / DatePicker.jsx / Skeleton.jsx / Toast.jsx / HelpPanel.jsx | UI primitives. DatePicker is duplicated with florist — TODO move to shared. |
 | order/ColumnFilterPopover.jsx | Generic header **funnel-button** popover shell for per-column filters. Props: `active` (fills the funnel + shows a dot), `title` (popover heading + aria-label), `align` ('left' \| 'right' — right-anchor the panel on right-aligned columns so it doesn't spill past the viewport), `children` (filter controls). Consumed by OrdersTab for all 8 column header popovers; the header label itself is a separate sort control (SortHeader). |

--- a/apps/dashboard/src/components/NewOrderTab.jsx
+++ b/apps/dashboard/src/components/NewOrderTab.jsx
@@ -31,6 +31,7 @@ export default function NewOrderTab({ onNavigate, initialFilter }) {
   const [submitting, setSubmitting] = useState(false);
   const [stock, setStock]     = useState([]);
   const [premadeBouquets, setPremadeBouquets] = useState([]);
+  const [importWarnings, setImportWarnings] = useState([]);
 
   useEffect(() => {
     cachedGet('/stock?includeEmpty=true&includeInactive=true').then(r => setStock(r.data)).catch(console.error);
@@ -72,6 +73,57 @@ export default function NewOrderTab({ onNavigate, initialFilter }) {
       }
     })();
   }, [initialFilter?.matchPremadeId]);
+
+  // Path C: owner pasted a customer message in the FAB's TextImportModal — the
+  // AI-parsed draft arrives via initialFilter.importDraft. Prefill the wizard.
+  // Mirror of the florist app's NewOrderPage importDraft handler (parity).
+  useEffect(() => {
+    const draft = initialFilter?.importDraft;
+    if (!draft) return;
+
+    const patch = {};
+    if (draft.customerRequest) patch.customerRequest = draft.customerRequest;
+    if (draft.source) patch.source = draft.source;
+    if (draft.paymentStatus) patch.paymentStatus = draft.paymentStatus;
+    if (draft.notes) patch.notes = draft.notes;
+    if (draft.deliveryFee != null) patch.deliveryFee = draft.deliveryFee;
+    if (draft.totalPrice) patch.priceOverride = String(draft.totalPrice);
+
+    // Delivery fields
+    if (draft.delivery?.address) {
+      patch.deliveryType = 'Delivery';
+      patch.deliveryAddress = draft.delivery.address;
+    }
+    if (draft.delivery?.recipientName) patch.recipientName = draft.delivery.recipientName;
+    if (draft.delivery?.recipientPhone) patch.recipientPhone = draft.delivery.recipientPhone;
+    if (draft.delivery?.date) patch.deliveryDate = draft.delivery.date;
+    if (draft.delivery?.time) patch.deliveryTime = draft.delivery.time;
+    if (draft.delivery?.cardText) patch.cardText = draft.delivery.cardText;
+
+    // Order lines from AI matching
+    if (draft.orderLines?.length > 0) {
+      patch.orderLines = draft.orderLines.map(l => ({
+        stockItemId:      l.stockItemId || null,
+        flowerName:       l.flowerName || '',
+        quantity:         l.quantity || 1,
+        costPricePerUnit: l.costPricePerUnit || 0,
+        sellPricePerUnit: l.sellPricePerUnit || 0,
+        confidence:       l.confidence || 'none',
+      }));
+    }
+
+    // Customer — if AI found a match, pre-select them and skip to Step 2
+    if (draft.customer?.suggestedMatchId) {
+      patch.customerId = draft.customer.suggestedMatchId;
+      patch.customerName = draft.customer.suggestedMatchName || draft.customer.name || '';
+      setStep(1);
+    } else if (draft.customer?.name || draft.customer?.phone) {
+      patch.customerName = draft.customer.name || '';
+    }
+
+    setForm(prev => ({ ...prev, ...patch }));
+    setImportWarnings(draft.warnings?.length > 0 ? draft.warnings : []);
+  }, [initialFilter?.importDraft]);
 
   // Path B: user taps a premade bouquet inside Step 2 — lock cart to its composition.
   function handleSelectPremade(bouquet) {
@@ -243,6 +295,16 @@ export default function NewOrderTab({ onNavigate, initialFilter }) {
           ))}
         </div>
       </div>
+
+      {/* Import warnings — surfaced when the AI paste-import flagged ambiguities */}
+      {importWarnings.length > 0 && (
+        <div className="max-w-2xl mx-auto mb-4 bg-amber-50 border border-amber-200 rounded-2xl px-4 py-3">
+          <p className="text-sm font-semibold text-amber-800 mb-1">{t.intake.warningsTitle}</p>
+          <ul className="list-disc list-inside text-sm text-amber-700 space-y-0.5">
+            {importWarnings.map((w, i) => <li key={i}>{w}</li>)}
+          </ul>
+        </div>
+      )}
 
       {/* Step content */}
       <div className="max-w-2xl mx-auto">

--- a/apps/dashboard/src/components/TextImportModal.jsx
+++ b/apps/dashboard/src/components/TextImportModal.jsx
@@ -1,0 +1,120 @@
+// TextImportModal — paste customer messages or Flowwow email text,
+// AI parses it into a structured draft that pre-fills the order wizard.
+// Mirror of the florist app's TextImportModal so the owner gets the same
+// paste-import entry point on the dashboard (cross-app parity). Like a
+// receiving inspection station: raw text in, structured draft out.
+
+import { useState } from 'react';
+import client from '../api/client.js';
+import t from '../translations.js';
+
+export default function TextImportModal({ onClose, onParsed }) {
+  const [text, setText]       = useState('');
+  const [type, setType]       = useState('general');
+  const [loading, setLoading] = useState(false);
+  const [error, setError]     = useState('');
+
+  async function handleParse() {
+    if (!text.trim()) return;
+    setLoading(true);
+    setError('');
+    try {
+      const res = await client.post('/intake/parse', { text: text.trim(), type });
+      onParsed(res.data);
+      onClose();
+    } catch (err) {
+      const msg = err.response?.data?.error || err.message || t.intake.parseError;
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center" onClick={onClose}>
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/40" />
+
+      {/* Modal — slides up from bottom, like iOS sheet */}
+      <div
+        className="relative w-full max-w-lg bg-white rounded-t-3xl shadow-2xl px-5 pt-4 pb-8 max-h-[85vh] flex flex-col"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Handle bar */}
+        <div className="w-10 h-1 bg-gray-300 rounded-full mx-auto mb-4" />
+
+        {/* Header */}
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-bold text-ios-label">{t.intake.title}</h2>
+          <button onClick={onClose} className="text-ios-tertiary text-2xl leading-none px-1">×</button>
+        </div>
+
+        {/* Mode toggle */}
+        <div className="flex gap-2 mb-4">
+          <button
+            onClick={() => setType('general')}
+            className={`flex-1 py-2.5 rounded-xl text-sm font-semibold transition-colors ${
+              type === 'general'
+                ? 'bg-brand-600 text-white'
+                : 'bg-gray-100 text-ios-secondary'
+            }`}
+          >
+            {t.intake.modeGeneral}
+          </button>
+          <button
+            onClick={() => setType('flowwow')}
+            className={`flex-1 py-2.5 rounded-xl text-sm font-semibold transition-colors ${
+              type === 'flowwow'
+                ? 'bg-brand-600 text-white'
+                : 'bg-gray-100 text-ios-secondary'
+            }`}
+          >
+            Flowwow
+          </button>
+        </div>
+
+        {/* Hint */}
+        <p className="text-xs text-ios-tertiary mb-2">
+          {type === 'flowwow' ? t.intake.hintFlowwow : t.intake.hintGeneral}
+        </p>
+
+        {/* Textarea */}
+        <textarea
+          value={text}
+          onChange={e => setText(e.target.value)}
+          placeholder={type === 'flowwow' ? t.intake.placeholderFlowwow : t.intake.placeholderGeneral}
+          rows={8}
+          className="flex-1 w-full bg-gray-50 rounded-2xl px-4 py-3 text-base text-ios-label
+                     outline-none resize-none placeholder-ios-tertiary/50 border border-gray-200
+                     focus:border-brand-300 focus:ring-2 focus:ring-brand-100 transition-all"
+          autoFocus
+        />
+
+        {/* Error */}
+        {error && (
+          <div className="mt-3 bg-red-50 border border-red-200 rounded-xl px-4 py-2.5">
+            <p className="text-sm text-red-700">{error}</p>
+          </div>
+        )}
+
+        {/* Parse button */}
+        <button
+          onClick={handleParse}
+          disabled={!text.trim() || loading}
+          className="mt-4 w-full h-14 rounded-2xl bg-brand-600 text-white text-base font-semibold
+                     disabled:opacity-30 active:bg-brand-700 transition-colors shadow-lg
+                     flex items-center justify-center gap-2"
+        >
+          {loading ? (
+            <>
+              <div className="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+              {t.intake.parsing}
+            </>
+          ) : (
+            t.intake.parseButton
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/src/pages/DashboardPage.jsx
+++ b/apps/dashboard/src/pages/DashboardPage.jsx
@@ -20,6 +20,10 @@ const SettingsTab = lazy(() => import('../components/SettingsTab.jsx'));
 const VarietyBackfillTab = lazy(() => import('../components/VarietyBackfillTab.jsx'));
 const FinancialTab = lazy(() => import('../components/FinancialTab.jsx'));
 const IssuesTab = lazy(() => import('../components/IssuesTab.jsx'));
+// Modals opened from the new-order speed-dial FAB (bottom-right). Lazy so
+// neither the AI paste-import nor the premade builder weighs on initial load.
+const TextImportModal = lazy(() => import('../components/TextImportModal.jsx'));
+const PremadeBouquetCreateModal = lazy(() => import('../components/PremadeBouquetCreateModal.jsx'));
 function TabFallback() {
   return (
     <div className="flex justify-center py-16">
@@ -34,7 +38,9 @@ export default function DashboardPage() {
   const TABS = [
     { key: 'today',     label: t.tabToday },
     { key: 'orders',    label: t.tabOrders },
-    { key: 'newOrder',  label: t.tabNewOrder },
+    // New Order is no longer a top pill — it's reached via the bottom-right
+    // speed-dial FAB (matching the florist app). The 'newOrder' tab content is
+    // still rendered below; only its nav pill was removed.
     { key: 'stock',     label: t.tabStock },
     { key: 'customers', label: t.tabCustomers },
     { key: 'financial', label: t.tabFinancial },
@@ -64,6 +70,10 @@ export default function DashboardPage() {
   const [filterKey, setFilterKey] = useState(0);
   const [showHelp, setShowHelp] = useState(false);
   const [reportOpen, setReportOpen] = useState(false);
+  // New-order speed-dial FAB (bottom-right) — mirrors the florist app's FAB.
+  const [fabOpen, setFabOpen] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+  const [showPremadeCreate, setShowPremadeCreate] = useState(false);
 
   useEffect(() => {
     setMountedTabs(prev => {
@@ -218,7 +228,77 @@ export default function DashboardPage() {
           onClose={() => setReportOpen(false)}
         />
       )}
-      <AskBlossomLauncher t={t} reporterRole="owner" reporterName="Owner" appArea="dashboard" />
+      {/* New-order speed-dial FAB — tap "+" to expand into paste-import /
+          premade / manual, matching the florist app's OrderListPage FAB.
+          Sits where the Ask Blossom launcher used to be (bottom-right); the
+          launcher is stacked above it so both stay tappable. */}
+      {fabOpen && (
+        <div className="fixed inset-0 z-40" onClick={() => setFabOpen(false)} />
+      )}
+      <div className="fixed bottom-6 right-6 z-50 flex flex-col items-end gap-3">
+        {fabOpen && (
+          <>
+            {/* Paste import option */}
+            <button
+              onClick={() => { setFabOpen(false); setShowImport(true); }}
+              className="flex items-center gap-2 bg-white shadow-lg rounded-full pl-4 pr-3 py-2.5 active:scale-95 transition-transform"
+            >
+              <span className="text-sm font-semibold text-ios-label">{t.intake.fabLabel}</span>
+              <span className="w-10 h-10 rounded-full bg-amber-500 text-white text-lg flex items-center justify-center">📋</span>
+            </button>
+            {/* Premade bouquet option — compose without a customer */}
+            <button
+              onClick={() => { setFabOpen(false); setShowPremadeCreate(true); }}
+              className="flex items-center gap-2 bg-white shadow-lg rounded-full pl-4 pr-3 py-2.5 active:scale-95 transition-transform"
+            >
+              <span className="text-sm font-semibold text-ios-label">{t.fabPremade}</span>
+              <span className="w-10 h-10 rounded-full bg-pink-500 text-white text-lg flex items-center justify-center">💐</span>
+            </button>
+            {/* Manual new order option */}
+            <button
+              onClick={() => { setFabOpen(false); navigateTo({ tab: 'newOrder' }); }}
+              className="flex items-center gap-2 bg-white shadow-lg rounded-full pl-4 pr-3 py-2.5 active:scale-95 transition-transform"
+            >
+              <span className="text-sm font-semibold text-ios-label">{t.intake.fabManual}</span>
+              <span className="w-10 h-10 rounded-full bg-brand-600 text-white text-lg flex items-center justify-center">✏️</span>
+            </button>
+          </>
+        )}
+        {/* Main FAB */}
+        <button
+          onClick={() => setFabOpen(v => !v)}
+          className={`w-14 h-14 bg-brand-600 text-white text-3xl rounded-full shadow-lg
+                     flex items-center justify-center active:bg-brand-700 active:scale-95
+                     transition-transform duration-200 ${fabOpen ? 'rotate-45' : ''}`}
+          aria-label={t.newOrder}
+        >
+          +
+        </button>
+      </div>
+
+      {/* Paste-import modal → AI parse → prefill the New Order wizard */}
+      {showImport && (
+        <Suspense fallback={null}>
+          <TextImportModal
+            onClose={() => setShowImport(false)}
+            onParsed={(draft) => navigateTo({ tab: 'newOrder', filter: { importDraft: draft } })}
+          />
+        </Suspense>
+      )}
+
+      {/* Premade bouquet builder */}
+      {showPremadeCreate && (
+        <Suspense fallback={null}>
+          <PremadeBouquetCreateModal
+            onClose={() => setShowPremadeCreate(false)}
+            onCreated={() => setShowPremadeCreate(false)}
+          />
+        </Suspense>
+      )}
+
+      {/* bottom-24 (not bottom-6): the new-order FAB now occupies bottom-6 right-6,
+          so stack the assistant above it — same pattern as the florist app. */}
+      <AskBlossomLauncher t={t} fabClassName="bottom-24 right-6" reporterRole="owner" reporterName="Owner" appArea="dashboard" />
     </div>
   );
 }

--- a/apps/dashboard/src/translations.js
+++ b/apps/dashboard/src/translations.js
@@ -277,6 +277,23 @@ const en = {
 
   // New order wizard
   newOrderTitle:    'New Order',
+  newOrder:         'New Order',
+  fabPremade:       'Premade bouquet',
+  // Text import / intake (paste-import FAB → AI parse → prefill wizard)
+  intake: {
+    title:              'Paste text',
+    modeGeneral:        'Any message',
+    hintGeneral:        'Paste customer messages from any channel — AI will extract order data.',
+    hintFlowwow:        'Paste Flowwow email text — we\'ll auto-detect order, address, recipient.',
+    placeholderGeneral: 'Paste customer message...\n\nMultiple messages at once are fine.',
+    placeholderFlowwow: 'Paste Flowwow email text...',
+    parseButton:        'Parse',
+    parsing:            'Parsing...',
+    parseError:         'Could not parse text. Try again.',
+    warningsTitle:      'Warnings',
+    fabLabel:           'Paste text',
+    fabManual:          'New order',
+  },
   step1:            'Customer',
   step2:            'Bouquet',
   step3:            'Details',
@@ -1433,6 +1450,23 @@ const ru = {
 
   // New order wizard
   newOrderTitle:    'Новый заказ',
+  newOrder:         'Новый заказ',
+  fabPremade:       'Готовый букет',
+  // Text import / intake (paste-import FAB → AI parse → prefill wizard)
+  intake: {
+    title:              'Вставить текст',
+    modeGeneral:        'Любое сообщение',
+    hintGeneral:        'Вставьте сообщения клиента из любого канала — AI извлечёт данные заказа.',
+    hintFlowwow:        'Вставьте текст письма от Flowwow — автоматически распознаем заказ, адрес, получателя.',
+    placeholderGeneral: 'Вставьте сообщение клиента...\n\nМожно несколько сообщений сразу.',
+    placeholderFlowwow: 'Вставьте текст письма Flowwow...',
+    parseButton:        'Распознать',
+    parsing:            'Распознаём...',
+    parseError:         'Не удалось распознать текст. Попробуйте ещё раз.',
+    warningsTitle:      'Предупреждения',
+    fabLabel:           'Вставить текст',
+    fabManual:          'Новый заказ',
+  },
   step1:            'Клиент',
   step2:            'Букет',
   step3:            'Детали',


### PR DESCRIPTION
## What

Moves **New Order** on the dashboard from a top-nav tab pill into a **bottom-right speed-dial FAB**, matching the florist app's `OrderListPage` FAB. The owner now gets the same layout on both apps (Cross-App Feature Parity).

Tapping **+** expands three options (same as florist):
- 📋 **Paste text** → `TextImportModal` → AI parse → prefills the New Order wizard
- 💐 **Premade bouquet** → `PremadeBouquetCreateModal`
- ✏️ **New order** → opens the manual wizard

The Ask Blossom launcher moves up to `bottom-24 right-6` to stack above the new-order FAB at `bottom-6 right-6` (same stacking pattern as florist).

## Why

Owner asked to move the new-order entry point to where the Ask Blossom assistant button sits, matching the florist app. The florist's entry point is a 3-option speed-dial — paste-import didn't exist on the dashboard at all, so this also brings AI paste-import to the dashboard (parity).

## Changes
- `pages/DashboardPage.jsx` — drop the `newOrder` tab pill; add the speed-dial FAB + lazy-loaded `TextImportModal`/`PremadeBouquetCreateModal`; reposition `AskBlossomLauncher`. The `newOrder` tab **content** is still rendered.
- `components/TextImportModal.jsx` (new) — mirror of florist's; `animate-slide-up` + `dark:` variants dropped (dashboard is light-only / `darkMode:media`).
- `components/NewOrderTab.jsx` — apply `initialFilter.importDraft` to prefill the wizard (mirror of florist `NewOrderPage`) + import-warnings banner.
- `translations.js` — `intake.*` block, `newOrder`, `fabPremade` (EN + RU).
- `CLAUDE.md` — document the FAB launch path + new component.

## Verification
- `vite build` (dashboard) passes; `TextImportModal` + `PremadeBouquetCreateModal` emit as separate lazy chunks.
- No backend / `packages/shared` changes → backend, shared, and lab suites unaffected.
- Logic mirrors proven florist code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Q85Nscp6hSQzw5ddLAs6w