### PR TITLE
fix(wix): round-trip variant availability through variant.visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Review this entire file before flipping to production.
 
 ---
 
+## 2026-07-05 — fix(wix): deactivating a bouquet variant now actually hides it on the storefront
+
+Owner report: unchecking individual **Red roses** sizes in the Florist app and pushing to Wix had **no effect on the website**, and a subsequent **Pull reset every variant back to active** ("7/7 active" when only 5 should have been). Diagnosed live against the Wix Stores catalog (Catalog V1): the product's variants 11/15 were `visible:false` on Wix, yet inventory showed all 7 `inStock:true` and the app showed 7/7 active — classic round-trip drift.
+
+- **Root cause — availability round-tripped through the wrong Wix field.** Push wrote per-variant availability into **inventory** (`inStock`/`quantity=0`), which only paints a "sold out" badge and, for an untracked product, doesn't remove the size from the storefront option picker at all. Pull read the **product-level** `visible` flag and stamped it onto **every** variant, silently reactivating any the owner had hidden.
+- **Fix — round-trip through the per-variant `variant.visible` flag** (the actual storefront option-picker toggle):
+  - **Push** (`wixProductSync.js` → new `updateWixVariantVisibility`, wired into `runPush` as a "видимость вариантов" phase): `PATCH /stores/v1/products/{id}/variants` sets each managed variant's `visible` from its local `Active`. Simple (unmanaged) products route through the existing product-level `updateWixProductVisibility`. Inventory push is unchanged (still tracks real stock).
+  - **Pull** (`runPull`): `Active` now derives from each `variant.visible` (per-variant), not the product-level flag. `Visible in Wix` still mirrors the product-level flag separately. New and existing rows both fixed.
+- No schema change. No florist/dashboard UI change — the app's variant checkbox already maps to `Active`; only the sync semantics moved. Regression tests: `backend/src/__tests__/wixProductSync.visibility.test.js` (payload builder, HTTP wiring incl. 404/5xx, runPull per-variant Active mapping). **Verification note:** proven against mocked Wix + the backend suite; a live prod-Wix push was **not** run from this session (no Wix write creds here) — owner should run one Push + Pull cycle to confirm on the live storefront before closing out.
+
 ## 2026-07-05 — fix(stock): creating a Stock Item no longer crashes on NOT NULL date (#508)
 
 Owner report: creating a **demand entry for peonies** during new-order intake threw an empty red error toast on both Florist app and Dashboard; other flowers were fine. Root cause found in Railway logs (`ERROR: null value in column "date" of relation "stock" violates not-null constraint`, `type_name=Peony`).

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -102,6 +102,7 @@ Key paths:
 
 ## Known Pitfalls (backend-specific)
 - **Product names are owned by flower-studio (ADR-0008)** — Pull must not overwrite a row whose `Translations.en.title` is set; see `localNameOwned` in `wixProductSync.js`. Push sends EN name + PL/RU/UK translations to Wix so all storefronts reflect the dashboard-set name.
+- **Variant availability = `variant.visible`, NOT inventory `inStock` (fixed 2026-07-05)** — a product_config row's `Active` flag round-trips through Wix's per-variant **`variant.visible`** (the storefront option-picker toggle), set on Push via `updateWixVariantVisibility` (`PATCH /stores/v1/products/{id}/variants`) and read back on Pull per-variant. Inventory `inStock`/`quantity` only paints "sold out" and (untracked) doesn't hide the option — never use it as the availability control. Pull must set `Active` from each `variant.visible`, never the product-level `visible` (that stamped every variant active and wiped per-variant deactivations). Product-level `visible` is a separate concern tracked in `Visible in Wix` (and drives simple/unmanaged products via `updateWixProductVisibility`). Regression-locked by `wixProductSync.visibility.test.js`.
 
 ## Tests
 Run all: `cd backend && npx vitest run`

