### PR TITLE
fix(stock): default date on Stock Item create — unblocks peony demand entry (#508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Review this entire file before flipping to production.
 
 ---
 
+## 2026-07-05 — fix(stock): creating a Stock Item no longer crashes on NOT NULL date (#508)
+
+Owner report: creating a **demand entry for peonies** during new-order intake threw an empty red error toast on both Florist app and Dashboard; other flowers were fine. Root cause found in Railway logs (`ERROR: null value in column "date" of relation "stock" violates not-null constraint`, `type_name=Peony`).
+
+- The "create demand entry" flow (`useOrderEditing.createDemandEntry`) posts to `POST /stock` when a variety isn't in stock yet — peony-specific only because that variety wasn't matched to an existing row. `stockRepo.create` never set `date`, but prod PG enforces **`stock.date NOT NULL`** (applied at the Y-model cutover DDL; the `STOCK_Y_MODEL` flag is still off, but the column constraint is live). The undated INSERT was rejected → generic 500 → empty toast.
+- Fix: `stockRepo.create` now defaults `date` to **today** when the caller supplies none (dated Demand Entries still go through `getOrCreateDemandEntry`, which sets it explicitly). Deepest seam — covers every create caller, not just this flow.
+- Backend-only; no schema migration. Regression test: `stockRepo.integration.test.js` asserts a created row is always dated. Verified: backend vitest 930, E2E 253.
+- **Follow-up (not this PR):** prod is in a half-cutover state — the `stock_demand_variety_date_idx` unique index is live while the flag is off, so two same-variety demand entries created the same day can collide on the later negative-qty update. Proper resolution is the #291 Y-model cutover (route creates through `getOrCreateDemandEntry`, which sums into an existing DE).
+
 ## 2026-07-02 — Explorer: sort + filter a shown view, including deep-join grids
 
 Owner ask: filter/sort the Explorer view once it's on screen — including a multi-hop (deep-join) report. Previously the per-column sort arrows + filter popovers only appeared on a plain 0-hop grid; on a chain the headers were plain.

--- a/backend/src/__tests__/stockRepo.integration.test.js
+++ b/backend/src/__tests__/stockRepo.integration.test.js
@@ -69,6 +69,27 @@ describe('postgres mode — real SQL', () => {
     expect(auditRows[0].diff.after['Display Name']).toBe('Red Rose');
   });
 
+  it('create() always writes a non-null date (prod enforces stock.date NOT NULL) — #508', async () => {
+    // Regression: the "create demand entry" flow (POST /stock, e.g. a peony
+    // variety not yet in stock) inserts a plain Stock Item without a date.
+    // Prod PG has NOT NULL on stock.date (applied at the Y-model cutover, even
+    // with the flag off), so an undated insert threw and the UI showed an empty
+    // error toast. create() must default the date so the row is always valid.
+    const out = await stockRepo.create({
+      'Display Name': 'Peony Pink',
+      Category: 'Other',
+      'Current Quantity': 0,
+      'Current Sell Price': 20,
+      Type: 'Peony',
+      Colour: 'Pink',
+    }, { actor: { actorRole: 'owner' } });
+
+    const [row] = await harness.db.select().from(stock).where(eq(stock.id, out._pgId));
+    expect(row.date).not.toBeNull();
+    // Defaulted to a YYYY-MM-DD string (today) when the caller supplies none.
+    expect(String(row.date)).toMatch(/^\d{4}-\d{2}-\d{2}/);
+  });
+
   it('update() captures only the changed fields in the audit diff', async () => {
     // Seed
     const created = await stockRepo.create({

--- a/backend/src/repos/stockRepo.js
+++ b/backend/src/repos/stockRepo.js
@@ -542,8 +542,21 @@ export async function create(fields, opts = {}) {
   }
   const actor = opts.actor || { actorRole: 'system', actorPinLabel: null };
 
+  // Every Stock row must carry a `date`. Prod enforces NOT NULL on stock.date
+  // (applied at the Stock Y-model cutover; the STOCK_Y_MODEL flag may still be
+  // off, but the column constraint is live). Callers that create a plain Stock
+  // Item — e.g. POST /stock from the "create demand entry" flow when a variety
+  // isn't in stock yet — don't supply one, so default to today. Dated Demand
+  // Entries go through getOrCreateDemandEntry, which sets `date` explicitly.
+  // Without this, the INSERT throws a NOT NULL violation and the UI surfaces
+  // an empty error toast (#508).
+  const values = responseToPg(safe);
+  if (values.date == null) {
+    values.date = new Date().toISOString().split('T')[0];
+  }
+
   if (opts.tx) {
-    const [row] = await opts.tx.insert(stock).values(responseToPg(safe)).returning();
+    const [row] = await opts.tx.insert(stock).values(values).returning();
     await tryAudit(opts.tx, {
       entityType: 'stock', entityId: row.id, action: 'create',
       before: null, after: pgToResponse(row), ...actor,
@@ -553,7 +566,7 @@ export async function create(fields, opts = {}) {
 
   if (!db) throw new Error('stockRepo.create: postgres backend but DATABASE_URL not configured');
   const pgRow = await db.transaction(async (tx) => {
-    const [row] = await tx.insert(stock).values(responseToPg(safe)).returning();
+    const [row] = await tx.insert(stock).values(values).returning();
     await tryAudit(tx, {
       entityType: 'stock',
       entityId:   row.id,


### PR DESCRIPTION
## What & why

Owner (#508): creating a **demand entry for peonies** during new-order intake threw an empty red error toast on both Florist app and Dashboard. Other flowers worked.

**Root cause** (found in Railway logs, not by guessing):
```
ERROR: null value in column "date" of relation "stock" violates not-null constraint
DETAIL: Failing row ... date=null, type_name=Peony, colour=Pink, sell_price=20.00
```
- The "create demand entry" flow (`useOrderEditing.createDemandEntry`) posts to `POST /stock` when a variety isn't in stock yet. Peony-specific only because "Peony Pink" wasn't matched to an existing stock row, so the flow created a brand-new item.
- `stockRepo.create` never set `date`, but **prod PG enforces `stock.date NOT NULL`** — the Y-model cutover DDL applied the constraint (+ backfilled every row to a single date) even though `STOCK_Y_MODEL` is still **off**. The undated INSERT was rejected → generic 500 → empty toast (`catch { showToast(t.updateError) }`).

## The fix

`stockRepo.create` defaults `date` to **today** when the caller supplies none. Deepest correct seam — covers every create caller, not just this flow. Dated Demand Entries continue through `getOrCreateDemandEntry`, which sets `date` explicitly.

## Verification

- **Regression test**: `stockRepo.integration.test.js` — asserts a created row is always dated (red before fix, green after).
- Backend vitest: **930 passed**, 0 failed (`--no-file-parallelism`).
- E2E: **253 passed**, 0 failed.
- Backend-only, no schema migration.

## Follow-up (not this PR)

Prod is in a **half-cutover** state: the `stock_demand_variety_date_idx` unique index is live while the flag is off, so two same-variety demand entries created the same day can collide on the later negative-qty update (source of the 2026-07-03 dup-key errors seen in logs). Proper resolution is the **#291 Y-model cutover** — the create path routes through `getOrCreateDemandEntry`, which sums into an existing dated DE instead of creating duplicates.

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)