### PR TITLE
fix(assistant): log the failing spec on post-validation query_records errors

### DIFF
--- a/backend/src/__tests__/assistantTools.dataQueryPack.errorLog.test.js
+++ b/backend/src/__tests__/assistantTools.dataQueryPack.errorLog.test.js
@@ -1,0 +1,45 @@
+// Post-validation failures in queryRecordsHandler must log the FULL spec to
+// the backend service log. Rationale (2026-07-06): PG-side Railway logs mix
+// app queries with ad-hoc read-only client queries (claude_ro sessions), so a
+// bare error message there is unattributable — an engine bug is only
+// diagnosable if the backend log carries the failing spec itself.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the db so a validated spec still explodes at execution time —
+// simulating the "spec passed validateSpec but the generated SQL failed"
+// class of engine bug.
+vi.mock('../db/index.js', () => ({
+  db: {
+    select: () => { throw new Error('operator does not exist: text = uuid'); },
+  },
+}));
+
+const { queryRecordsHandler } = await import('../services/assistantTools/dataQueryPack.js');
+
+describe('queryRecordsHandler post-validation error logging', () => {
+  let errSpy;
+  beforeEach(() => { errSpy = vi.spyOn(console, 'error').mockImplementation(() => {}); });
+  afterEach(() => { errSpy.mockRestore(); });
+
+  it('returns { error } and logs the failing spec verbatim', async () => {
+    const spec = { entity: 'orders', limit: 5 };
+    const result = await queryRecordsHandler(spec);
+
+    // Clean tool-error shape — never a throw/500 to the caller.
+    expect(result).toEqual({ error: 'operator does not exist: text = uuid' });
+
+    // The backend log line carries the spec JSON for attribution.
+    const call = errSpy.mock.calls.find(args =>
+      String(args[0]).includes('post-validation failure'));
+    expect(call).toBeTruthy();
+    expect(call.join(' ')).toContain(JSON.stringify(spec));
+  });
+
+  it('does NOT log validation rejections (they return early, model-readable)', async () => {
+    const result = await queryRecordsHandler({ entity: 'nope' });
+    expect(result.error).toBeTruthy();
+    const call = errSpy.mock.calls.find(args =>
+      String(args[0]).includes('post-validation failure'));
+    expect(call).toBeUndefined();
+  });
+});

--- a/backend/src/services/assistantTools/dataQueryPack.js
+++ b/backend/src/services/assistantTools/dataQueryPack.js
@@ -667,7 +667,15 @@ export async function queryRecordsHandler(spec) {
     if (hasChain) result.fanOut = fanOut;
     return result;
   } catch (err) {
-    console.error('[dataQueryPack] queryRecordsHandler error:', err.message);
+    // A failure here means the spec PASSED validation but the generated SQL
+    // still blew up — an engine bug by definition. Log the full spec so the
+    // backend service log alone identifies the failing shape: the PG-side log
+    // can't (it mixes in ad-hoc read-only client queries and has no spec).
+    console.error(
+      '[dataQueryPack] queryRecordsHandler post-validation failure:',
+      err.message,
+      '— spec:', JSON.stringify(spec),
+    );
     return { error: err.message };
   }
 }


### PR DESCRIPTION
Plan W3 (re-scoped after live diagnosis — docs/superpowers/plans/2026-07-06-fable-improvement-plan.md, Cluster A4).

## What happened
Prod Postgres logs showed query errors (`text = uuid`, `o.customer_name`, `sell_price`, `order_id`) that looked like assistant/Explorer engine failures. Diagnosis disproved it: `assistant_conversations` has no rows after 07-02, the backend service log is clean, and Drizzle never emits those SQL shapes — they were ad-hoc read-only `claude_ro` exploration queries from Claude sessions. The engine has been clean since #506.

## What this ships
The misattribution itself is the defect: a real post-validation engine failure and an ad-hoc probe are indistinguishable in the PG log. `queryRecordsHandler`'s catch now logs the FULL failing spec (`[dataQueryPack] queryRecordsHandler post-validation failure: <err> — spec: {...}`) to the backend service log. Validation rejections are unchanged (early return, model-readable, unlogged).

## Verification
- New `assistantTools.dataQueryPack.errorLog.test.js` — 2 tests: spec logged verbatim on execution failure; validation rejection does NOT log.
- Full backend suite: 106 files, 955 passed (1 pre-existing todo), `--no-file-parallelism`.
- E2E harness suite: 253/253 incl. section 29 (Explorer engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)