--- a/backend/src/__tests__/wixProductSync.visibility.test.js
+++ b/backend/src/__tests__/wixProductSync.visibility.test.js
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Regression suite for per-variant storefront availability (#florist-variants).
+//
+// Two bugs this locks down:
+//   1. PUSH never told Wix which VARIANTS to hide — it only wrote inventory
+//      (`inStock`/`quantity`), which paints a "sold out" badge but does not
+//      remove a size from the storefront option picker. Deactivating a size
+//      in the app therefore had no visible effect on the website.
+//   2. PULL stamped the PRODUCT-level `visible` flag onto EVERY variant, so a
+//      Pull silently reactivated variants the owner had hidden ("7/7 active"
+//      after a Pull that should have been "5/7").
+//
+// The fix round-trips availability through Wix's per-variant `variant.visible`.
+
+const ZERO_UUID = '00000000-0000-0000-0000-000000000000';
+
+describe('buildVariantVisibilityPayload', () => {
+  it('maps each managed variant Active flag to a visible toggle', async () => {
+    const { buildVariantVisibilityPayload } = await import('../services/wixProductSync.js');
+    const payload = buildVariantVisibilityPayload([
+      { variantId: 'v1', active: true },
+      { variantId: 'v2', active: false },
+      { variantId: 'v3', active: true },
+    ]);
+    expect(payload).toEqual({
+      variants: [
+        { variantIds: ['v1'], visible: true },
+        { variantIds: ['v2'], visible: false },
+        { variantIds: ['v3'], visible: true },
+      ],
+    });
+  });
+
+  it('excludes the synthetic ZERO_UUID default variant (simple products)', async () => {
+    const { buildVariantVisibilityPayload } = await import('../services/wixProductSync.js');
+    const payload = buildVariantVisibilityPayload([{ variantId: ZERO_UUID, active: false }]);
+    expect(payload).toEqual({ variants: [] });
+  });
+
+  it('treats only strict true as visible (never coerces truthy values)', async () => {
+    const { buildVariantVisibilityPayload } = await import('../services/wixProductSync.js');
+    const payload = buildVariantVisibilityPayload([
+      { variantId: 'v1', active: 1 },
+      { variantId: 'v2', active: undefined },
+    ]);
+    expect(payload).toEqual({
+      variants: [
+        { variantIds: ['v1'], visible: false },
+        { variantIds: ['v2'], visible: false },
+      ],
+    });
+  });
+});
+
+describe('updateWixVariantVisibility (HTTP wiring)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    vi.stubEnv('WIX_API_KEY', 'k');
+    vi.stubEnv('WIX_SITE_ID', 's');
+  });
+
+  it('PATCHes /products/{id}/variants with the per-variant visible payload', async () => {
+    fetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+    const { updateWixVariantVisibility } = await import('../services/wixProductSync.js');
+    await updateWixVariantVisibility('prod-1', [
+      { variantId: 'v1', active: true },
+      { variantId: 'v2', active: false },
+    ]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetch.mock.calls[0];
+    expect(url).toBe('https://www.wixapis.com/stores/v1/products/prod-1/variants');
+    expect(opts.method).toBe('PATCH');
+    const body = JSON.parse(opts.body);
+    expect(body).toEqual({
+      variants: [
+        { variantIds: ['v1'], visible: true },
+        { variantIds: ['v2'], visible: false },
+      ],
+    });
+  });
+
+  it('is a no-op (no fetch) for a simple product with only the default variant', async () => {
+    const { updateWixVariantVisibility } = await import('../services/wixProductSync.js');
+    await updateWixVariantVisibility('prod-1', [{ variantId: ZERO_UUID, active: false }]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('throws WixProductNotFoundError on 404 PRODUCT_NOT_FOUND (so the push can dedupe stale ids)', async () => {
+    fetch.mockResolvedValue({ ok: false, status: 404, text: async () => 'PRODUCT_NOT_FOUND' });
+    const { updateWixVariantVisibility } = await import('../services/wixProductSync.js');
+    await expect(
+      updateWixVariantVisibility('gone', [{ variantId: 'v1', active: false }])
+    ).rejects.toMatchObject({ name: 'WixProductNotFoundError', productId: 'gone' });
+  });
+
+  it('retries once on a transient 5xx then succeeds', async () => {
+    fetch
+      .mockResolvedValueOnce({ ok: false, status: 502, text: async () => 'upstream reset' })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+    const { updateWixVariantVisibility } = await import('../services/wixProductSync.js');
+    await updateWixVariantVisibility('prod-1', [{ variantId: 'v1', active: true }]);
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── Full round-trip: runPull maps per-variant visible → Active ──
+//
+// Mocks the data-access + config seams so we can drive a deterministic Wix
+// payload through the real runPull loop and assert what it writes back.
+
+const upsertMock = vi.fn();
+const listMock = vi.fn();
+const softDeleteMock = vi.fn();
+const deactivateMock = vi.fn();
+
+vi.mock('../repos/productConfigRepo.js', () => ({
+  list: (...a) => listMock(...a),
+  upsert: (...a) => upsertMock(...a),
+  softDelete: (...a) => softDeleteMock(...a),
+  deactivate: (...a) => deactivateMock(...a),
+}));
+vi.mock('../repos/syncLogRepo.js', () => ({ logSync: vi.fn() }));
+vi.mock('../repos/stockRepo.js', () => ({ list: vi.fn(async () => []) }));
+vi.mock('../services/telegram.js', () => ({ sendAlert: vi.fn(), notifyWixSyncError: vi.fn() }));
+vi.mock('../services/configService.js', () => ({
+  getConfig: () => ({}),
+  updateConfig: vi.fn(),
+  getActiveSeasonalSlots: () => [],
+  getActiveSeasonalCategory: () => null,
+}));
+
+// One managed-variant product: size "S" visible, size "L" hidden on Wix.
+function redRosesPayload() {
+  return {
+    products: [
+      {
+        id: 'p-red',
+        name: 'Red roses',
+        visible: true, // product-level: the whole product is shown
+        variants: [
+          { id: 'v-s', choices: { Rozmiar: 'S' }, visible: true, variant: { priceData: { price: 100 } } },
+          { id: 'v-l', choices: { Rozmiar: 'L' }, visible: false, variant: { priceData: { price: 200 } } },
+        ],
+      },
+    ],
+  };
+}
+
+describe('runPull — per-variant availability', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    vi.stubEnv('WIX_API_KEY', 'k');
+    vi.stubEnv('WIX_SITE_ID', 's');
+    upsertMock.mockReset().mockResolvedValue({});
+    softDeleteMock.mockReset().mockResolvedValue({});
+    deactivateMock.mockReset().mockResolvedValue({});
+    listMock.mockReset();
+    // fetch: products query returns Red roses; anything else (categories) → empty
+    fetch.mockImplementation(async (url) => {
+      if (typeof url === 'string' && url.includes('/stores/v1/products/query')) {
+        return { ok: true, json: async () => redRosesPayload() };
+      }
+      return { ok: true, json: async () => ({ collections: [] }) };
+    });
+  });
+
+  it('sets Active from each variant.visible, NOT the product-level flag', async () => {
+    // Both rows already exist and are currently Active — the hidden variant
+    // must be flipped to inactive by the Pull (the pre-fix bug kept it active).
+    listMock.mockResolvedValue([
+      { id: 'r1', 'Wix Product ID': 'p-red', 'Wix Variant ID': 'v-s', 'Product Name': 'Red roses', 'Active': true, 'Price': 100 },
+      { id: 'r2', 'Wix Product ID': 'p-red', 'Wix Variant ID': 'v-l', 'Product Name': 'Red roses', 'Active': true, 'Price': 200 },
+    ]);
+
+    const { runPull } = await import('../services/wixProductSync.js');
+    await runPull();
+
+    const hiddenUpdate = upsertMock.mock.calls
+      .map(([f]) => f)
+      .find(f => f.wixVariantId === 'v-l');
+    expect(hiddenUpdate).toBeTruthy();
+    expect(hiddenUpdate['Active']).toBe(false);
+
+    // The visible variant must NOT be deactivated — no Active:false update for it.
+    const visibleUpdate = upsertMock.mock.calls
+      .map(([f]) => f)
+      .find(f => f.wixVariantId === 'v-s' && 'Active' in f);
+    expect(visibleUpdate?.['Active']).not.toBe(false);
+  });
+
+  it('new rows inherit per-variant visibility on first import', async () => {
+    listMock.mockResolvedValue([]); // nothing local yet → both are new rows
+
+    const { runPull } = await import('../services/wixProductSync.js');
+    await runPull();
+
+    const rows = upsertMock.mock.calls.map(([f]) => f);
+    const sRow = rows.find(f => f['Wix Variant ID'] === 'v-s');
+    const lRow = rows.find(f => f['Wix Variant ID'] === 'v-l');
+    expect(sRow['Active']).toBe(true);
+    expect(lRow['Active']).toBe(false);
+    // Product-level flag is tracked separately and stays true for both.
+    expect(sRow['Visible in Wix']).toBe(true);
+    expect(lRow['Visible in Wix']).toBe(true);
+  });
+});

--- a/backend/src/services/wixProductSync.js
+++ b/backend/src/services/wixProductSync.js
@@ -30,6 +30,13 @@ const NO_PROGRESS = () => {};
 
 const WIX_API_URL = 'https://www.wixapis.com';
 
+// Wix's synthetic "default variant" ID for products WITHOUT managed variants.
+// A simple single-SKU product exposes exactly one variant with this zero-UUID
+// on read; its availability is controlled at the PRODUCT level (`visible`),
+// not per-variant. Managed-variant products (e.g. Red roses / sizes) get real
+// UUIDs and per-variant `visible`. Used by both the visibility push and pull.
+const ZERO_UUID = '00000000-0000-0000-0000-000000000000';
+
 // Thrown when a Wix Stores endpoint returns 404 PRODUCT_NOT_FOUND.
 // The push loop dedupes these by product ID so the owner sees one
 // actionable warning instead of N identical errors per variant.
@@ -248,10 +255,64 @@ async function updateWixInventory(productId, variantStates) {
 }
 
 /**
- * Update Wix product visibility (hide/show).
+ * Build the Wix `PATCH /products/{id}/variants` body that toggles each
+ * managed variant's storefront visibility from its local `Active` flag.
+ *
+ * This is THE availability control the storefront honours. A hidden variant
+ * (`visible: false`) is removed from the product's option picker entirely —
+ * unlike inventory `inStock: false`, which only paints a "sold out" badge and
+ * (when the product is untracked) does not hide the size at all. That mismatch
+ * was the root cause of "deactivated sizes still show on the website": the app
+ * was pushing availability into inventory, never into `variant.visible`.
+ *
+ * Only managed variants (real UUIDs) are emitted. Simple products expose the
+ * synthetic ZERO_UUID default variant, whose availability is a PRODUCT-level
+ * `visible` toggle (see updateWixProductVisibility) — never per-variant.
+ *
+ * @param variantStates Array of { variantId, active } — one per variant
+ * @returns {{ variants: Array<{ variantIds: string[], visible: boolean }> }}
  */
-// Reserved for future use — hides/shows a product on Wix storefront.
-// eslint-disable-next-line no-unused-vars
+export function buildVariantVisibilityPayload(variantStates) {
+  const variants = variantStates
+    .filter(v => v.variantId && v.variantId !== ZERO_UUID)
+    .map(v => ({ variantIds: [v.variantId], visible: v.active === true }));
+  return { variants };
+}
+
+/**
+ * Push per-variant storefront visibility for a managed-variant product.
+ * No-op for simple products (only the ZERO_UUID default variant) — the caller
+ * routes those through updateWixProductVisibility instead.
+ *
+ * Mirrors updateWixInventory's transient-5xx retry so a flaky Wix proxy
+ * doesn't silently drop an availability change.
+ */
+export async function updateWixVariantVisibility(productId, variantStates) {
+  const body = buildVariantVisibilityPayload(variantStates);
+  if (body.variants.length === 0) return;
+
+  const MAX_ATTEMPTS = 3;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const res = await fetch(
+      `${WIX_API_URL}/stores/v1/products/${productId}/variants`,
+      { method: 'PATCH', headers: wixHeaders(), body: JSON.stringify(body) }
+    );
+    if (res.ok) return;
+    const text = await res.text();
+    if (isProductNotFound(res.status, text)) throw new WixProductNotFoundError(productId);
+    if (res.status >= 500 && attempt < MAX_ATTEMPTS) {
+      await new Promise(r => setTimeout(r, 1000 * attempt));
+      continue;
+    }
+    throw new Error(`Wix variant visibility update failed for ${productId}: ${text}`);
+  }
+}
+
+/**
+ * Update Wix product visibility (hide/show).
+ * Availability control for SIMPLE (unmanaged) products — the whole product is
+ * shown/hidden, since a single-SKU product has no per-variant visibility.
+ */
 async function updateWixProductVisibility(productId, visible) {
   const res = await fetch(
     `${WIX_API_URL}/stores/v1/products/${productId}`,
@@ -266,6 +327,7 @@ async function updateWixProductVisibility(productId, visible) {
 
   if (!res.ok) {
     const text = await res.text();
+    if (isProductNotFound(res.status, text)) throw new WixProductNotFoundError(productId);
     throw new Error(`Wix visibility update failed for ${productId}: ${text}`);
   }
 }
@@ -693,6 +755,13 @@ export async function runPull() {
         const variantName = Object.values(variant.choices || {}).join(' / ') || `Variant ${i + 1}`;
         const variantPrice = variant.variant?.priceData?.price
           || variant.variant?.priceData?.discountedPrice || 0;
+        // Availability is PER-VARIANT: a managed variant carries its own
+        // `visible` flag (the storefront option-picker toggle). Only fall back
+        // to the product-level `visible` for a simple product's synthetic
+        // default variant, which has no per-variant flag of its own.
+        const variantVisible = variantId && variantId !== ZERO_UUID
+          ? variant.visible !== false
+          : wixVisible;
 
         const key = `${productId}::${variantId}`;
         seenKeys.add(key);
@@ -709,7 +778,7 @@ export async function runPull() {
               'Image URL': imageUrl,
               'Price': Number(variantPrice) || 0,
               'Lead Time Days': 1,
-              'Active': wixVisible,
+              'Active': variantVisible,
               'Visible in Wix': wixVisible,
               'Product Type': productType,
               'Min Stems': productType === 'mono' ? parseMinStems(variantName) : 0,
@@ -739,15 +808,15 @@ export async function runPull() {
           if (Math.abs(airtablePriceNum - wixPriceNum) > 0.01) {
             updates['Price'] = wixPriceNum;
           }
-          // Active follows Wix "Show in online store". The earlier policy
-          // treated Active as Airtable-owned, but in practice that caused
-          // drift: a product re-listed on Wix stayed inactive in Airtable
-          // forever (seen with "Mix of the day 1 - L/S": live on the
-          // storefront, shown as 0/1 active in the florist app). Wix is
-          // authoritative for whether a product is being sold; local
-          // deactivation should happen via Push (Airtable→Wix), not by
-          // editing Airtable directly and hoping Pull won't overwrite.
-          if (existing['Active'] !== wixVisible) updates['Active'] = wixVisible;
+          // Active mirrors each variant's OWN storefront visibility
+          // (`variant.visible`), not the product-level flag. The earlier
+          // policy stamped the product-level `visible` onto EVERY variant,
+          // which silently reactivated variants the owner had hidden — a Pull
+          // turned "5/7 active" back into "7/7 active". Wix is authoritative
+          // per variant; local deactivation happens via Push (which now sets
+          // `variant.visible`), and a subsequent Pull mirrors it back exactly.
+          // `Visible in Wix` still tracks the product-level flag separately.
+          if (existing['Active'] !== variantVisible) updates['Active'] = variantVisible;
           if (existing['Visible in Wix'] !== wixVisible) updates['Visible in Wix'] = wixVisible;
           // Category reconciliation: Wix is authoritative for any category
           // that maps to a tracked Wix collection (mappedNames). Airtable-
@@ -895,6 +964,7 @@ export async function runPush(onProgress = NO_PROGRESS) {
   const stats = {
     pricesSynced: 0,
     stockSynced: 0,
+    visibilitySynced: 0,
     categoriesSynced: 0,
     descriptionsSynced: 0,
     translationsSynced: 0,
@@ -927,11 +997,9 @@ export async function runPush(onProgress = NO_PROGRESS) {
       }
     }
 
-    // Zero-UUID = Wix's default-variant placeholder for products without
-    // managed variants. Those need the product-level price endpoint, not
-    // the variant batch endpoint (see `updateWixProductPrice` above).
-    const ZERO_UUID = '00000000-0000-0000-0000-000000000000';
-
+    // Zero-UUID (module const) = Wix's default-variant placeholder for
+    // products without managed variants. Those need the product-level price
+    // endpoint, not the variant batch endpoint (see `updateWixProductPrice`).
     const priceJobs = [];
     for (const row of configRows) {
       const pid = row['Wix Product ID'];
@@ -1020,6 +1088,42 @@ export async function runPush(onProgress = NO_PROGRESS) {
       );
       log('item', `Внимание: ${staleInventoryIds.size} товар(ов) удалены в Wix — очистите их из конфигурации.`, 'warn');
     }
+
+    // ── Storefront visibility (the real availability control) ──
+    // Inventory (above) tracks stock; `variant.visible` decides whether a
+    // size is OFFERED on the storefront. Deactivating a variant in the app
+    // must HIDE it — inventory `inStock:false` only shows "sold out" and,
+    // for untracked products, doesn't hide the option at all. This phase
+    // reuses the same `byProduct` map (all variants, active flag per row):
+    //   Managed-variant product → PATCH each variant's `visible` from Active.
+    //   Simple product (only the ZERO_UUID default variant) → toggle the
+    //     PRODUCT-level `visible` from that single row's Active.
+    log('phase', 'Обновляем видимость вариантов...');
+    {
+      const queue = new PQueue({ concurrency: PUSH_CONCURRENCY });
+      await Promise.all([...byProduct.entries()].map(([pid, variantStates]) => queue.add(async () => {
+        if (staleInventoryIds.has(pid)) return; // already known-gone from Wix
+        const isSimpleProduct = variantStates.every(v => v.variantId === ZERO_UUID);
+        try {
+          if (isSimpleProduct) {
+            await updateWixProductVisibility(pid, variantStates.some(v => v.active === true));
+            stats.visibilitySynced += 1;
+          } else {
+            await updateWixVariantVisibility(pid, variantStates);
+            stats.visibilitySynced += variantStates.filter(v => v.variantId !== ZERO_UUID).length;
+          }
+        } catch (err) {
+          if (err instanceof WixProductNotFoundError) {
+            staleInventoryIds.add(pid);
+            return;
+          }
+          stats.errors.push(`Visibility ${pid}: ${err.message}`);
+          const productName = wixProductNameById.get(pid) || pid;
+          log('item', `Ошибка видимости · ${productName}: ${err.message}`, 'error');
+        }
+      })));
+    }
+    log('summary', `Видимость: обновлено ${stats.visibilitySynced} вариант(ов)`);
 
     // ── Categories ──────────────────────────────────────
     log('phase', 'Обновляем категории...');


### PR DESCRIPTION
## Summary

- Deactivating a bouquet size in the Florist app and pushing to Wix had **no effect on the storefront**, and a subsequent **Pull reset every variant back to active**. Confirmed live against the Wix catalog: after the owner unchecked sizes 11 & 7 and pushed, Wix showed those two as inventory `inStock:false` but every variant's `variant.visible` untouched and `trackInventory:false` — so the sizes stayed visible on the storefront.
- **Root cause:** availability round-tripped through the wrong Wix field. Push wrote inventory (`inStock`/`quantity`), which only paints a "sold out" badge and — for an untracked product — doesn't hide the size at all. Pull read the **product-level** `visible` flag and stamped it onto **every** variant, wiping per-variant deactivations.
- **Fix:** round-trip through the per-variant `variant.visible` flag (the real storefront option-picker toggle). Push sets each managed variant's `visible` from its local `Active` via `PATCH /stores/v1/products/{id}/variants` (new `updateWixVariantVisibility`, wired into `runPush` as a dedicated phase); simple/unmanaged products route through the existing product-level `updateWixProductVisibility`. Pull now derives `Active` from each `variant.visible`, not the product-level flag. `Visible in Wix` still tracks the product-level flag separately.

## Test plan

- [x] `cd backend && npx vitest run` — 939 passed (incl. new `wixProductSync.visibility.test.js`, 9 tests)
- [x] `npm run harness &` + `npm run test:e2e` — 253 passed
- [x] `npm run lab:test:unit` — 77 passed
- [ ] `npm run lab:test:api` — not run (needs docker Postgres; unrelated cancel-with-return gate, no schema/factory change here)

## Risk surface

- No schema change, no app-UI change (the variant checkbox already maps to `Active` — only the sync semantics moved).
- **First post-deploy Push makes the app the source of truth for variant visibility.** Any variant hidden directly in the Wix editor (not via the app) will be re-shown if the app has it checked. As of diagnosis nothing is hidden on Wix, so this is a clean start.
- The visibility phase now runs for every product on every push (reuses the existing per-product inventory concurrency queue); stale/deleted Wix products dedupe via `WixProductNotFoundError` exactly like the inventory phase.

## Verification gate (per CLAUDE.md "Verification Gate")

- [x] Named the automated path: `backend/src/__tests__/wixProductSync.visibility.test.js` (payload builder, HTTP wiring incl. 404/5xx retry, and the `runPull` per-variant `Active` regression) + backend Vitest + E2E harness.
- Live prod-Wix push was **not** run from the session that wrote this (no Wix write creds there). Diagnosis was confirmed against a live read of the storefront. Post-merge: owner runs one Push + Pull on Red roses and the result is verified via the Wix API.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBUz6AbzZMRzqRoWD2JQmT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBUz6AbzZMRzqRoWD2JQmT)_