### PR TITLE
feat(stock): florist Stock — flat (ungrouped) default view + time-in-stock sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Review this entire file before flipping to production.
 
 ---
 
+## 2026-07-01 — Florist Stock: Flat (ungrouped) default view + time-in-stock sort
+
+Post-Y-model-cutover owner request: the shop-floor Stock view should default to an ungrouped list like the previous stock model, sorted by how long stems have been in stock, with grouping opt-in.
+
+- `apps/florist/src/pages/StockPanelPage.jsx` — new **Flat ⇄ By type** segmented toggle (persisted `localStorage['blossom-florist-stock-flat']`, **default Flat**). Flat = one `VarietyListItem` per Variety in a single list (no Type headers) sorted by time-in-stock; **By type** = the existing `TypeGroupHeader` grouping. A **Longest ⇄ Newest** sort button (flat only) flips the order; default **longest in stock first** = oldest **on-hand** batch date ascending (Demand-Entry rows ignored; unknown-age varieties sink last). Extracted `renderVariety` so both layouts render identically. Negative/Low/Slow pills + search + hide-zero apply in both.
+- Translations: `stockFlat` / `stockByType` / `stockLongestFirst` / `stockNewestFirst` (en + ru).
+- Frontend-only; no schema/API change. Verified on a lab mirror of migrated prod data (read-only snapshot → lab; no prod writes): flat is default, toggle switches to grouped Type headers, sort control present. Florist `vite build` green.
+- Note: on the just-migrated prod data every on-hand batch shares the cutover date, so the age sort is a tie until fresh stock arrives with distinct dates.
+
 ## 2026-06-30 — Feature (CR-30): recipient phone + address as first-class key_people fields
 
 Y-model test-session CR. Each connected key person becomes a reusable address book: phone + delivery address are stored once and pre-fill every future delivery to that person. Plan: `docs/superpowers/plans/2026-06-30-ymodel-test-crs-features.md` (Feature C). Built slice-by-slice on branch `feat/recipient-key-person`.

--- a/apps/florist/CLAUDE.md
+++ b/apps/florist/CLAUDE.md
@@ -12,7 +12,7 @@ The florist should see all relevant information at a glance — what to prepare 
 | OrderListPage | /orders | all | Today's worklist — active/completed tabs, status filters, owner dashboard alerts |
 | OrderDetailPage | /orders/:id | all | Full-page order detail with inline editing, status transitions, bouquet editor. Owner can also delete the order — both Cancellation and Deletion flow through `useOrderTerminationFlow` + `OrderTerminationConfirm` from shared. |
 | NewOrderPage | /orders/new | all | 4-step wizard: Customer → Bouquet → Details → Review. AI text import shortcut. |
-| StockPanelPage | /stock | all | Inventory view with search, sort, filter, adjust, write-off, receive. Y-model collapsed Variety list under `STOCK_Y_MODEL` (TypeGroupHeader + VarietyListItem + BatchTraceModal from shared); legacy flat list when flag off. |
+| StockPanelPage | /stock | all | Inventory view with search, sort, filter, adjust, write-off, receive. Under `STOCK_Y_MODEL` a **Flat ⇄ By type** layout toggle (persisted `blossom-florist-stock-flat`, **default Flat/ungrouped**): Flat = one VarietyListItem row per Variety sorted by time-in-stock (oldest on-hand batch first; a **Longest ⇄ Newest** sort button flips it); By type = the TypeGroupHeader-grouped list. Both share `renderVariety`. Negative/Low/Slow pills + search + hide-zero apply in both. Legacy flat StockItem list when the flag is off. |
 | StockEvaluationPage | /stock-evaluation | all | Quality inspection of incoming PO deliveries (accept/write-off per line). |
 | PurchaseOrderPage | /purchase-orders | owner | PO management — create from negative stock, assign drivers, track lifecycle |
 | ShoppingSupportPage | /shopping-support | owner | Real-time supervision of active PO shopping runs (SSE + polling) |

