### PR TITLE
fix(stock): over-consumed Batch routes shortfall to a Demand Entry (dup-key 500s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Review this entire file before flipping to production.
 
 ---
 
+## 2026-07-06 — fix(stock): over-consumed Batch no longer collides on the demand unique index (dup-key 500s)
+
+Prod symptom (Railway PG logs 2026-07-03 & 07-06): `duplicate key value violates unique constraint "stock_demand_variety_date_idx"` on order-creation / stock-adjust `UPDATE stock SET current_quantity`. Root cause: the cutover backfilled ~62 active Batches onto one shared date (`2026-06-29`); when order consumption pushed a **second** same-`(variety,date)` row negative via the raw `adjustQuantity` in `orderRepo` step 4, it collided with the existing negative Demand Entry on the partial unique index (`WHERE current_quantity < 0`). The order create/edit 500'd and rolled back.
+
+- **Option A invariant (owner-approved): Batches never go negative — shortfall lives on the dated Demand Entry.** `orderRepo.createOrder` step 3b now also catches a positive Batch that can't fully cover a line and routes the **whole line's demand** to `getOrCreateDemandEntry(variety, needDate)` (create-or-sum), leaving the Batch at its physical qty. Same guard added to the order-**edit** new-line path. Net inventory is identical; the collision is impossible by construction. Routing on the order's **need date** means a far-future order opens a **new** demand for that plan date rather than merging into a nearer one (matches the Y-model demand model).
+- No data migration required — the fix handles the legacy shared-date rows and any future occurrence. No schema change.
+- Regression: `orderRepo.batchUnderflowDemand.integration.test.js` reproduces the exact `23505` collision (positive Batch + negative DE on the same variety+date) and proves it resolves; the pre-existing FEFO "goes negative" test was updated to the new invariant. Verified: backend vitest **941**, E2E **253**.
+
 ## 2026-07-06 — fix(wix): Pull now reads the NESTED per-variant visible path (follow-up to #511)
 
 Owner re-tested after #511 deployed: Push worked (live Wix confirmed sizes 11 & 7 at `variant.variant.visible = false`), but **Pull still reset all 7 variants to active**. Root cause: the per-variant `visible` flag in the `/stores/v1/products/query` response is **nested** at `variant.variant.visible` (same envelope as `priceData`) — #511's `runPull` read the **top-level** `variant.visible`, which is `undefined`, and `undefined !== false` coerces to `true`, so every variant round-tripped back to active.

--- a/backend/src/__tests__/orderRepo.batchUnderflowDemand.integration.test.js
+++ b/backend/src/__tests__/orderRepo.batchUnderflowDemand.integration.test.js
@@ -1,0 +1,133 @@
+// Regression: an over-consumed Batch must NOT be driven negative — the shortfall
+// belongs on the dated Demand Entry (Y-model invariant, Option A, 2026-07).
+//
+// Prod incident (dup-key 500s, 2026-07-03 / 07-06): the cutover parked many
+// legacy Batches on one shared date (2026-06-29). When order consumption pushed
+// a second same-(variety,date) row negative via the raw adjustQuantity in
+// orderRepo step 4, it collided with the existing negative Demand Entry on the
+// partial unique index `stock_demand_variety_date_idx` (UNIQUE on
+// type_name,colour,size_cm,cultivar,date WHERE current_quantity < 0). Order
+// creation 500'd and rolled back.
+//
+// Invariant proven here: Batches never go negative. A line whose Batch can't
+// fully cover routes the WHOLE line's demand to a Demand Entry dated to the
+// order's need date (create-or-sum), leaving the Batch at its physical qty.
+// Net inventory is unchanged; the collision is impossible by construction.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import { stock, orderLines } from '../db/schema.js';
+import { eq, and, sql, isNull } from 'drizzle-orm';
+
+const dbHolder = { db: null };
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  isPostgresConfigured: true,
+  pool: null,
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+const yModelFlag = { enabled: true };
+vi.mock('../services/configService.js', () => ({
+  getStockYModelEnabled: () => yModelFlag.enabled,
+  getStockXModelEnabled: () => false,
+  getConfig: (k) => ({ defaultDeliveryFee: 25, driverCostPerDelivery: 10 }[k] ?? 0),
+  updateConfig: vi.fn(),
+  generateOrderId: vi.fn(async () => `BLO-UF-${Math.floor(performance.now())}`),
+  getDriverOfDay: () => 'Timur',
+  isPastCutoff: vi.fn(),
+  getActiveSeasonalCategory: vi.fn(),
+  loadConfig: vi.fn(),
+  saveConfig: vi.fn(),
+}));
+
+import * as orderRepo from '../repos/orderRepo.js';
+
+const config = {
+  getConfig: (k) => ({ defaultDeliveryFee: 25, driverCostPerDelivery: 10 }[k] ?? 0),
+  getDriverOfDay: () => 'Timur',
+  generateOrderId: async () => `BLO-UF-${Math.floor(performance.now())}`,
+};
+
+let harness;
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+  yModelFlag.enabled = true;
+});
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+async function seedRow({ qty, date, typeName = 'Hydrangea', colour = 'White' }) {
+  const [row] = await harness.db.insert(stock).values({
+    displayName: `${typeName} ${colour} (${date})`,
+    currentQuantity: qty, active: true, typeName, colour, date,
+  }).returning();
+  return row;
+}
+
+// All Demand Entries (qty<0) for the Variety.
+async function demandEntries(typeName = 'Hydrangea', colour = 'White') {
+  return harness.db.select().from(stock).where(and(
+    eq(stock.typeName, typeName), eq(stock.colour, colour),
+    sql`${stock.currentQuantity} < 0`, isNull(stock.deletedAt),
+  ));
+}
+
+describe('createOrder — over-consumed Batch routes shortfall to a Demand Entry (no dup-key collision)', () => {
+  it('does not throw when a Batch shares (variety,date) with an existing negative DE', async () => {
+    // The exact prod collision setup: a positive Batch and a negative Demand
+    // Entry on the SAME (variety, date).
+    const batch = await seedRow({ qty: 1, date: '2026-06-29' });
+    const existingDe = await seedRow({ qty: -3, date: '2026-06-29' });
+
+    // Pickup order (no required_by) needing 5 → demand date = today (a DIFFERENT
+    // plan date than the 06-29 DE, so it must NOT merge into it).
+    await expect(orderRepo.createOrder({
+      customer: 'recCust1',
+      deliveryType: 'Pickup',
+      orderLines: [{ stockItemId: batch.id, flowerName: 'Hydrangea White', quantity: 5 }],
+      paymentStatus: 'Unpaid',
+      paymentMethod: 'Cash',
+      createdBy: 'florist',
+    }, config, { actor: { actorRole: 'florist' } })).resolves.toBeTruthy();
+
+    // Batch never went negative — kept its physical qty.
+    const [batchAfter] = await harness.db.select().from(stock).where(eq(stock.id, batch.id));
+    expect(batchAfter.currentQuantity).toBe(1);
+
+    // The pre-existing 06-29 plan DE is untouched (need-date routing → new DE).
+    const [deAfter] = await harness.db.select().from(stock).where(eq(stock.id, existingDe.id));
+    expect(deAfter.currentQuantity).toBe(-3);
+
+    // A new DE holds the full order demand (5) at the order's need date.
+    const des = await demandEntries();
+    const total = des.reduce((s, r) => s + Number(r.currentQuantity), 0);
+    expect(total).toBe(-8); // -3 (existing plan) + -5 (this order)
+    // Net inventory across the Variety = 1 (batch) + (-8) demand = -7.
+  });
+
+  it('same need-date sums into the existing DE instead of creating a duplicate', async () => {
+    const batch = await seedRow({ qty: 2, date: '2026-07-20' });
+    await seedRow({ qty: -3, date: '2026-07-20' });
+
+    await orderRepo.createOrder({
+      customer: 'recCust1',
+      deliveryType: 'Delivery',
+      requiredBy: '2026-07-20',
+      deliveryAddress: 'ul. Test 1', recipientName: 'X', recipientPhone: '1',
+      orderLines: [{ stockItemId: batch.id, flowerName: 'Hydrangea White', quantity: 6 }],
+      paymentStatus: 'Unpaid', paymentMethod: 'Cash', createdBy: 'florist',
+    }, config, { actor: { actorRole: 'florist' } });
+
+    // Batch untouched; single DE at 2026-07-20 summed to -9 (no duplicate row).
+    const [batchAfter] = await harness.db.select().from(stock).where(eq(stock.id, batch.id));
+    expect(batchAfter.currentQuantity).toBe(2);
+    const des = await demandEntries();
+    expect(des).toHaveLength(1);
+    expect(Number(des[0].currentQuantity)).toBe(-9); // -3 + -6
+  });
+});

