### PR TITLE
feat(assistant): Explorer v2 Wave 1 — handoff polish (bilingual labels · both buttons · persist on reopen)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Review this entire file before flipping to production.
 
 ---
 
+## 2026-07-02 — Explorer v2 · Wave 1: Ask Blossom handoff polish
+
+First wave of Explorer v2 (PRD #496, wave #497). Cleanup of the Ask Blossom → screen handoff from the owner's first live use. No engine change; assistant + shared chat panel only.
+
+- **Handoff button label follows the app language.** The `open_orders_view` / `open_explorer_view` signal tools now return **both** `label` (Russian) + `labelEn` (English); `AskBlossomPanel` picks by `useLanguage()` (falls back to either label, then the generic `t.openInOrders`/`openInExplorer`). Previously the tool's Russian `label` always won, so an English dashboard showed a Russian button. Tool input schemas gained a `labelEn` field; the system prompt instructs the model to supply both.
+- **Both buttons for savable order lists.** The panel already rendered an Orders button and an Explorer button independently; the system prompt now tells the model to ALSO emit `open_explorer_view` for a list of orders worth saving/exporting, so the owner sees **both** "Open in Orders" (act) and "Open in Explorer" (save view / export CSV). Pure cross-entity results → Explorer only; pure aggregates → neither.
+- **Handoff button survives chat reopen.** `toDisplayTurns` (assistantService) previously stripped all tool blocks, so reopening a saved chat lost the button. It now reconstructs the signal tools' `{name, output}` from the stored `tool_use`/`tool_result` pair and attaches it to the answer turn (matching the live path), so the button re-renders on reopen.
+- Tests: new `assistantService.toDisplayTurns.test.js` (7); extended `ordersViewPack`/`explorerViewPack` handler tests for `labelEn`; new `AskBlossomPanel` tests (EN/RU label pick, both buttons, persist-on-reopen). Both-buttons tool *selection* is LLM-driven → verified by the SAFE `assistant-live-smoke.js` (owner, real key), noted in the PR.
+- Verified: backend vitest, shared 688 vitest, all three apps build. (Additive shapes — E2E unaffected.)
+
 ## 2026-07-02 — Explorer polish: bilingual labels + pinned drill column
 
 Two fixes from first owner use of the live Explorer (prod).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -225,6 +225,14 @@ The phone app used by Drivers. Covers assigned deliveries and Stock Order shoppi
 A read-only linked-record surface inside the Dashboard (owner-only, desktop) for exploring Blossom's data. The Owner picks a start-point (a Flower, Order, Customer, Supplier, …), filters it, and drills through relationships by clicking a row to open its related records — e.g. a Flower → the Orders that used it → each Order's Customer → that Customer's Key People. Distinct from **Ask Blossom** (natural-language questions, one answer per turn): Explorer is click-driven navigation with no LLM per click. Ask Blossom can hand a query off to Explorer ("Open in Explorer"). Safe by construction — it can only emit the same validated declarative query spec the assistant uses (allow-listed entities/fields/joins, row cap), never raw SQL, and never edits data (rows deep-link into the existing edit screens).
 _Avoid_: Super-search (the origin term for this idea; "Explorer" is canonical), linked-record explorer, grid
 
+**Deep-join report** (Explorer v2):
+A single flat grid that follows a **fixed chain of relationship edges** across 3+ entities and flattens them into one denormalized row set — e.g. Flower → the Orders that used it → each Order's Customer → that Customer's Key Person, all as columns of one grid. Distinct from **navigation drilling** (v1: clicking a row opens a fresh single-hop query — you move *between* grids). A deep-join report shows every hop at once. Only follows the pre-defined descriptor edges (no arbitrary entity-to-entity joins — that is the deferred **Arbitrary join builder**, v3). Bounded by the same row cap; fan-out (a "many" hop) is warned/capped.
+_Avoid_: multi-hop join, chained query, denormalized report
+
+**Pivot** (Explorer v2):
+A two-dimension summary of a **Measure** — rows × columns × measure (e.g. sales *summed* with Order status down the side and month across the top). A **Measure** is an aggregate of a numeric field: sum / avg / min / max / count. v1 exposed count-only over a single group-by; v2 adds real measures and the second (column) dimension.
+_Avoid_: cross-tab, matrix report
+
 ## Flagged ambiguities
 
 - "Bouquet" is used both for a **Product** (Wix listing) and a **Premade Bouquet** (pre-built inventory item) — these are distinct. Context determines which is meant; prefer the full term when precision matters.

--- a/backend/src/__tests__/assistantService.toDisplayTurns.test.js
+++ b/backend/src/__tests__/assistantService.toDisplayTurns.test.js
@@ -1,0 +1,133 @@
+// Unit test for toDisplayTurns — the projection of the canonical Anthropic
+// message array into UI display turns.
+//
+// Explorer v2 Wave 1 (#497): a reopened chat must keep the "Open in Orders" /
+// "Open in Explorer" handoff button. The button renders from `toolResults` on
+// the message; the live path attaches them to the final answer. On reopen the
+// projection must reconstruct the same {name, output} for the signal tools from
+// the stored tool_use / tool_result blocks, and attach them to the answer turn.
+//
+// The Anthropic SDK is mocked so importing assistantService doesn't build a
+// live client (mirrors assistantTools.goldenQuestions.test.js).
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class { messages = { create: vi.fn() }; },
+}));
+
+const { toDisplayTurns } = await import('../services/assistantService.js');
+
+// Helpers to build canonical stored turns the way ask() persists them.
+const userText = (text) => ({ role: 'user', content: text });
+const assistantText = (text) => ({ role: 'assistant', content: [{ type: 'text', text }] });
+const assistantToolUse = (id, name, input = {}) => ({
+  role: 'assistant',
+  content: [{ type: 'tool_use', id, name, input }],
+});
+const toolResultTurn = (id, output) => ({
+  role: 'user',
+  content: [{ type: 'tool_result', tool_use_id: id, content: JSON.stringify(output) }],
+});
+
+describe('toDisplayTurns', () => {
+  it('projects a plain Q&A with no tool blocks', () => {
+    const turns = toDisplayTurns([userText('hi'), assistantText('hello')]);
+    expect(turns).toEqual([
+      { role: 'user', text: 'hi' },
+      { role: 'assistant', text: 'hello' },
+    ]);
+  });
+
+  it('surfaces an open_orders_view signal onto the following answer turn', () => {
+    const stored = [
+      userText('which orders are unpaid?'),
+      assistantToolUse('tu_1', 'open_orders_view', { paymentStatus: 'unpaid' }),
+      toolResultTurn('tu_1', { view: 'orders', filter: { paymentStatus: 'unpaid' }, label: 'Неоплаченные заказы', labelEn: 'Unpaid orders' }),
+      assistantText('You have 2 unpaid orders.'),
+    ];
+    const turns = toDisplayTurns(stored);
+    expect(turns).toEqual([
+      { role: 'user', text: 'which orders are unpaid?' },
+      {
+        role: 'assistant',
+        text: 'You have 2 unpaid orders.',
+        toolResults: [
+          { name: 'open_orders_view', output: { view: 'orders', filter: { paymentStatus: 'unpaid' }, label: 'Неоплаченные заказы', labelEn: 'Unpaid orders' } },
+        ],
+      },
+    ]);
+  });
+
+  it('surfaces an open_explorer_view signal onto the answer turn', () => {
+    const spec = { entity: 'purchases', filters: [{ field: 'supplier', op: 'eq', value: 'X' }], sort: [] };
+    const stored = [
+      userText('purchases from X'),
+      assistantToolUse('tu_9', 'open_explorer_view', { spec }),
+      toolResultTurn('tu_9', { view: 'explorer', spec, label: 'Закупки', labelEn: 'Purchases' }),
+      assistantText('Here they are.'),
+    ];
+    const turns = toDisplayTurns(stored);
+    expect(turns[1].toolResults).toEqual([
+      { name: 'open_explorer_view', output: { view: 'explorer', spec, label: 'Закупки', labelEn: 'Purchases' } },
+    ]);
+  });
+
+  it('attaches BOTH signals when a turn emitted both', () => {
+    const spec = { entity: 'orders', filters: [], sort: [] };
+    const stored = [
+      userText('unpaid orders'),
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'a', name: 'open_orders_view', input: {} },
+          { type: 'tool_use', id: 'b', name: 'open_explorer_view', input: { spec } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'a', content: JSON.stringify({ view: 'orders', filter: {}, label: 'Заказы', labelEn: 'Orders' }) },
+          { type: 'tool_result', tool_use_id: 'b', content: JSON.stringify({ view: 'explorer', spec, label: 'Заказы', labelEn: 'Orders' }) },
+        ],
+      },
+      assistantText('done'),
+    ];
+    const names = toDisplayTurns(stored)[1].toolResults.map((r) => r.name);
+    expect(names).toEqual(['open_orders_view', 'open_explorer_view']);
+  });
+
+  it('does NOT surface non-signal data tools (e.g. query_records)', () => {
+    const stored = [
+      userText('count orders'),
+      assistantToolUse('tu_2', 'query_records', { entity: 'orders' }),
+      toolResultTurn('tu_2', { rows: [], matchedCount: 0 }),
+      assistantText('There are 0 orders.'),
+    ];
+    const turns = toDisplayTurns(stored);
+    expect(turns[1].toolResults).toBeUndefined();
+  });
+
+  it('drops a signal whose tool_result is an error', () => {
+    const stored = [
+      userText('bad'),
+      assistantToolUse('tu_3', 'open_explorer_view', { spec: {} }),
+      toolResultTurn('tu_3', { error: 'invalid spec' }),
+      assistantText('Sorry.'),
+    ];
+    const turns = toDisplayTurns(stored);
+    expect(turns[1].toolResults).toBeUndefined();
+  });
+
+  it('does not emit a display turn for an intermediate tool_use-only turn', () => {
+    const stored = [
+      userText('q'),
+      assistantToolUse('tu_4', 'open_orders_view', {}),
+      toolResultTurn('tu_4', { view: 'orders', filter: {}, label: 'Заказы', labelEn: 'Orders' }),
+      assistantText('a'),
+    ];
+    const turns = toDisplayTurns(stored);
+    // user + single assistant answer only (no stray turn for the tool_use step)
+    expect(turns.map((t) => t.role)).toEqual(['user', 'assistant']);
+  });
+});

