### PR TITLE
feat(assistant): flower-AI "Blossom bubble" launcher mark + gradient FAB + align FABs

### DIFF
--- a/apps/florist/CLAUDE.md
+++ b/apps/florist/CLAUDE.md
@@ -24,7 +24,7 @@ The florist should see all relevant information at a glance — what to prepare 
 | CustomerDetailPage | /customers/:id | all | Customer profile + order history |
 | WasteLogPage | /waste | owner | Stock-loss entry log by reason |
 | SubstituteReconciliationPage | /reconcile | owner | Reconcile substitutions made during PO shopping |
-| ~~AssistantPage~~ | ~~`/assistant`~~ | owner | Removed — replaced by the shared `AskBlossomLauncher` FAB (`bottom-36 right-4`) rendered owner-only in `App.jsx` `Layout`. Sits at `bottom-36` (not `bottom-20`) to stack **above** the OrderListPage "Новый заказ" FAB (`bottom-20 right-5 z-50`), which would otherwise paint over it on `/orders`. Opens the same `AskBlossomPanel` as the dashboard. |
+| ~~AssistantPage~~ | ~~`/assistant`~~ | owner | Removed — replaced by the shared `AskBlossomLauncher` FAB (`bottom-36 right-5`) rendered owner-only in `App.jsx` `Layout`. Sits at `bottom-36` (not `bottom-20`) to stack **above** the OrderListPage "Новый заказ" FAB (`bottom-20 right-5 z-50`), which would otherwise paint over it on `/orders`; **`right-5` matches that FAB so both circles line up vertically** (was `right-4` → 4px off, fixed). The FAB is a **brand gradient** circle with the **"Blossom bubble"** flower-AI mark (chat bubble + bloom). Opens the same `AskBlossomPanel` as the dashboard. |
 
 ## Key Components (src/components/)
 | Component | Purpose |