--- a/apps/florist/src/pages/StockPanelPage.jsx
+++ b/apps/florist/src/pages/StockPanelPage.jsx
@@ -92,6 +92,16 @@ export default function StockPanelPage() {
   const [sortAsc, setSortAsc] = useState(true);
   const [view, setView]       = useState('all');
   const [hideZero, setHideZero] = useState(true);
+  // Layout: flat ungrouped list (default) vs grouped by Type. The owner wanted
+  // the shop-floor view flat like the pre-Y-model stock list, with grouping as
+  // an opt-in. Persisted so the choice sticks between visits.
+  const [flatView, setFlatView] = useState(() => {
+    const saved = localStorage.getItem('blossom-florist-stock-flat');
+    return saved === null ? true : saved === 'true';
+  });
+  useEffect(() => { localStorage.setItem('blossom-florist-stock-flat', String(flatView)); }, [flatView]);
+  // Flat sort by time-in-stock: longest-sitting (oldest batch) first by default.
+  const [flatOldestFirst, setFlatOldestFirst] = useState(true);
 
   const fetchStock = useCallback(async () => {
     setLoading(true);
@@ -313,6 +323,30 @@ export default function StockPanelPage() {
     return list;
   }, [groups, hideZero, view, yEnabled, reservationsMap, debouncedSearch]);
 
+  // Flat (ungrouped) list sorted by time-in-stock. A Variety's age = its OLDEST
+  // dated batch (longest-sitting stems). Varieties with no dated batch (unknown
+  // age) always sink to the bottom, regardless of direction.
+  function oldestBatchDate(group) {
+    // Only on-hand batches (positive qty) count toward "how long in stock" —
+    // Demand Entries (negative qty) are future needs, not sitting stems.
+    const dates = (group.rows || [])
+      .filter(r => (Number(r.current_quantity) || 0) > 0)
+      .map(r => r.date)
+      .filter(Boolean)
+      .sort();
+    return dates[0] || null;
+  }
+  const flatGroups = useMemo(() => {
+    const withDate = [];
+    const undated = [];
+    for (const g of filteredGroups) (oldestBatchDate(g) ? withDate : undated).push(g);
+    withDate.sort((a, b) => {
+      const cmp = String(oldestBatchDate(a)).localeCompare(String(oldestBatchDate(b)));
+      return flatOldestFirst ? cmp : -cmp; // oldest-first (longest in stock) by default
+    });
+    return [...withDate, ...undated];
+  }, [filteredGroups, flatOldestFirst]);
+
   // Filtered + sorted stock (legacy path)
   const filteredStock = useMemo(() => {
     const now = Date.now();
@@ -390,6 +424,58 @@ export default function StockPanelPage() {
           return qty > 0 && qty <= (Number(s['Reorder Threshold']) || 5);
         }).length,
   [yEnabled, groups, reservationsMap, stock]);
+
+  // One Variety row — shared by the grouped (under a Type header) and the flat
+  // (ungrouped) layouts so both render identically.
+  function renderVariety(group) {
+    return (
+      <div key={group.key}>
+        <VarietyListItem
+          variety={group}
+          reservations={reservationsMap}
+          pendingPO={pendingPO}
+          hideType={false}
+          isOwner={role === 'owner'}
+          expanded={expandedKey === group.key}
+          onToggle={() => setExpandedKey(k => k === group.key ? null : group.key)}
+          onRowClick={(stockId) => setTraceStockId(stockId)}
+          onVarietyTrace={async (key) => {
+            setVarietyTraceKey(key);
+            setVarietyTrail([]);
+            setVarietyUnaccounted(0);
+            setVarietyDrift(0);
+            setVarietyTraceLoading(true);
+            try {
+              const res = await client.get(`/stock/varieties/${encodeURIComponent(key)}/usage`);
+              setVarietyTrail(res.data.events || []);
+              setVarietyUnaccounted(res.data.unaccountedStems ?? 0);
+              setVarietyDrift(res.data.drift ?? 0);
+            } catch {
+              setVarietyTrail([]);
+            } finally {
+              setVarietyTraceLoading(false);
+            }
+          }}
+          onWriteOff={(v) => setWriteOffVariety(v)}
+          onAdjust={handleAdjustGroup}
+          premadesByStockId={premadesByStockId}
+          t={t}
+        />
+        {/* Write-off picker inline when this variety is selected */}
+        {writeOffVariety?.key === group.key && (
+          <div className="px-4 pb-3">
+            <WriteOffBatchPicker
+              variety={group}
+              reasons={writeOffReasons}
+              t={{ ...t, writeOffQty: t.writeOffPickerQty }}
+              onConfirm={handleWriteOffY}
+              onCancel={() => setWriteOffVariety(null)}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen">
@@ -505,11 +591,40 @@ export default function StockPanelPage() {
           ))}
         </div>
 
-        {/* Hide-zero / show-cleared toggle — same semantics, different label in Y-model */}
-        <div className="flex justify-end mb-2">
+        {/* Layout toggle (Flat ⇄ By type) + age sort on the left (Y-model);
+            hide-zero / show-cleared on the right. */}
+        <div className="flex items-center gap-2 mb-2">
+          {yEnabled && (
+            <>
+              {/* Flat ⇄ By-type segmented control — flat is the shop-floor default */}
+              <div className="inline-flex rounded-full bg-gray-100 dark:bg-gray-700 p-0.5">
+                <button
+                  onClick={() => setFlatView(true)}
+                  className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                    flatView ? 'bg-brand-600 text-white' : 'text-ios-secondary dark:text-gray-300'
+                  }`}
+                >{t.stockFlat || 'Flat'}</button>
+                <button
+                  onClick={() => setFlatView(false)}
+                  className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                    !flatView ? 'bg-brand-600 text-white' : 'text-ios-secondary dark:text-gray-300'
+                  }`}
+                >{t.stockByType || 'By type'}</button>
+              </div>
+              {/* Age sort — flat layout only */}
+              {flatView && (
+                <button
+                  onClick={() => setFlatOldestFirst(v => !v)}
+                  className="px-3 py-1.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-ios-secondary dark:text-gray-300 active-scale"
+                >
+                  {flatOldestFirst ? (t.stockLongestFirst || 'Longest in stock ↓') : (t.stockNewestFirst || 'Newest first ↓')}
+                </button>
+              )}
+            </>
+          )}
           <button
             onClick={() => setHideZero(!hideZero)}
-            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors active-scale ${
+            className={`ml-auto px-3 py-1.5 rounded-full text-xs font-medium transition-colors active-scale ${
               hideZero
                 ? 'bg-brand-100 text-brand-700 ring-1 ring-brand-200'
                 : 'bg-gray-200 dark:bg-gray-600 text-ios-label dark:text-gray-200'
@@ -581,6 +696,12 @@ export default function StockPanelPage() {
                   "Flat table" (dashboard format) is gone here; owner financials
                   live in the By-Variety tap-to-expand (CR-36). Dashboard keeps
                   the Flat table for desktop. */}
+            {flatView ? (
+              /* ── Flat (ungrouped) list, sorted by time-in-stock ── */
+              <div className="ios-card overflow-hidden">
+                {flatGroups.map(renderVariety)}
+              </div>
+            ) : (
             <div className="ios-card overflow-hidden">
               {Array.from(typeGroups.entries()).map(([typeName, typeRows]) => {
                 // Only show types with at least one group surviving filteredGroups
@@ -608,57 +729,12 @@ export default function StockPanelPage() {
                       })}
                       t={t}
                     />
-                    {!isCollapsed && visibleRows.map(group => (
-                      <div key={group.key}>
-                        <VarietyListItem
-                          variety={group}
-                          reservations={reservationsMap}
-                          pendingPO={pendingPO}
-                          hideType={false}
-                          isOwner={role === 'owner'}
-                          expanded={expandedKey === group.key}
-                          onToggle={() => setExpandedKey(k => k === group.key ? null : group.key)}
-                          onRowClick={(stockId) => setTraceStockId(stockId)}
-                          onVarietyTrace={async (key) => {
-                            setVarietyTraceKey(key);
-                            setVarietyTrail([]);
-                            setVarietyUnaccounted(0);
-                            setVarietyDrift(0);
-                            setVarietyTraceLoading(true);
-                            try {
-                              const res = await client.get(`/stock/varieties/${encodeURIComponent(key)}/usage`);
-                              setVarietyTrail(res.data.events || []);
-                              setVarietyUnaccounted(res.data.unaccountedStems ?? 0);
-                              setVarietyDrift(res.data.drift ?? 0);
-                            } catch {
-                              setVarietyTrail([]);
-                            } finally {
-                              setVarietyTraceLoading(false);
-                            }
-                          }}
-                          onWriteOff={(v) => setWriteOffVariety(v)}
-                          onAdjust={handleAdjustGroup}
-                          premadesByStockId={premadesByStockId}
-                          t={t}
-                        />
-                        {/* Write-off picker inline when this variety is selected */}
-                        {writeOffVariety?.key === group.key && (
-                          <div className="px-4 pb-3">
-                            <WriteOffBatchPicker
-                              variety={group}
-                              reasons={writeOffReasons}
-                              t={{ ...t, writeOffQty: t.writeOffPickerQty }}
-                              onConfirm={handleWriteOffY}
-                              onCancel={() => setWriteOffVariety(null)}
-                            />
-                          </div>
-                        )}
-                      </div>
-                    ))}
+                    {!isCollapsed && visibleRows.map(renderVariety)}
                   </div>
                 );
               })}
             </div>
+            )}
             </>
           )
         ) : (

--- a/apps/florist/src/translations.js
+++ b/apps/florist/src/translations.js
@@ -898,6 +898,10 @@ const en = {
   writeOffBatch:         'Batch',
   writeOffConfirm:       'Confirm',
   showClearedRows:       'Show cleared rows',
+  stockFlat:             'Flat',
+  stockByType:           'By type',
+  stockLongestFirst:     'Longest in stock ↓',
+  stockNewestFirst:      'Newest first ↓',
 };
 
 const ru = {
@@ -1795,6 +1799,10 @@ const ru = {
   writeOffBatch:         'Партия',
   writeOffConfirm:       'Подтвердить',
   showClearedRows:       'Показать списанные',
+  stockFlat:             'Списком',
+  stockByType:           'По типу',
+  stockLongestFirst:     'Дольше на складе ↓',
+  stockNewestFirst:      'Сначала новые ↓',
 };
 
 // ── Proxy-based dynamic translation ──


### PR DESCRIPTION
**Owner request (post-cutover):** the florist shop-floor Stock view should default to an **ungrouped** list like the previous stock model, **sorted by how long stems have been in stock**, with grouping as an opt-in.

## What changed (florist only)
- **Flat ⇄ By type** segmented toggle on `/stock` (persisted, **default Flat**).
  - **Flat** = one `VarietyListItem` per Variety in a single list (no Type headers), sorted by time-in-stock.
  - **By type** = the existing `TypeGroupHeader` grouping.
- **Longest ⇄ Newest** sort button (flat only) — default **longest in stock first** = oldest **on-hand** batch date ascending (Demand-Entry rows ignored; unknown-age varieties sink last).
- Extracted `renderVariety` so both layouts render identical rows. Negative/Low/Slow pills + search + hide-zero apply in both. New translations en+ru.

## Design choice
One row **per variety** (owner's lean, Y-model-consistent) rather than per-batch: a variety's age = its oldest on-hand batch; per-batch detail stays reachable via the row's Trace/expand. The dashboard already defaults to a flat "By Batch" view.

## Verification (no prod writes)
Verified on a **lab mirror of the migrated prod data** (read-only prod snapshot → lab restore; prod never written): Flat is the default, "By type" switches to grouped Type headers, sort control present. Florist `vite build` green.

- **Note:** post-migration every on-hand batch shares the cutover date, so the age sort is a visual tie until fresh stock arrives with distinct dates.
- **Pre-existing (not this PR):** a React dev key-warning inside the shared `VarietyListItem` (`<li>` children) surfaces more in flat mode because all rows render at once — `VarietyListItem` is unchanged here; worth a separate tidy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)