--- a/backend/src/__tests__/orderRepo.fefo.integration.test.js
+++ b/backend/src/__tests__/orderRepo.fefo.integration.test.js
@@ -7,7 +7,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
 import { stock, orderLines } from '../db/schema.js';
-import { eq } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
 
 const dbHolder = { db: null };
 vi.mock('../db/index.js', () => ({
@@ -96,7 +96,11 @@ describe('createOrder FEFO routing (#319)', () => {
     expect(line.stockItemId).toBe(oldBatch.id);
   });
 
-  it('falls back to oldest Batch when none has enough cover (lets it go negative)', async () => {
+  it('when no Batch fully covers, routes shortfall to a Demand Entry — Batches never go negative (Option A)', async () => {
+    // Under Option A (2026-07 dup-key incident) a Batch is never driven negative:
+    // an under-covering line routes its whole demand to a dated Demand Entry so a
+    // negative Batch can't collide with a same-(variety,date) DE on the unique
+    // index. Both Batches keep their physical qty; the shortfall lives on the DE.
     const oldBatch = await seedBatch({ qty: 1, date: '2026-05-16' });
     const newBatch = await seedBatch({ qty: 2, date: '2026-05-18' });
 
@@ -113,8 +117,17 @@ describe('createOrder FEFO routing (#319)', () => {
 
     const [oldAfter] = await harness.db.select().from(stock).where(eq(stock.id, oldBatch.id));
     const [newAfter] = await harness.db.select().from(stock).where(eq(stock.id, newBatch.id));
-    expect(oldAfter.currentQuantity).toBe(-4);  // 1 - 5
-    expect(newAfter.currentQuantity).toBe(2);
+    expect(oldAfter.currentQuantity).toBe(1);   // untouched — no longer driven negative
+    expect(newAfter.currentQuantity).toBe(2);   // untouched
+
+    // A Demand Entry now carries the full order demand; Variety net = 1+2-5 = -2.
+    const all = await harness.db.select().from(stock)
+      .where(and(eq(stock.typeName, 'Hydrangea'), eq(stock.colour, 'White')));
+    const net = all.reduce((s, r) => s + Number(r.currentQuantity), 0);
+    expect(net).toBe(-2);
+    const de = all.find(r => Number(r.currentQuantity) < 0);
+    expect(de).toBeTruthy();
+    expect(Number(de.currentQuantity)).toBe(-5);
   });
 
   it('prefers newer full-cover Batch over older short Batch', async () => {

--- a/backend/src/repos/orderRepo.js
+++ b/backend/src/repos/orderRepo.js
@@ -691,7 +691,16 @@ export async function createOrder(params, config, opts = {}) {
         const isDemandRow =
           _q < 0 ||
           (_q === 0 && stockRow.date != null && stockRow.date !== demandDate);
-        if (!isDemandRow) continue;
+        // Option A (2026-07, dup-key incident): a positive Batch that can't fully
+        // cover this line must NOT be pushed negative by step 4's raw
+        // adjustQuantity — a negative Batch collides with a same-(variety,date)
+        // Demand Entry on the `stock_demand_variety_date_idx` partial unique index
+        // (prod 500s on order create/edit). Route the WHOLE line's demand to the
+        // dated DE instead (create-or-sum at the order's need date, so different
+        // plan dates stay separate); the Batch keeps its physical qty. Net
+        // inventory is identical — shortfall lives on the DE, its proper home.
+        const isBatchUnderflow = _q > 0 && _q < Number(line.quantity);
+        if (!isDemandRow && !isBatchUnderflow) continue;
 
         // Y-model DE row: create or deepen dated DE
         const varietyKey = {
@@ -1194,6 +1203,33 @@ export async function editBouquetLines(orderId, { lines = [], removedLines = [] 
             );
             line.stockItemId = de._pgId;
             line._deApplied = true;
+          }
+
+          // Option A (2026-07 dup-key incident): after FEFO, if the resolved Batch
+          // is positive but still can't fully cover this new line, route the whole
+          // demand to the dated DE instead of letting step-4's raw adjustQuantity
+          // drive the Batch negative (which would collide with a same-(variety,
+          // date) DE on the unique index). Mirrors createOrder step 3b.
+          if (!line._deApplied && line.stockItemId) {
+            const [b] = await tx.select({
+              typeName: stock.typeName, colour: stock.colour,
+              sizeCm: stock.sizeCm, cultivar: stock.cultivar,
+              currentQuantity: stock.currentQuantity,
+            }).from(stock)
+              .where(and(eq(stock.id, line.stockItemId), isNull(stock.deletedAt)))
+              .limit(1);
+            if (b?.typeName && Number(b.currentQuantity) > 0 && Number(b.currentQuantity) < Number(line.quantity)) {
+              const demandDate = computeDemandDate({
+                requiredBy: order.requiredBy || null,
+                orderDate:  new Date().toISOString().split('T')[0],
+              });
+              const de = await getOrCreateDemandEntry(
+                { typeName: b.typeName, colour: b.colour, sizeCm: b.sizeCm, cultivar: b.cultivar },
+                demandDate, Number(line.quantity), tx, actor,
+              );
+              line.stockItemId = de._pgId;
+              line._deApplied = true;
+            }
           }
         }
 


### PR DESCRIPTION
## Why
Prod Railway PG logs (2026-07-03 & 07-06): `duplicate key value violates unique constraint "stock_demand_variety_date_idx"` on order-creation / stock-adjust. **Root cause:** the cutover parked ~62 active Batches on one shared date (`2026-06-29`); when order consumption pushed a **second** same-`(variety,date)` row negative via the raw `adjustQuantity` in `orderRepo` step 4, it collided with the existing negative Demand Entry on the partial unique index (`WHERE current_quantity < 0`). The order create/edit **500'd and rolled back** — the owner couldn't place/edit orders for affected varieties.

## What (Option A — owner-approved invariant)
**Batches never go negative — all shortfall lives on the dated Demand Entry.**
- `orderRepo.createOrder` step 3b now also catches a **positive Batch that can't fully cover** a line and routes the whole line's demand to `getOrCreateDemandEntry(variety, needDate)` (create-or-sum), leaving the Batch at its physical qty.
- Same guard added to the order-**edit** new-line path.
- Routing on the order's **need date** means a far-future order opens a **new** demand for that plan date instead of merging into a nearer one (matches the Y-model demand model the owner described).
- Net inventory is identical (`1 batch + −8 demand = −7`, same as before); the collision is now **impossible by construction**. No data migration, no schema change.

## Verification
- `orderRepo.batchUnderflowDemand.integration.test.js` (new) reproduces the exact `23505` collision (positive Batch + negative DE on the same variety+date) and proves it resolves; a second case proves same-need-date **sums** (no duplicate DE).
- The pre-existing FEFO "goes negative" test was updated to the new invariant (Batch stays positive; shortfall on the DE).
- **941** backend vitest + **253** E2E green.

## Relationship to #513
Independent of #513 (W1, the substitute double-book / missing-Type fix) — different files. Either can merge first. Minor CHANGELOG merge may be needed if both land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)