--- a/apps/florist/src/App.jsx
+++ b/apps/florist/src/App.jsx
@@ -72,7 +72,7 @@ function Layout({ children }) {
       {role === 'owner' && (
         <AskBlossomLauncher
           t={t}
-          fabClassName="bottom-36 right-4"
+          fabClassName="bottom-36 right-5"
           reporterRole={role}
           reporterName={reporterName}
           appArea="florist"

--- a/packages/shared/components/AskBlossomLauncher.jsx
+++ b/packages/shared/components/AskBlossomLauncher.jsx
@@ -5,7 +5,29 @@ import AskBlossomPanel from './AskBlossomPanel.jsx';
 // a bottom sheet on phones, a right-side drawer on desktop (responsive via `sm:`).
 // Shared by the dashboard + florist apps; replaces the old top tab / nav entry.
 // `fabClassName` lets a host nudge the button (e.g. above the florist bottom nav).
-const SPARKLE = "M12 2l1.8 4.9L19 8.7l-4.2 2.6L13.5 16 12 11.6 10.5 16 9.2 11.3 5 8.7l5.2-1.8L12 2z";
+
+// "Blossom bubble" — the flower-AI assistant mark: a chat bubble (currentColor,
+// so it inherits the button's white) with a small brand-tint bloom inside, saying
+// "assistant" + "flowers" at once. Two-tone (white bubble + brand-200 petals) reads
+// on both the flat pink and the gradient FAB, and on the brand-600 panel header.
+function BlossomMark({ size = 24 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        fill="currentColor"
+        d="M6.2 3.4h11.6a2.9 2.9 0 0 1 2.9 2.9v6.6a2.9 2.9 0 0 1-2.9 2.9h-6l-4.5 3.6a.7.7 0 0 1-1.14-.55v-3.05H6.2A2.9 2.9 0 0 1 3.3 12.9V6.3A2.9 2.9 0 0 1 6.2 3.4z"
+      />
+      <g transform="translate(0 -1.7)">
+        <circle cx="12" cy="9.45" r="2" fill="#fbcfe8" />
+        <circle cx="14.42" cy="11.21" r="2" fill="#fbcfe8" />
+        <circle cx="13.5" cy="13.06" r="2" fill="#fbcfe8" />
+        <circle cx="10.5" cy="13.06" r="2" fill="#fbcfe8" />
+        <circle cx="9.58" cy="11.21" r="2" fill="#fbcfe8" />
+        <circle cx="12" cy="12" r="1.6" fill="currentColor" />
+      </g>
+    </svg>
+  );
+}
 
 export default function AskBlossomLauncher({
   t,
@@ -28,9 +50,9 @@ export default function AskBlossomLauncher({
         <button
           aria-label={t.tabAssistant}
           onClick={() => setOpen(true)}
-          className={`fixed z-40 ${fabClassName} w-14 h-14 rounded-full bg-brand-600 text-white shadow-xl flex items-center justify-center hover:bg-brand-700 active:scale-95 transition`}
+          className={`fixed z-40 ${fabClassName} w-14 h-14 rounded-full bg-gradient-to-br from-brand-400 via-brand-600 to-brand-700 text-white shadow-xl flex items-center justify-center hover:from-brand-500 hover:to-brand-800 active:scale-95 transition`}
         >
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d={SPARKLE} /></svg>
+          <BlossomMark size={24} />
         </button>
       )}
 
@@ -48,7 +70,7 @@ export default function AskBlossomLauncher({
                          : 'inset-x-0 bottom-0 top-[12%] rounded-t-2xl sm:inset-y-0 sm:left-auto sm:right-0 sm:top-0 sm:w-[440px] sm:max-w-[92vw] sm:rounded-none'}`}
           >
             <div className="flex items-center gap-2 px-3 py-2 border-b bg-brand-600 text-white shrink-0">
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d={SPARKLE} /></svg>
+              <BlossomMark size={18} />
               <span className="font-semibold text-sm flex-1">Ask Blossom</span>
               <button
                 aria-label={maximized ? 'Restore' : 'Maximize'}

--- a/packages/shared/test/AskBlossomLauncher.test.jsx
+++ b/packages/shared/test/AskBlossomLauncher.test.jsx
@@ -16,6 +16,17 @@ describe('AskBlossomLauncher', () => {
     expect(screen.queryByPlaceholderText('Ask…')).not.toBeInTheDocument();
   });
 
+  it('renders the gradient FAB with the Blossom-bubble flower-AI mark', () => {
+    render(<AskBlossomLauncher t={t} />);
+    const fab = screen.getByLabelText('Assistant');
+    // gradient button treatment (owner-chosen), not the old flat brand-600
+    expect(fab.className).toContain('bg-gradient-to-br');
+    expect(fab.className).not.toContain('bg-brand-600');
+    // the "Blossom bubble" mark = a chat-bubble path + a bloom (brand-200 petals)
+    expect(fab.querySelector('path[d^="M6.2 3.4"]')).toBeTruthy();
+    expect(fab.querySelector('circle[fill="#fbcfe8"]')).toBeTruthy();
+  });
+
   it('opens the panel on FAB click and closes on ✕', async () => {
     render(<AskBlossomLauncher t={t} />);
     fireEvent.click(screen.getByLabelText('Assistant'));


### PR DESCRIPTION
Two small owner-facing polish items from the florist app.

## 1 · Assistant FAB alignment (bug)
The Ask Blossom (assistant) button sat at `right-4` while the "+" new-order button sits at `right-5`, so the two stacked circles were **4px off-centre** from each other. Both are now `right-5` → their right edges + centres line up. Dashboard FABs were already both `right-6`, so no change there.

## 2 · New flower-AI assistant symbol
Replaced the generic sparkle glyph with the **"Blossom bubble"** mark — a chat bubble with a small bloom inside, so it reads as "the assistant that knows flowers". Chosen by the owner from a 4-option board (round 3). Also upgraded the assistant FAB to a soft **brand gradient** (brand-400 → brand-700), the modern AI-era button treatment.

- Shared `BlossomMark` component in `AskBlossomLauncher.jsx` (two-tone: white bubble + brand-200 petals) — used on both the FAB (24px) and the open-panel header (18px).
- The launcher is shared, so the new mark + gradient apply to **both** the florist app and the dashboard.

## Verification
- 648 shared vitest tests green, incl. a new assertion pinning the gradient FAB + Blossom-bubble mark (`AskBlossomLauncher.test.jsx`).
- Florist + dashboard + delivery all `vite build` clean.
- Visual check on the exact final classes: the gradient FAB + mark render as approved, and both FABs share the right edge (alignment fixed).

Frontend/shared only — no schema, no backend, no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