--- a/backend/src/__tests__/assistantTools.explorerViewPack.test.js
+++ b/backend/src/__tests__/assistantTools.explorerViewPack.test.js
@@ -9,25 +9,26 @@ import { db } from '../db/index.js';
 // handler never touches `db` at all.
 
 describe('explorerViewPack.open_explorer_view', () => {
-  it('returns view/spec/label for a valid spec, using the given label', async () => {
+  it('returns view/spec + both labels for a valid spec, using the given labels', async () => {
     const spec = {
       entity: 'orders',
       filters: [{ field: 'status', op: 'eq', value: 'New' }],
     };
-    const r = await openExplorerViewHandler({ spec, label: 'Новые заказы' });
-    expect(r).toEqual({ view: 'explorer', spec, label: 'Новые заказы' });
+    const r = await openExplorerViewHandler({ spec, label: 'Новые заказы', labelEn: 'New orders' });
+    expect(r).toEqual({ view: 'explorer', spec, label: 'Новые заказы', labelEn: 'New orders' });
   });
 
-  it('defaults to the Russian label "Данные" when label is omitted', async () => {
+  it('defaults to the RU/EN labels ("Данные"/"Data") when labels are omitted', async () => {
     const spec = { entity: 'orders' };
     const r = await openExplorerViewHandler({ spec });
-    expect(r).toEqual({ view: 'explorer', spec, label: 'Данные' });
+    expect(r).toEqual({ view: 'explorer', spec, label: 'Данные', labelEn: 'Data' });
   });
 
-  it('ignores a blank/non-string label and falls back to the default', async () => {
+  it('ignores a blank/non-string label and falls back to the default (each language independently)', async () => {
     const spec = { entity: 'orders' };
-    const r = await openExplorerViewHandler({ spec, label: '   ' });
+    const r = await openExplorerViewHandler({ spec, label: '   ', labelEn: '  ' });
     expect(r.label).toBe('Данные');
+    expect(r.labelEn).toBe('Data');
   });
 
   it('returns { error } for an invalid spec (unknown entity), never a view', async () => {
@@ -48,10 +49,11 @@ describe('explorerViewPack.open_explorer_view', () => {
     expect(db).toBeNull();
 
     const spec = { entity: 'orders', filters: [{ field: 'status', op: 'eq', value: 'New' }] };
-    await expect(openExplorerViewHandler({ spec, label: 'Test' })).resolves.toEqual({
+    await expect(openExplorerViewHandler({ spec, label: 'Test', labelEn: 'Test' })).resolves.toEqual({
       view: 'explorer',
       spec,
       label: 'Test',
+      labelEn: 'Test',
     });
   });
 });

--- a/backend/src/__tests__/assistantTools.ordersViewPack.test.js
+++ b/backend/src/__tests__/assistantTools.ordersViewPack.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { openOrdersViewHandler } from '../services/assistantTools/ordersViewPack.js';
 
 describe('ordersViewPack.open_orders_view', () => {
-  it('normalizes recognized filter keys and echoes the view/label', () => {
+  it('normalizes recognized filter keys and echoes the view + both labels', () => {
     const r = openOrdersViewHandler({
       status: 'New',
       paymentStatus: 'Unpaid',
@@ -11,6 +11,7 @@ describe('ordersViewPack.open_orders_view', () => {
       orderDateTo: '2026-06-30',
       priceMin: 50,
       label: 'Неоплаченные заказы за июнь',
+      labelEn: 'Unpaid orders in June',
     });
     expect(r).toEqual({
       view: 'orders',
@@ -23,6 +24,7 @@ describe('ordersViewPack.open_orders_view', () => {
         priceMin: 50,
       },
       label: 'Неоплаченные заказы за июнь',
+      labelEn: 'Unpaid orders in June',
     });
   });
 
@@ -40,14 +42,21 @@ describe('ordersViewPack.open_orders_view', () => {
     expect(r.filter.source).toBe('Wix');
   });
 
-  it('defaults to an empty filter + default label on empty input, never errors', () => {
-    expect(openOrdersViewHandler()).toEqual({ view: 'orders', filter: {}, label: 'Отфильтрованные заказы' });
-    expect(openOrdersViewHandler({})).toEqual({ view: 'orders', filter: {}, label: 'Отфильтрованные заказы' });
+  it('defaults to an empty filter + default RU/EN labels on empty input, never errors', () => {
+    expect(openOrdersViewHandler()).toEqual({ view: 'orders', filter: {}, label: 'Отфильтрованные заказы', labelEn: 'Filtered orders' });
+    expect(openOrdersViewHandler({})).toEqual({ view: 'orders', filter: {}, label: 'Отфильтрованные заказы', labelEn: 'Filtered orders' });
   });
 
-  it('ignores a blank/non-string label and falls back to the default', () => {
-    const r = openOrdersViewHandler({ status: 'Ready', label: '   ' });
+  it('ignores a blank/non-string label and falls back to the default (each language independently)', () => {
+    const r = openOrdersViewHandler({ status: 'Ready', label: '   ', labelEn: '  ' });
     expect(r.label).toBe('Отфильтрованные заказы');
+    expect(r.labelEn).toBe('Filtered orders');
+  });
+
+  it('carries a Russian label with a default English label when only label is given', () => {
+    const r = openOrdersViewHandler({ label: 'Заказы' });
+    expect(r.label).toBe('Заказы');
+    expect(r.labelEn).toBe('Filtered orders');
   });
 
   it('ignores null values for recognized keys (treated as absent)', () => {

--- a/backend/src/services/assistantService.js
+++ b/backend/src/services/assistantService.js
@@ -33,7 +33,7 @@ function systemPrompt(today) {
     "Order counts and revenue EXCLUDE cancelled orders unless the user explicitly asks about cancellations — say so when it matters.",
     "Revenue 'flowers' is NET: total = flowers + delivery, always. Do not describe flower revenue as if it were gross.",
     "For ad spend (marketing_spend) vs revenue per source: channel names are free text and do not map exactly to Order Source, so do not state a precise ROAS — present spend and revenue side by side and note the caveat.",
-    "When the owner would plausibly want to SEE and keep interacting with a set of orders (not just a number) — e.g. after answering 'which orders are unpaid' or 'show me June's cancellations' — call open_orders_view with the same filters you used to answer, so the UI can offer an 'Open in Orders' action. Do not call it for pure aggregate questions (totals, averages, counts alone) with no natural underlying order list to browse.",
+    "HANDOFF BUTTONS: when the owner would plausibly want to SEE and keep interacting with a result set (not just a number), signal the UI to open a pre-filtered screen. Rules: (1) For a list of ORDERS the owner may act on (e.g. 'which orders are unpaid', 'June's cancellations'), call open_orders_view with the same filters you used. If that list is also worth saving or exporting (most multi-row order lists are), ALSO call open_explorer_view with the equivalent query_records spec — the UI then shows BOTH buttons ('Open in Orders' to act on them, 'Open in Explorer' to save the view / export CSV). (2) For any OTHER entity or a cross-entity / connect-the-dots result (purchases, write-offs, customers, key people, deliveries, stock, …), call open_explorer_view with the query_records spec. (3) Do NOT signal for pure aggregate answers (totals, averages, counts alone) with no natural underlying list to browse. (4) ALWAYS pass BOTH a Russian `label` and an English `labelEn` to these tools so the button reads in the app's current language.",
   ].join('\n');
 }
 
@@ -65,18 +65,53 @@ function deriveTitle(messages) {
   return raw.length > 80 ? raw.slice(0, 80).trimEnd() + '…' : raw;
 }
 
+// Signal tools whose output the UI turns into an "Open in …" handoff button.
+// Their result must survive the display projection so a reopened chat keeps the
+// button (Explorer v2 #497) — every other tool block is display-irrelevant.
+const SIGNAL_TOOLS = new Set(['open_orders_view', 'open_explorer_view']);
+
+function safeParseToolResult(content) {
+  if (typeof content !== 'string') return content && typeof content === 'object' ? content : null;
+  try { return JSON.parse(content); } catch { return null; }
+}
+
 // Project the canonical Anthropic message array to UI display turns:
-// keep user text + assistant text, drop tool_use / tool_result blocks.
+// keep user text + assistant text, drop tool_use / tool_result blocks — EXCEPT
+// the signal tools, whose {name, output} is reconstructed from the stored
+// tool_use / tool_result pair and attached to the next answer turn (matching the
+// live path, which attaches toolResults to the final answer message).
 export function toDisplayTurns(messages) {
+  const arr = messages || [];
   const turns = [];
-  for (const m of messages || []) {
+  let pendingSignals = [];
+  for (let i = 0; i < arr.length; i++) {
+    const m = arr[i];
     if (m.role === 'user') {
+      // Only string-content user turns are real user text; tool_result turns
+      // (array content) are consumed alongside their assistant tool_use turn.
       if (typeof m.content === 'string') turns.push({ role: 'user', text: m.content });
     } else if (m.role === 'assistant') {
+      const blocks = Array.isArray(m.content) ? m.content : null;
+      if (blocks) {
+        const signalUses = blocks.filter(b => b.type === 'tool_use' && SIGNAL_TOOLS.has(b.name));
+        if (signalUses.length) {
+          const next = arr[i + 1];
+          const resultBlocks = next && next.role === 'user' && Array.isArray(next.content) ? next.content : [];
+          for (const use of signalUses) {
+            const res = resultBlocks.find(b => b.type === 'tool_result' && b.tool_use_id === use.id);
+            const output = res ? safeParseToolResult(res.content) : null;
+            if (output && !output.error) pendingSignals.push({ name: use.name, output });
+          }
+        }
+      }
       const text = typeof m.content === 'string'
         ? m.content
-        : (Array.isArray(m.content) ? m.content.filter(b => b.type === 'text').map(b => b.text).join('\n').trim() : '');
-      if (text) turns.push({ role: 'assistant', text });
+        : (blocks ? blocks.filter(b => b.type === 'text').map(b => b.text).join('\n').trim() : '');
+      if (text) {
+        const turn = { role: 'assistant', text };
+        if (pendingSignals.length) { turn.toolResults = pendingSignals; pendingSignals = []; }
+        turns.push(turn);
+      }
     }
   }
   return turns;

--- a/backend/src/services/assistantTools/explorerViewPack.js
+++ b/backend/src/services/assistantTools/explorerViewPack.js
@@ -16,14 +16,21 @@
 import { validateSpec } from './dataQueryPack.js';
 
 const DEFAULT_LABEL = 'Данные';
+const DEFAULT_LABEL_EN = 'Data';
+
+const pickLabel = (v, fallback) => (typeof v === 'string' && v.trim() ? v.trim() : fallback);
 
 export async function openExplorerViewHandler(input = {}) {
-  const { spec, label } = input;
+  const { spec, label, labelEn } = input;
 
   const v = validateSpec(spec);
   if (!v.ok) return { error: v.error };
 
-  const resolvedLabel = (typeof label === 'string' && label.trim()) ? label.trim() : DEFAULT_LABEL;
-
-  return { view: 'explorer', spec, label: resolvedLabel };
+  // Both labels so the panel can follow the app language (Explorer v2 #497).
+  return {
+    view: 'explorer',
+    spec,
+    label: pickLabel(label, DEFAULT_LABEL),
+    labelEn: pickLabel(labelEn, DEFAULT_LABEL_EN),
+  };
 }

--- a/backend/src/services/assistantTools/index.js
+++ b/backend/src/services/assistantTools/index.js
@@ -482,6 +482,7 @@ export const TOOLS = [
         priceMin: { type: 'number' },
         priceMax: { type: 'number' },
         label: { type: 'string', description: "Short Russian phrase describing what's filtered, shown on the button, e.g. 'Заказы без оплаты за июнь'" },
+        labelEn: { type: 'string', description: "English version of the label, shown when the app is in English, e.g. 'Unpaid orders in June'. Always provide alongside label." },
       },
       additionalProperties: false,
     },
@@ -506,6 +507,10 @@ export const TOOLS = [
         label: {
           type: 'string',
           description: "Short Russian title for the view, shown on the button, e.g. 'Заказы за июнь'.",
+        },
+        labelEn: {
+          type: 'string',
+          description: "English version of the title, shown when the app is in English, e.g. 'June orders'. Always provide alongside label.",
         },
       },
       required: ['spec'],

--- a/backend/src/services/assistantTools/ordersViewPack.js
+++ b/backend/src/services/assistantTools/ordersViewPack.js
@@ -30,6 +30,9 @@ const EMPTY_ORDER_FILTER = {
 };
 
 const DEFAULT_LABEL = 'Отфильтрованные заказы';
+const DEFAULT_LABEL_EN = 'Filtered orders';
+
+const pickLabel = (v, fallback) => (typeof v === 'string' && v.trim() ? v.trim() : fallback);
 
 export function openOrdersViewHandler(input = {}) {
   const filter = {};
@@ -46,6 +49,9 @@ export function openOrdersViewHandler(input = {}) {
       filter[key] = String(input[key]);
     }
   }
-  const label = typeof input.label === 'string' && input.label.trim() ? input.label : DEFAULT_LABEL;
-  return { view: 'orders', filter, label };
+  // Both labels so the panel can follow the app language (Explorer v2 #497):
+  // `label` (Russian) when the app is in Russian, `labelEn` when in English.
+  const label = pickLabel(input.label, DEFAULT_LABEL);
+  const labelEn = pickLabel(input.labelEn, DEFAULT_LABEL_EN);
+  return { view: 'orders', filter, label, labelEn };
 }

--- a/docs/adr/0011-explorer-deep-join-reports-fixed-chains.md
+++ b/docs/adr/0011-explorer-deep-join-reports-fixed-chains.md
@@ -1,0 +1,36 @@
+# Explorer deep-join reports follow fixed descriptor-edge chains, not arbitrary joins
+
+**Status:** accepted (2026-07-02, Explorer v2 grill — see `docs/superpowers/plans/2026-07-02-explorer-v2.md`)
+
+**Extends:** ADR-0010 (Explorer is a read-only second front-end on `query_records`). ADR-0010 deferred "flat multi-hop denormalized reports (the only case needing chained joins + a cycle/row-explosion guard)" to v2. This ADR decides how that engine work is done.
+
+## Decision
+
+Explorer v2's **deep-join report** flattens a **fixed chain of the relationship edges already declared in the schema descriptor** into one denormalized grid. The owner starts at an entity and appends hops by following the descriptor's existing drill edges (Flower → orders that used it → order's customer → customer's key person); each appended hop is one predefined edge, chained. The `query_records` engine gains chained-join support constrained to those edges. It does **not** become an arbitrary entity-to-entity join builder — the owner cannot pick two unrelated entities and join them on chosen keys. That (the **Arbitrary join builder**) is deferred to v3.
+
+Guards, so the read-only safe-by-construction guarantee survives the new join depth:
+
+1. **Edges only.** A hop must be a declared descriptor edge (same allow-list that powers navigation drilling). No free-form join predicates. This makes cartesian products structurally impossible — every join is along a known FK relationship.
+2. **Fan-out cap + warning.** Following a "many" edge multiplies rows. The engine caps total output at the existing `ROW_CAP` and the UI warns when a chain fans out, rather than silently truncating.
+3. **Cycle bound.** A chain has a fixed maximum hop count; revisiting an entity already in the chain is disallowed, so no infinite traversal.
+4. Still read-only, still a validated declarative spec, still no raw SQL — the spec grammar gains a `chain` construct; the executor stays parameterized Drizzle.
+
+## Why
+
+The owner's stated need ("query anything, drill anywhere, see it as one grid") is fully served by chaining the edges that already exist — the same edges navigation drilling walks one at a time. Reusing them means:
+
+- **Safe by construction, still.** Joining only along declared FK edges means no cartesian explosion and no injection surface; the deep-join engine inherits ADR-0010's guarantees instead of reopening them.
+- **One relationship graph, two depths.** Navigation drilling (v1) walks one edge per click; a deep-join report (v2) walks N edges at once. Both read the *same* descriptor edge definitions — no second source of truth for "how entities relate."
+- **Arbitrary joins are a different risk class.** Free-form entity-to-entity joins on chosen keys reintroduce cartesian/cycle risk and need a real query planner + explosion guard. That is a v3 decision with its own trade-offs; shipping fixed chains first delivers the owner's concrete examples with bounded risk and lets real usage inform whether arbitrary joins are ever needed.
+
+## Considered and rejected
+
+- **Arbitrary join builder in v2** — rejected (deferred to v3): reintroduces cartesian-explosion + cycle risk that ADR-0010 was designed to avoid; the owner's examples are all fixed chains along existing edges, so the power isn't needed yet. Captured as a v3 follow-up.
+- **Materialized report views / a reporting API** — rejected (same reasoning as ADR-0010): duplicates access rules, drifts from Ask Blossom's canonical numbers.
+- **Client-side stitching of multiple single-hop queries** — rejected: N sequential round-trips, no server-side row cap across the joined set, and the fan-out/dedup logic would live in the browser where it can't be enforced.
+
+## Consequences
+
+- `query_records` grammar gains a bounded `chain` construct; the allow-list of edges = the descriptor drill edges (already defined for v1). Widening reachable chains = adding descriptor edges, which also widens Ask Blossom — one allow-list, two front-ends (per ADR-0010).
+- **Pivot** (Explorer v2, item B) is deliberately kept *out* of this engine change: a 2-D pivot is a client-side reshape of a two-field `group-by` result (measures the engine's `aggregate` already supports), so it emits an ordinary validated spec and needs no join-depth change. Pivot's safety story is unchanged from ADR-0010.
+- A future arbitrary-join-builder (v3) must revisit this ADR — it is a different risk class, not an increment.

--- a/docs/superpowers/plans/2026-07-02-explorer-v2.md
+++ b/docs/superpowers/plans/2026-07-02-explorer-v2.md
@@ -1,0 +1,57 @@
+# Explorer v2 — implementation plan
+
+PRD: #496. Waves: #497 (W1 handoff polish) · #498 (W2 deep-join) · #499 (W3 pivot) · #500 (W4 two-way+premade+deep-links).
+ADR-0010 (read-only 2nd front-end), ADR-0011 (deep-join = fixed edge chains).
+
+Grill outcomes (2026-07-02): full scope in; both-buttons handoff; deep-join = fixed descriptor-edge chains (arbitrary builder → v3); pivot = full 2-D matrix; two-way = "Ask about these" button; Premade entity in; florist parity dropped; no in-grid editing.
+
+Sequenced so each wave ≈ one Opus window. Build W1 first.
+
+---
+
+## Wave 1 — handoff polish (#497)  ← THIS BRANCH `feat/explorer-v2-handoff-polish`
+
+No engine change. Three gaps from first live use. Key discovery: **`AskBlossomPanel` already renders both an Orders button and an Explorer button independently** — each guarded by its own tool result. So "both buttons" is prompt tuning (emit both signals), not panel surgery.
+
+Data shapes (from map):
+- `ask()` returns `{sessionId, answer, toolResults:[{name,input,output}]}`; toolResults accumulate across the tool loop and attach to the final answer message.
+- Stored canonical: assistant turn `{role:'assistant',content:[...blocks incl tool_use]}` then user turn `{role:'user',content:[{type:'tool_result',tool_use_id,content:JSON.stringify(output)}]}`.
+- `toDisplayTurns` currently drops ALL tool blocks → button vanishes on reopen.
+
+### T1 — persist handoff signal on chat reopen  [RED phase mandatory: backend pure fn]
+`backend/src/services/assistantService.js` → rewrite `toDisplayTurns` so an assistant *answer* turn carries reconstructed `toolResults:[{name,output}]` for the signal tools (`open_orders_view`,`open_explorer_view`). Walk messages: collect signal `tool_use` blocks, resolve each output from the matching `tool_result` (by `tool_use_id`) in the following user turn (JSON.parse, skip on error/`output.error`), accumulate, and attach to the next assistant turn that has text (mirrors the live "attach to final answer" behaviour). Shape must match the live `{name,output}` the panel `.find`s.
+- Test: `backend/src/__tests__/assistantService.toDisplayTurns.test.js` (new). Cases: plain Q&A (no toolResults); a turn with an `open_orders_view` tool_use+result → answer turn carries `{name:'open_orders_view',output}`; `open_explorer_view` likewise; a `tool_result` with `{error}` is dropped; a non-signal data tool (e.g. `query_records`) is NOT surfaced; intermediate tool_use-only turns don't produce a stray display turn.
+- Mock `@anthropic-ai/sdk` (or set dummy `ANTHROPIC_API_KEY`) so importing the module doesn't construct a live client — mirror `assistantTools.goldenQuestions.test.js`.
+
+### T2 — bilingual signal-tool labels (`label` RU + `labelEn`)  [RED phase: pure handlers]
+- `backend/src/services/assistantTools/ordersViewPack.js` → handler returns `{view:'orders',filter,label,labelEn}`; add `DEFAULT_LABEL_EN='Filtered orders'`; `labelEn` from `input.labelEn` (trim) else default.
+- `backend/src/services/assistantTools/explorerViewPack.js` → returns `{view:'explorer',spec,label,labelEn}`; `DEFAULT_LABEL_EN='Data'`.
+- `backend/src/services/assistantTools/index.js` → add `labelEn` to both tool input schemas (description: "English version of the label, shown when the app is in English").
+- `assistantService.js` system prompt → instruct: for `open_orders_view`/`open_explorer_view`, provide BOTH `label` (Russian) and `labelEn` (English).
+- Tests: extend/add `ordersViewPack` + `explorerViewPack` handler tests — labelEn passthrough + default; existing label behaviour unchanged.
+
+### T3 — panel picks label by UI language + persisted button renders  [skip RED: UI wiring; add component test]
+- `packages/shared/components/AskBlossomPanel.jsx` → `import { useLanguage }`; `const { lang } = useLanguage();`. Both buttons pick `pickLabel(out) = (lang==='en' ? out.labelEn : out.label) || out.label || out.labelEn || t.openInOrders/openInExplorer`.
+- Test: `packages/shared/test/AskBlossomPanel.test.jsx` — (a) EN language shows `labelEn`; RU shows `label`; (b) a message loaded with `toolResults` (simulating reopen) still renders the button (guards the persistence path end-to-end at the component boundary).
+
+### T4 — both-buttons prompt tuning  [prompt only; verified by live smoke]
+- `assistantService.js` system prompt → when the answer is a list of ORDERS the owner may want to keep (save view / export), ALSO call `open_explorer_view` with the equivalent spec so both buttons appear (Orders = act; Explorer = save/CSV). Pure cross-entity (non-orders) → Explorer only. Pure aggregates → neither.
+- Not deterministically unit-testable (LLM selection). Verify via `scripts/assistant-live-smoke.js` (owner, real key). Note in PR as the verification path.
+
+**Wave 1 verify:** `cd backend && npx vitest run` (assistantService + packs); `cd packages/shared && ../../backend/node_modules/.bin/vitest run`; build all three apps; E2E if routes touched (they aren't — but run section 25 assistant if present). Quote green output.
+
+---
+
+## Wave 2 — deep-join reports (#498)  [ADR-0011 — own branch, largest]
+Engine: `dataQueryPack.js` grammar gains bounded `chain` construct (ordered descriptor edges from a start entity). New isolated tested module: validate chain vs descriptor edges → execute parameterized chained Drizzle joins → flatten → `ROW_CAP` across joined set → fan-out flag. Guards: edges-only (no cartesian), fan-out cap+warn, cycle/length bound, read-only. UI: chain builder in `ExplorerTab` + fan-out warning; savable + CSV. Mandatory red phase; real recXXX↔UUID join keys in integration. May split MVP+follow-up.
+
+## Wave 3 — pivot & measures (#499)  [own branch]
+Spec-builder exposes sum/avg/min/max (+count) over group-by (engine already supports fns). New shared pure util reshapes a two-field group-by result → rows×cols×measure matrix. Matrix grid renderer in ExplorerTab. CSV handles matrix. No engine safety change (pivot = client reshape of an ordinary validated group-by spec). Mandatory red phase (new shared util).
+
+## Wave 4 — two-way + premade + deep-links (#500)  [own branch]
+- Two-way: "Ask about these" in ExplorerTab → opens AskBlossom launcher seeded with current spec + compact row summary (seed prop).
+- Premade entity: add `premade_bouquets`(+lines) to `dataQueryPack` allow-list + `explorerSchema` descriptor with drill edges (widens Explorer AND Ask Blossom).
+- Deep-links: per-item focus support in Stock + PO screens so those Explorer rows can "Open" (deep-link only).
+
+## Deferred → v3
+Arbitrary join builder (pick any two entities, join on chosen keys) — ADR-0011.

--- a/packages/shared/components/AskBlossomPanel.jsx
+++ b/packages/shared/components/AskBlossomPanel.jsx
@@ -3,8 +3,18 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import client from '../api/client.js';
 import FeedbackModal from './FeedbackModal.jsx';
+import { useLanguage } from '../context/LanguageContext.jsx';
+
+// Handoff button label follows the app language (Explorer v2 #497): the signal
+// tool returns `label` (Russian) + `labelEn` (English); prefer the current
+// language, then either label, then the generic translated fallback.
+function pickHandoffLabel(output, lang, tFallback) {
+  const primary = lang === 'en' ? output?.labelEn : output?.label;
+  return primary || output?.label || output?.labelEn || tFallback;
+}
 
 export default function AskBlossomPanel({ t, reporterRole, reporterName, appArea, onOpenOrders, onOpenExplorer }) {
+  const { lang } = useLanguage();
   const [messages, setMessages] = useState([]); // { role: 'user'|'assistant', text }
   const [input, setInput] = useState('');
   const [sessionId, setSessionId] = useState(null);
@@ -216,7 +226,7 @@ export default function AskBlossomPanel({ t, reporterRole, reporterName, appArea
                         <path d="M19 5l-7 7" />
                         <path d="M19 13v5a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h5" />
                       </svg>
-                      {openOrdersResult.output.label || t.openInOrders || 'Open in Orders'}
+                      {pickHandoffLabel(openOrdersResult.output, lang, t.openInOrders || 'Open in Orders')}
                     </button>
                   </div>
                 )}
@@ -231,7 +241,7 @@ export default function AskBlossomPanel({ t, reporterRole, reporterName, appArea
                         <rect x="3" y="3" width="18" height="18" rx="2" />
                         <path d="M3 9h18M3 15h18M9 3v18" />
                       </svg>
-                      {openExplorerResult.output.label || t.openInExplorer || 'Open in Explorer'}
+                      {pickHandoffLabel(openExplorerResult.output, lang, t.openInExplorer || 'Open in Explorer')}
                     </button>
                   </div>
                 )}

--- a/packages/shared/test/AskBlossomPanel.test.jsx
+++ b/packages/shared/test/AskBlossomPanel.test.jsx
@@ -5,6 +5,11 @@ import AskBlossomPanel from '../components/AskBlossomPanel.jsx';
 vi.mock('../api/client.js', () => ({ default: { post: vi.fn(), get: vi.fn(), patch: vi.fn(), delete: vi.fn() } }));
 // FeedbackModal uses resizeImageBlob; mock it so jsdom canvas is not needed.
 vi.mock('../utils/imageResize.js', () => ({ resizeImageBlob: vi.fn().mockResolvedValue(new Blob()) }));
+// Control the app language for the handoff-label tests (Explorer v2 #497).
+const { langRef } = vi.hoisted(() => ({ langRef: { current: 'ru' } }));
+vi.mock('../context/LanguageContext.jsx', () => ({
+  useLanguage: () => ({ lang: langRef.current, setLang: () => {} }),
+}));
 import client from '../api/client.js';
 
 const t = {
@@ -21,7 +26,7 @@ const t = {
   reportExpired: 'Сессия устарела',
 };
 
-beforeEach(() => { vi.clearAllMocks(); client.get.mockResolvedValue({ data: [] }); });
+beforeEach(() => { vi.clearAllMocks(); langRef.current = 'ru'; client.get.mockResolvedValue({ data: [] }); });
 
 describe('AskBlossomPanel', () => {
   it('sends a question and renders the markdown answer', async () => {
@@ -159,6 +164,68 @@ describe('AskBlossomPanel — Open in Orders', () => {
     fireEvent.click(screen.getByText('Спросить'));
     await screen.findByText('просто ответ');
     expect(screen.queryByText('Отфильтрованные заказы')).not.toBeInTheDocument();
+  });
+});
+
+// ── Bilingual handoff labels + both buttons + persist-on-reopen (Explorer v2 #497) ──
+
+describe('AskBlossomPanel — bilingual handoff labels', () => {
+  const bothLabels = { view: 'orders', filter: { paymentStatus: 'Unpaid' }, label: 'Неоплаченные заказы', labelEn: 'Unpaid orders' };
+
+  it('shows the English label when the app is in English', async () => {
+    langRef.current = 'en';
+    client.post.mockResolvedValueOnce({ data: { sessionId: 's1', answer: 'ans', toolResults: [{ name: 'open_orders_view', output: bothLabels }] } });
+    render(<AskBlossomPanel t={t} onOpenOrders={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText('Спросите…'), { target: { value: 'unpaid?' } });
+    fireEvent.click(screen.getByText('Спросить'));
+    expect(await screen.findByText('Unpaid orders')).toBeInTheDocument();
+    expect(screen.queryByText('Неоплаченные заказы')).not.toBeInTheDocument();
+  });
+
+  it('shows the Russian label when the app is in Russian', async () => {
+    langRef.current = 'ru';
+    client.post.mockResolvedValueOnce({ data: { sessionId: 's1', answer: 'ans', toolResults: [{ name: 'open_orders_view', output: bothLabels }] } });
+    render(<AskBlossomPanel t={t} onOpenOrders={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText('Спросите…'), { target: { value: 'unpaid?' } });
+    fireEvent.click(screen.getByText('Спросить'));
+    expect(await screen.findByText('Неоплаченные заказы')).toBeInTheDocument();
+    expect(screen.queryByText('Unpaid orders')).not.toBeInTheDocument();
+  });
+
+  it('renders BOTH buttons when a message carries both signals', async () => {
+    const spec = { entity: 'orders', filters: [], sort: [] };
+    const toolResults = [
+      { name: 'open_orders_view', output: { view: 'orders', filter: {}, label: 'Заказы', labelEn: 'Orders' } },
+      { name: 'open_explorer_view', output: { view: 'explorer', spec, label: 'Заказы (данные)', labelEn: 'Orders (data)' } },
+    ];
+    langRef.current = 'en';
+    client.post.mockResolvedValueOnce({ data: { sessionId: 's1', answer: 'ans', toolResults } });
+    const onOpenOrders = vi.fn();
+    const onOpenExplorer = vi.fn();
+    render(<AskBlossomPanel t={t} onOpenOrders={onOpenOrders} onOpenExplorer={onOpenExplorer} />);
+    fireEvent.change(screen.getByPlaceholderText('Спросите…'), { target: { value: 'orders' } });
+    fireEvent.click(screen.getByText('Спросить'));
+    fireEvent.click(await screen.findByText('Orders'));
+    fireEvent.click(screen.getByText('Orders (data)'));
+    expect(onOpenOrders).toHaveBeenCalledWith({});
+    expect(onOpenExplorer).toHaveBeenCalledWith(spec);
+  });
+
+  it('keeps the handoff button when a saved conversation is reopened (toolResults survive projection)', async () => {
+    // Simulates the new toDisplayTurns output: the assistant turn carries the
+    // reconstructed signal toolResults, so the button re-renders on reopen.
+    client.get
+      .mockResolvedValueOnce({ data: [{ id: 'c1', title: 'Unpaid', updatedAt: 'x', messageCount: 2 }] }) // mount list
+      .mockResolvedValueOnce({ data: { id: 'c1', title: 'Unpaid', messages: [
+        { role: 'user', text: 'unpaid?' },
+        { role: 'assistant', text: 'ans', toolResults: [{ name: 'open_orders_view', output: bothLabels }] },
+      ] } });
+    const onOpenOrders = vi.fn();
+    render(<AskBlossomPanel t={t} onOpenOrders={onOpenOrders} />);
+    fireEvent.click(await screen.findByText('Unpaid'));
+    const btn = await screen.findByText('Неоплаченные заказы'); // ru default
+    fireEvent.click(btn);
+    expect(onOpenOrders).toHaveBeenCalledWith({ paymentStatus: 'Unpaid' });
   });
 });
 


### PR DESCRIPTION
First wave of **Explorer v2** (PRD #496). Ask Blossom → screen handoff cleanup from the owner's first live Explorer use. **No engine change** — assistant + shared chat panel only.

## What changed
1. **Bilingual handoff label.** `open_orders_view` / `open_explorer_view` now return both `label` (RU) + `labelEn` (EN). `AskBlossomPanel` picks by `useLanguage()` (falls back to either label, then generic `t.openInOrders`/`openInExplorer`). Previously the tool's Russian `label` always won → English dashboard showed a Russian button. Tool input schemas gained `labelEn`; system prompt asks the model for both.
2. **Both buttons for savable order lists.** The panel already renders an Orders button and an Explorer button independently. The system prompt now tells the model to ALSO emit `open_explorer_view` for a list of orders worth keeping, so the owner sees **both** "Open in Orders" (act) and "Open in Explorer" (save view / export CSV). Cross-entity → Explorer only; pure aggregates → neither.
3. **Persist on reopen.** `toDisplayTurns` previously stripped all tool blocks, so a reopened chat lost the handoff button. It now reconstructs the signal tools' `{name, output}` from the stored `tool_use`/`tool_result` pair and attaches it to the answer turn (matching the live path).

## Tests
- `assistantService.toDisplayTurns.test.js` (new, 7) — signal reconstruction, error-drop, non-signal ignored, both-signals, no stray turn.
- `ordersViewPack` / `explorerViewPack` handler tests extended for `labelEn` (passthrough + default).
- `AskBlossomPanel` tests (new) — EN shows `labelEn`, RU shows `label`, both buttons render, button survives reopen.

## Verification
- `cd backend && npx vitest run` → **899 passed** (1 todo)
- `cd packages/shared && vitest run` → **688 passed**
- `vite build` florist + dashboard + delivery → all OK
- `npm run harness` + `npm run test:e2e` → **253 passed, 0 failed** (incl. Explorer section 29)
- Both-buttons tool *selection* is LLM-driven (not deterministically unit-testable) → verify with the SAFE `scripts/assistant-live-smoke.js` against a real key (owner).

CI gate: `.github/workflows/test.yml` (Vitest backend+shared + E2E + lab-api) runs on this PR; Vercel builds all three apps.

Docs: CONTEXT.md (v2 terms) + ADR-0011 (deep-join engine) landed in `84bbfb2`; plan `docs/superpowers/plans/2026-07-02-explorer-v2.md`.

Closes #497
Refs #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)