### PR TITLE
chore(ops): prod-error watchdog — daily log sweep files issues for new error signatures

### DIFF
--- a/backend/scripts/prod-error-signatures.json
+++ b/backend/scripts/prod-error-signatures.json
@@ -1,0 +1,7 @@
+{
+  "signatures": [
+    "ERROR: duplicate key value violates unique constraint \"stock_demand_variety_date_idx\"",
+    "ERROR: null value in column \"date\" of relation \"stock\" violates not-null constraint",
+    "ERROR: null value in column \"type_name\" of relation \"stock\" violates not-null constraint"
+  ]
+}

--- a/backend/scripts/prod-error-sweep.js
+++ b/backend/scripts/prod-error-sweep.js
@@ -1,0 +1,421 @@
+// Category: SAFE — read-only log sweep; files GitHub issues for new error signatures
+//
+// Daily watchdog over two Railway log streams:
+//
+//   1. PRIMARY — the `flower-studio-backend` service. This is app-side
+//      Node/Express code, and every error path in this codebase logs via
+//      `console.error('[TAG] description:', err)` (see backend/src/index.js
+//      `[FATAL] Uncaught exception:` / `[FATAL] Unhandled promise rejection:`,
+//      and dozens of `[XXX] ... failed:` / `[XXX] ... error:` call sites
+//      across routes/services). A real app bug shows up here.
+//
+//   2. SECONDARY — the `Postgres` service, filtered to CONSTRAINT
+//      VIOLATIONS ONLY (`violates unique constraint`, `violates not-null
+//      constraint`, `violates foreign key constraint`). These indicate a
+//      real write-path bug regardless of which client issued the query.
+//
+//      IMPORTANT ATTRIBUTION CAVEAT: the Postgres service log also
+//      captures every ad-hoc read-only query run by Claude sessions
+//      against the `claude_ro` role while diagnosing production issues
+//      (per CLAUDE.md's "Postgres issues" guidance). Generic errors like
+//      `column "x" does not exist`, `operator does not exist: ...`, and
+//      `function ... does not exist` are almost always typos in those
+//      throwaway exploration queries, NOT app bugs — the app's own SQL is
+//      static and already passed CI/tests, so it doesn't hit "column does
+//      not exist" in production. We deliberately EXCLUDE those classes
+//      from the Postgres sweep to avoid filing issues about our own
+//      debugging queries. Only genuine data-integrity violations
+//      (constraint errors) are swept from the Postgres stream.
+//
+// Extracted lines are normalized into a stable "signature" (timestamps,
+// PIDs, `at character N` offsets, and variable quoted literal values
+// stripped out — object names like `column "sell_price"` are kept), then
+// diffed against the known-signature ledger
+// (backend/scripts/prod-error-signatures.json). One GitHub issue is filed
+// per genuinely NEW signature; re-runs are idempotent because the ledger
+// is appended to after filing.
+//
+// Never touches prod data: it only reads `railway logs` output (or
+// `--input` files for tests) and calls `gh issue create`.
+//
+// Usage:
+//   node backend/scripts/prod-error-sweep.js                        # live sweep, files issues
+//   node backend/scripts/prod-error-sweep.js --dry-run               # report only, no issues filed, ledger untouched
+//   node backend/scripts/prod-error-sweep.js --input-backend f.log --input-postgres g.log   # file-driven, for tests
+//   node backend/scripts/prod-error-sweep.js --tail 2000              # override --tail count passed to `railway logs`
+
+import { execFileSync } from 'child_process';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { fileURLToPath, pathToFileURL } from 'url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const SIGNATURES_PATH = path.join(__dirname, 'prod-error-signatures.json');
+
+export const BACKEND_SERVICE = 'flower-studio-backend';
+export const POSTGRES_SERVICE = 'Postgres';
+
+// ── Backend stream (app-side) ──
+// Every error path in this codebase logs via console.error with a
+// bracket tag ([FATAL], [WEBHOOK], [STOCK-ORDER], etc.) or, less often,
+// a bare "... failed"/"... error" message (see backend/src/routes/stock.js
+// `stock usage: loss log fetch failed`). We treat any line containing
+// "error" or "failed" (case-insensitive) as a candidate, then apply the
+// ignore list below.
+const BACKEND_ERROR_PATTERN = /\berror\b|\bfailed\b|\[FATAL\]/i;
+
+// ── Postgres stream (constraint violations only) ──
+// See the attribution caveat above: we ONLY sweep genuine data-integrity
+// violations from Postgres logs, never generic "does not exist" errors,
+// because those are overwhelmingly ad-hoc claude_ro exploration queries.
+const POSTGRES_CONSTRAINT_PATTERN =
+  /violates (unique constraint|not-null constraint|foreign key constraint|check constraint)/i;
+
+// Lines that look like errors but are routine noise — never surfaced.
+const IGNORE_PATTERNS = [
+  /SSL error: unexpected eof while reading/i,
+  /could not receive data from client: Connection reset by peer/i,
+];
+
+// Object-noun keywords that precede a Postgres identifier we want to KEEP
+// in the signature (e.g. column "sell_price", constraint "foo_idx").
+// Quoted substrings NOT preceded by one of these are treated as variable
+// literal values and collapsed to a placeholder.
+const OBJECT_KEYWORDS =
+  /\b(column|relation|constraint|table|function|operator|role|schema|type|index|sequence|database|extension|trigger|view|policy)\s+$/i;
+
+/**
+ * Extract app-side error lines from the backend service log blob.
+ * @param {string} rawLog
+ * @returns {string[]}
+ */
+export function extractBackendErrorLines(rawLog) {
+  if (!rawLog) return [];
+  return rawLog
+    .split('\n')
+    .map((l) => l.trimEnd())
+    .filter((l) => BACKEND_ERROR_PATTERN.test(l))
+    .filter((l) => !IGNORE_PATTERNS.some((re) => re.test(l)));
+}
+
+/**
+ * Extract constraint-violation lines from the Postgres service log blob.
+ * Deliberately excludes generic "does not exist" errors — see header.
+ * @param {string} rawLog
+ * @returns {string[]}
+ */
+export function extractPostgresConstraintLines(rawLog) {
+  if (!rawLog) return [];
+  return rawLog
+    .split('\n')
+    .map((l) => l.trimEnd())
+    .filter((l) => /ERROR/i.test(l))
+    .filter((l) => !IGNORE_PATTERNS.some((re) => re.test(l)))
+    .filter((l) => POSTGRES_CONSTRAINT_PATTERN.test(l));
+}
+
+/**
+ * Backward/general-purpose helper: extract lines matching /ERROR/i from a
+ * raw log blob, excluding noise. Used internally by
+ * extractPostgresConstraintLines; also exported for tests that want the
+ * unfiltered ERROR-line extraction step in isolation.
+ * @param {string} rawLog
+ * @returns {string[]}
+ */
+export function extractErrorLines(rawLog) {
+  if (!rawLog) return [];
+  return rawLog
+    .split('\n')
+    .map((l) => l.trimEnd())
+    .filter((l) => /ERROR/i.test(l))
+    .filter((l) => !IGNORE_PATTERNS.some((re) => re.test(l)));
+}
+
+/**
+ * Normalize a raw log line to a stable signature: strip timestamps, PIDs,
+ * "at character N" offsets, and variable quoted literal values — while
+ * keeping the error class + quoted object names (column/relation/constraint/...).
+ * @param {string} line
+ * @returns {string}
+ */
+export function normalizeSignature(line) {
+  let s = line;
+
+  // Strip leading Postgres-style timestamp: "2026-07-06 14:15:34.353 UTC "
+  s = s.replace(/^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(\.\d+)?\s*(UTC)?\s*/i, '');
+
+  // Strip leading generic bracketed ISO timestamp, e.g. "[2026-07-06T14:15:34.353Z]"
+  s = s.replace(/^\[\d{4}-\d{2}-\d{2}T[\d:.]+Z?\]\s*/i, '');
+
+  // Strip PID markers like "[97131]" (Postgres log_line_prefix).
+  s = s.replace(/\[\d+\]\s*/g, '');
+
+  // Strip "at character N" offsets (with or without trailing punctuation).
+  s = s.replace(/\s*at character \d+/gi, '');
+
+  // Collapse quoted literal values that are NOT object names into a placeholder.
+  s = s.replace(/(\S+\s+)?(["'])((?:\\.|(?!\2).)*)\2/g, (match, before, quote, _inner) => {
+    if (before && OBJECT_KEYWORDS.test(before)) {
+      // Keep object names verbatim (e.g. column "sell_price").
+      return match;
+    }
+    return `${before || ''}${quote}?${quote}`;
+  });
+
+  // Collapse repeated whitespace.
+  s = s.replace(/\s+/g, ' ').trim();
+
+  return s;
+}
+
+/**
+ * Group raw error lines by their normalized signature.
+ * @param {string[]} lines
+ * @param {string} [source] optional tag recorded on each group (e.g. "backend" / "postgres")
+ * @returns {Map<string, { signature: string, lines: string[], count: number, source?: string }>}
+ */
+export function groupBySignature(lines, source) {
+  const groups = new Map();
+  for (const line of lines) {
+    const signature = normalizeSignature(line);
+    if (!groups.has(signature)) {
+      groups.set(signature, { signature, lines: [], count: 0, source });
+    }
+    const g = groups.get(signature);
+    g.lines.push(line);
+    g.count += 1;
+  }
+  return groups;
+}
+
+/**
+ * Merge multiple signature-group maps (e.g. backend + postgres) into one.
+ * @param {Array<Map<string, {signature: string, lines: string[], count: number, source?: string}>>} groupMaps
+ * @returns {Map<string, {signature: string, lines: string[], count: number, source?: string}>}
+ */
+export function mergeGroups(groupMaps) {
+  const merged = new Map();
+  for (const groups of groupMaps) {
+    for (const g of groups.values()) {
+      if (!merged.has(g.signature)) {
+        merged.set(g.signature, { signature: g.signature, lines: [], count: 0, source: g.source });
+      }
+      const m = merged.get(g.signature);
+      m.lines.push(...g.lines);
+      m.count += g.count;
+    }
+  }
+  return merged;
+}
+
+/**
+ * Extract a leading timestamp from a raw log line, if present.
+ * @param {string} line
+ * @returns {string|null}
+ */
+export function extractTimestamp(line) {
+  const m = line.match(/^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(\.\d+)?/);
+  return m ? m[0] : null;
+}
+
+/**
+ * Load the known-signature ledger from disk. Returns an empty set if the
+ * file is missing (first run).
+ * @param {string} [filePath]
+ * @returns {Set<string>}
+ */
+export function loadKnownSignatures(filePath = SIGNATURES_PATH) {
+  if (!existsSync(filePath)) return new Set();
+  const raw = readFileSync(filePath, 'utf8');
+  const parsed = JSON.parse(raw);
+  const list = Array.isArray(parsed) ? parsed : parsed.signatures || [];
+  return new Set(list);
+}
+
+/**
+ * Diff grouped signatures against the known ledger, returning only the
+ * groups whose signature is NOT already known.
+ * @param {Map<string, {signature: string}>} groups
+ * @param {Set<string>} known
+ * @returns {Array<{signature: string, lines: string[], count: number}>}
+ */
+export function diffNewSignatures(groups, known) {
+  return Array.from(groups.values()).filter((g) => !known.has(g.signature));
+}
+
+/**
+ * Persist an updated known-signature ledger to disk (sorted, deduped).
+ * @param {Iterable<string>} signatures
+ * @param {string} [filePath]
+ */
+export function saveKnownSignatures(signatures, filePath = SIGNATURES_PATH) {
+  const sorted = Array.from(new Set(signatures)).sort();
+  writeFileSync(filePath, JSON.stringify({ signatures: sorted }, null, 2) + '\n');
+}
+
+/**
+ * Build the GitHub issue title + body for a new signature group.
+ * @param {{signature: string, lines: string[], count: number, source?: string}} group
+ * @returns {{ title: string, body: string }}
+ */
+export function buildIssueContent(group) {
+  const title = `prod-error: ${group.signature}`;
+  const timestamps = group.lines.map(extractTimestamp).filter(Boolean);
+  const first = timestamps[0] || 'unknown';
+  const last = timestamps[timestamps.length - 1] || 'unknown';
+  const sampleLines = group.lines.slice(0, 10).join('\n');
+
+  const body = [
+    `**Signature:** \`${group.signature}\``,
+    group.source ? `**Source:** ${group.source}` : null,
+    '',
+    `**Occurrences in this sweep:** ${group.count}`,
+    `**First seen:** ${first}`,
+    `**Last seen:** ${last}`,
+    '',
+    '**Raw sample lines:**',
+    '```',
+    sampleLines,
+    '```',
+    '',
+    '_Filed automatically by `backend/scripts/prod-error-sweep.js` (SAFE, read-only log sweep)._',
+  ]
+    .filter((l) => l !== null)
+    .join('\n');
+
+  return { title, body };
+}
+
+/**
+ * Pull raw logs for a given Railway service (or read from a file when
+ * inputFile is supplied — used by tests so nothing ever shells out).
+ * @param {{ service: string, inputFile?: string, tail?: number }} opts
+ * @returns {string}
+ */
+export function fetchLogs({ service, inputFile, tail = 1000 } = {}) {
+  if (inputFile) {
+    if (!existsSync(inputFile)) return '';
+    return readFileSync(inputFile, 'utf8');
+  }
+  return execFileSync('railway', ['logs', '-s', service, '--tail', String(tail)], {
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024 * 50,
+  });
+}
+
+/**
+ * File a single GitHub issue for a new-signature group via `gh issue create`.
+ * @param {{ title: string, body: string }} content
+ */
+export function fileGithubIssue({ title, body }) {
+  execFileSync(
+    'gh',
+    ['issue', 'create', '--label', 'needs-triage', '--title', title, '--body', body],
+    { encoding: 'utf8' }
+  );
+}
+
+/**
+ * Core sweep logic — pure aside from the injected IO functions, so tests
+ * can drive it without shelling out or hitting GitHub.
+ * @param {object} opts
+ * @param {string} opts.backendLog raw log text from the backend service
+ * @param {string} opts.postgresLog raw log text from the Postgres service
+ * @param {Set<string>} opts.known
+ * @param {boolean} opts.dryRun
+ * @param {(content: {title: string, body: string}) => void} [opts.createIssue]
+ * @param {(signatures: Iterable<string>) => void} [opts.persistSignatures]
+ * @returns {{ newSignatures: Array<{signature: string, count: number}>, totalErrorLines: number }}
+ */
+export function runSweep({
+  backendLog = '',
+  postgresLog = '',
+  known,
+  dryRun,
+  createIssue = fileGithubIssue,
+  persistSignatures = saveKnownSignatures,
+}) {
+  const backendLines = extractBackendErrorLines(backendLog);
+  const postgresLines = extractPostgresConstraintLines(postgresLog);
+
+  const backendGroups = groupBySignature(backendLines, 'backend');
+  const postgresGroups = groupBySignature(postgresLines, 'postgres');
+  const groups = mergeGroups([backendGroups, postgresGroups]);
+
+  const newGroups = diffNewSignatures(groups, known);
+
+  for (const group of newGroups) {
+    const content = buildIssueContent(group);
+    console.log(`[prod-error-sweep] NEW signature (${group.count}x, ${group.source}): ${group.signature}`);
+    if (!dryRun) {
+      createIssue(content);
+      known.add(group.signature);
+    }
+  }
+
+  const totalErrorLines = backendLines.length + postgresLines.length;
+
+  if (!dryRun && newGroups.length > 0) {
+    persistSignatures(known);
+  }
+
+  if (newGroups.length === 0) {
+    console.log(
+      `[prod-error-sweep] 0 new signatures (${groups.size} known families seen, ${totalErrorLines} error lines total — ${backendLines.length} backend, ${postgresLines.length} postgres).`
+    );
+  } else if (dryRun) {
+    console.log(`[prod-error-sweep] DRY RUN — would file ${newGroups.length} new issue(s). Ledger not written.`);
+  } else {
+    console.log(`[prod-error-sweep] Filed ${newGroups.length} new issue(s). Ledger updated.`);
+  }
+
+  return {
+    newSignatures: newGroups.map((g) => ({ signature: g.signature, count: g.count })),
+    totalErrorLines,
+  };
+}
+
+function parseArgs(argv) {
+  const dryRun = argv.includes('--dry-run');
+  const backendInputIdx = argv.indexOf('--input-backend');
+  const backendInputFile = backendInputIdx !== -1 ? argv[backendInputIdx + 1] : undefined;
+  const postgresInputIdx = argv.indexOf('--input-postgres');
+  const postgresInputFile = postgresInputIdx !== -1 ? argv[postgresInputIdx + 1] : undefined;
+  // Legacy single --input flag: treat as the backend stream only.
+  const legacyInputIdx = argv.indexOf('--input');
+  const legacyInputFile = legacyInputIdx !== -1 ? argv[legacyInputIdx + 1] : undefined;
+  const tailIdx = argv.indexOf('--tail');
+  const tail = tailIdx !== -1 ? Number(argv[tailIdx + 1]) : 1000;
+  return {
+    dryRun,
+    backendInputFile: backendInputFile || legacyInputFile,
+    postgresInputFile,
+    tail,
+  };
+}
+
+async function main() {
+  const { dryRun, backendInputFile, postgresInputFile, tail } = parseArgs(process.argv.slice(2));
+
+  let backendLog, postgresLog;
+  try {
+    backendLog = fetchLogs({ service: BACKEND_SERVICE, inputFile: backendInputFile, tail });
+    postgresLog = fetchLogs({ service: POSTGRES_SERVICE, inputFile: postgresInputFile, tail });
+  } catch (err) {
+    console.error('[prod-error-sweep] FAILED to fetch logs:', err.message);
+    process.exitCode = 1;
+    return;
+  }
+
+  const known = loadKnownSignatures();
+  runSweep({ backendLog, postgresLog, known, dryRun });
+}
+
+// Only run the CLI side-effects when executed directly, not on import (tests).
+const isCli = import.meta.url === pathToFileURL(process.argv[1] || '').href;
+if (isCli) {
+  main().catch((err) => {
+    console.error('[prod-error-sweep] FAILED:', err.message);
+    process.exitCode = 1;
+  });
+}

--- a/backend/src/__tests__/prodErrorSweep.test.js
+++ b/backend/src/__tests__/prodErrorSweep.test.js
@@ -1,0 +1,313 @@
+// Unit tests for backend/scripts/prod-error-sweep.js — pure parts only
+// (normalization, filtering, grouping, signature diffing). No shell-out,
+// no GitHub calls, no filesystem writes: `runSweep` is exercised with
+// injected `createIssue` / `persistSignatures` fakes.
+
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeSignature,
+  extractBackendErrorLines,
+  extractPostgresConstraintLines,
+  extractErrorLines,
+  groupBySignature,
+  mergeGroups,
+  diffNewSignatures,
+  buildIssueContent,
+  extractTimestamp,
+  runSweep,
+} from '../../scripts/prod-error-sweep.js';
+
+describe('normalizeSignature', () => {
+  it('strips timestamp, PID, and character offset while keeping the error class', () => {
+    const a = normalizeSignature(
+      '2026-07-06 12:00:27.233 UTC [96897] ERROR:  column "sell_price" does not exist at character 91'
+    );
+    const b = normalizeSignature(
+      '2026-07-06 12:05:10.001 UTC [12345] ERROR:  column "sell_price" does not exist at character 42'
+    );
+    expect(a).toBe(b);
+    expect(a).toBe('ERROR: column "sell_price" does not exist');
+  });
+
+  it('keeps quoted object names (column/relation/constraint) distinct', () => {
+    const s1 = normalizeSignature(
+      '2026-07-06 08:40:08.189 UTC [96352] ERROR:  duplicate key value violates unique constraint "stock_demand_variety_date_idx"'
+    );
+    const s2 = normalizeSignature(
+      '2026-07-06 08:40:08.189 UTC [96352] ERROR:  duplicate key value violates unique constraint "other_idx"'
+    );
+    expect(s1).not.toBe(s2);
+    expect(s1).toContain('"stock_demand_variety_date_idx"');
+    expect(s2).toContain('"other_idx"');
+  });
+
+  it('normalizes the not-null constraint families from the brief', () => {
+    const dateErr = normalizeSignature(
+      '2026-07-05 17:59:30.678 UTC [95170] ERROR:  null value in column "date" of relation "stock" violates not-null constraint'
+    );
+    const typeErr = normalizeSignature(
+      '2026-07-05 22:40:18.628 UTC [95596] ERROR:  null value in column "type_name" of relation "stock" violates not-null constraint'
+    );
+    expect(dateErr).toBe('ERROR: null value in column "date" of relation "stock" violates not-null constraint');
+    expect(typeErr).toBe('ERROR: null value in column "type_name" of relation "stock" violates not-null constraint');
+    expect(dateErr).not.toBe(typeErr);
+  });
+
+  it('normalizes the uuid operator family', () => {
+    const s = normalizeSignature(
+      '2026-07-06 09:27:55.537 UTC [96493] ERROR:  operator does not exist: text = uuid at character 167'
+    );
+    expect(s).toBe('ERROR: operator does not exist: text = uuid');
+  });
+
+  it('collapses variable quoted literal values that are not object names', () => {
+    const s1 = normalizeSignature('ERROR:  invalid input syntax for type uuid: "abc-123"');
+    const s2 = normalizeSignature('ERROR:  invalid input syntax for type uuid: "def-456"');
+    expect(s1).toBe(s2);
+  });
+});
+
+describe('extractBackendErrorLines (app-side backend service log)', () => {
+  it('matches bracket-tagged failure/error lines used throughout the codebase', () => {
+    const raw = [
+      'Health check: http://localhost:3001/api/health',
+      '[SSE] Client connected (1 total)',
+      '[FATAL] Uncaught exception: TypeError: cannot read foo',
+      '[STOCK-ORDER] PO creation failed: some detail',
+      '[PULL] Complete: {"new":0,"updated":0,"deactivated":0,"errors":[]}',
+    ].join('\n');
+    const lines = extractBackendErrorLines(raw);
+    expect(lines).toContain('[FATAL] Uncaught exception: TypeError: cannot read foo');
+    expect(lines).toContain('[STOCK-ORDER] PO creation failed: some detail');
+    expect(lines).not.toContain('[SSE] Client connected (1 total)');
+    // "errors":[] must NOT false-trigger the word-boundary "error" match
+    expect(lines.some((l) => l.includes('[PULL] Complete'))).toBe(false);
+  });
+
+  it('matches bare "failed"/"error" messages without a bracket tag', () => {
+    const raw = 'stock usage: loss log fetch failed';
+    expect(extractBackendErrorLines(raw)).toEqual([raw]);
+  });
+
+  it('drops SSL/connection-churn noise even if it slips into the backend stream', () => {
+    const raw = 'LOG:  SSL error: unexpected eof while reading';
+    expect(extractBackendErrorLines(raw)).toEqual([]);
+  });
+
+  it('returns empty array for empty/undefined input', () => {
+    expect(extractBackendErrorLines('')).toEqual([]);
+    expect(extractBackendErrorLines(undefined)).toEqual([]);
+  });
+});
+
+describe('extractPostgresConstraintLines (Postgres service log, constraint-only)', () => {
+  const rawLog = [
+    '2026-07-06 08:40:08.189 UTC [96352] ERROR:  duplicate key value violates unique constraint "stock_demand_variety_date_idx"',
+    '2026-07-05 17:59:30.678 UTC [95170] ERROR:  null value in column "date" of relation "stock" violates not-null constraint',
+    '2026-07-06 09:27:43.032 UTC [96491] ERROR:  column o.customer_name does not exist at character 108',
+    '2026-07-06 09:27:55.537 UTC [96493] ERROR:  operator does not exist: text = uuid at character 167',
+    '2026-06-30 20:29:27.458 UTC [85752] ERROR:  function left(uuid, integer) does not exist at character 8',
+    '2026-06-30 21:35:00.897 UTC [85853] ERROR:  column "name" does not exist at character 8',
+    '2026-07-06 15:00:56.251 UTC [97265] LOG:  SSL error: unexpected eof while reading',
+  ].join('\n');
+
+  it('keeps only genuine constraint-violation errors', () => {
+    const lines = extractPostgresConstraintLines(rawLog);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('violates unique constraint');
+    expect(lines[1]).toContain('violates not-null constraint');
+  });
+
+  it('excludes "does not exist" errors — these are ad-hoc claude_ro exploration queries, not app bugs', () => {
+    const lines = extractPostgresConstraintLines(rawLog);
+    expect(lines.some((l) => l.includes('does not exist'))).toBe(false);
+  });
+
+  it('excludes SSL/connection-churn noise', () => {
+    const lines = extractPostgresConstraintLines(rawLog);
+    expect(lines.some((l) => l.includes('SSL error'))).toBe(false);
+  });
+});
+
+describe('extractErrorLines (generic ERROR-line extraction)', () => {
+  it('matches ERROR lines case-insensitively and drops ignore-listed noise', () => {
+    const raw = [
+      '2026-07-06 14:15:34.353 UTC [97131] ERROR:  column "order_id" does not exist at character 12',
+      '2026-07-06 14:15:34.401 UTC [97131] LOG:  SSL error: unexpected eof while reading',
+      '2026-07-06 14:15:34.401 UTC [97131] LOG:  could not receive data from client: Connection reset by peer',
+      '2026-07-06 12:28:36.406 UTC [31] LOG:  checkpoint starting: time',
+    ].join('\n');
+    const lines = extractErrorLines(raw);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('column "order_id" does not exist');
+  });
+});
+
+describe('groupBySignature + mergeGroups', () => {
+  it('counts duplicate occurrences of the same signature', () => {
+    const lines = [
+      '2026-07-03 08:10:29.982 UTC [90926] ERROR:  duplicate key value violates unique constraint "stock_demand_variety_date_idx"',
+      '2026-07-03 08:10:31.558 UTC [90926] ERROR:  duplicate key value violates unique constraint "stock_demand_variety_date_idx"',
+      '2026-07-03 08:14:25.567 UTC [90934] ERROR:  duplicate key value violates unique constraint "stock_demand_variety_date_idx"',
+    ];
+    const groups = groupBySignature(lines, 'postgres');
+    expect(groups.size).toBe(1);
+    const [group] = groups.values();
+    expect(group.count).toBe(3);
+    expect(group.lines).toHaveLength(3);
+    expect(group.source).toBe('postgres');
+  });
+
+  it('separates distinct signatures into distinct groups', () => {
+    const lines = [
+      'ERROR: column "a" does not exist',
+      'ERROR: column "b" does not exist',
+    ];
+    const groups = groupBySignature(lines);
+    expect(groups.size).toBe(2);
+  });
+
+  it('merges backend + postgres group maps, summing counts for shared signatures', () => {
+    const g1 = groupBySignature(['[FATAL] boom: X'], 'backend');
+    const g2 = groupBySignature(['[FATAL] boom: X', '[FATAL] boom: X'], 'backend');
+    const merged = mergeGroups([g1, g2]);
+    expect(merged.size).toBe(1);
+    const [group] = merged.values();
+    expect(group.count).toBe(3);
+  });
+});
+
+describe('diffNewSignatures', () => {
+  it('returns only signatures not already in the known set', () => {
+    const groups = groupBySignature([
+      'ERROR: duplicate key value violates unique constraint "stock_demand_variety_date_idx"',
+      'ERROR: totally new error signature here',
+    ]);
+    const known = new Set(['ERROR: duplicate key value violates unique constraint "stock_demand_variety_date_idx"']);
+    const diff = diffNewSignatures(groups, known);
+    expect(diff).toHaveLength(1);
+    expect(diff[0].signature).toBe('ERROR: totally new error signature here');
+  });
+
+  it('returns empty array when every signature is already known', () => {
+    const groups = groupBySignature(['ERROR: already known']);
+    const known = new Set(['ERROR: already known']);
+    expect(diffNewSignatures(groups, known)).toEqual([]);
+  });
+});
+
+describe('extractTimestamp', () => {
+  it('extracts a leading Postgres-style timestamp', () => {
+    expect(extractTimestamp('2026-07-06 14:15:34.353 UTC [97131] ERROR:  boom')).toBe('2026-07-06 14:15:34.353');
+  });
+
+  it('returns null when there is no leading timestamp', () => {
+    expect(extractTimestamp('[FATAL] boom')).toBeNull();
+  });
+});
+
+describe('buildIssueContent', () => {
+  it('builds a title prefixed with prod-error: and a body with counts + sample lines', () => {
+    const group = {
+      signature: 'ERROR: something bad',
+      count: 3,
+      source: 'backend',
+      lines: [
+        '2026-07-06 08:00:00.000 UTC [1] ERROR: something bad',
+        '2026-07-06 09:00:00.000 UTC [2] ERROR: something bad',
+        '2026-07-06 10:00:00.000 UTC [3] ERROR: something bad',
+      ],
+    };
+    const { title, body } = buildIssueContent(group);
+    expect(title).toBe('prod-error: ERROR: something bad');
+    expect(body).toContain('**Occurrences in this sweep:** 3');
+    expect(body).toContain('2026-07-06 08:00:00.000');
+    expect(body).toContain('2026-07-06 10:00:00.000');
+    expect(body).toContain('something bad');
+  });
+});
+
+describe('runSweep (pure orchestration with injected IO)', () => {
+  it('reports 0 new signatures when everything is already known, and never calls createIssue/persistSignatures', () => {
+    const known = new Set([
+      'ERROR: duplicate key value violates unique constraint "stock_demand_variety_date_idx"',
+      'ERROR: null value in column "date" of relation "stock" violates not-null constraint',
+      'ERROR: null value in column "type_name" of relation "stock" violates not-null constraint',
+    ]);
+    const postgresLog = [
+      '2026-07-06 08:40:08.189 UTC [96352] ERROR:  duplicate key value violates unique constraint "stock_demand_variety_date_idx"',
+      '2026-07-05 17:59:30.678 UTC [95170] ERROR:  null value in column "date" of relation "stock" violates not-null constraint',
+    ].join('\n');
+    let createIssueCalls = 0;
+    let persistCalls = 0;
+    const result = runSweep({
+      backendLog: '[SSE] Client connected (1 total)',
+      postgresLog,
+      known,
+      dryRun: false,
+      createIssue: () => { createIssueCalls += 1; },
+      persistSignatures: () => { persistCalls += 1; },
+    });
+    expect(result.newSignatures).toEqual([]);
+    expect(createIssueCalls).toBe(0);
+    expect(persistCalls).toBe(0);
+  });
+
+  it('files one issue per new signature and persists the updated ledger (non-dry-run)', () => {
+    const known = new Set();
+    const backendLog = '[FATAL] Uncaught exception: TypeError: boom';
+    let filedTitles = [];
+    let persistedSignatures = null;
+    const result = runSweep({
+      backendLog,
+      postgresLog: '',
+      known,
+      dryRun: false,
+      createIssue: (content) => filedTitles.push(content.title),
+      persistSignatures: (sigs) => { persistedSignatures = Array.from(sigs); },
+    });
+    expect(result.newSignatures).toHaveLength(1);
+    expect(filedTitles).toEqual(['prod-error: [FATAL] Uncaught exception: TypeError: boom']);
+    expect(persistedSignatures).toContain('[FATAL] Uncaught exception: TypeError: boom');
+  });
+
+  it('groups multiple occurrences of the same new signature into a single filed issue', () => {
+    const known = new Set();
+    const backendLog = [
+      '[STOCK-ORDER] PO creation failed: err A',
+      '[STOCK-ORDER] PO creation failed: err B',
+      '[STOCK-ORDER] PO creation failed: err C',
+    ].join('\n');
+    let filedCount = 0;
+    const result = runSweep({
+      backendLog,
+      postgresLog: '',
+      known,
+      dryRun: false,
+      createIssue: () => { filedCount += 1; },
+      persistSignatures: () => {},
+    });
+    // Signature normalization does not strip free-form suffixes like "err A"
+    // vs "err B" (no quotes/offsets to strip), so these are technically
+    // distinct signatures — verifying grouping only collapses TRUE dupes.
+    expect(filedCount).toBe(result.newSignatures.length);
+    expect(result.totalErrorLines).toBe(3);
+  });
+
+  it('dry-run reports what would be filed but calls neither createIssue nor persistSignatures', () => {
+    const known = new Set();
+    let createIssueCalls = 0;
+    let persistCalls = 0;
+    const result = runSweep({
+      backendLog: '[FATAL] Uncaught exception: brand new',
+      postgresLog: '',
+      known,
+      dryRun: true,
+      createIssue: () => { createIssueCalls += 1; },
+      persistSignatures: () => { persistCalls += 1; },
+    });
+    expect(result.newSignatures).toHaveLength(1);
+    expect(createIssueCalls).toBe(0);
+    expect(persistCalls).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `backend/scripts/prod-error-sweep.js` (Category: **SAFE** — read-only; reads Railway logs, files GitHub issues, never touches prod data) as a daily prod-error watchdog.
- Sweeps **two** Railway log streams, deliberately scoped differently:
  - **PRIMARY — `flower-studio-backend` service**: app-side errors. Every error path in this codebase logs via `console.error('[TAG] ... failed/error:', err)` (e.g. `[FATAL] Uncaught exception:`, `[STOCK-ORDER] PO creation failed:`) — a real bug shows up here.
  - **SECONDARY — `Postgres` service, constraint violations ONLY** (`violates unique constraint`, `violates not-null constraint`, `violates foreign key constraint`, `violates check constraint`).
- **Attribution correction made mid-build**: the Postgres service log also captures every ad-hoc read-only query run by Claude sessions against the `claude_ro` role while diagnosing production issues (per CLAUDE.md's "Postgres issues" guidance). Generic errors like `column "x" does not exist`, `operator does not exist: ...`, `function ... does not exist` in that stream are almost always typos in throwaway exploration queries, not app bugs — the app's own SQL is static and already passed CI, so it doesn't hit "column does not exist" in production. These classes are **deliberately excluded** from the Postgres sweep (see header comment in the script for the full reasoning) rather than seeded as "known" — a naive design that swept `column/operator/function does not exist` from Postgres logs would file false-positive issues about our own exploration queries.

## How signatures are normalized
`normalizeSignature(line)` (pure, exported):
- Strips leading timestamp (`2026-07-06 14:15:34.353 UTC `) and PID (`[97131]`)
- Strips `at character N` offsets
- Collapses variable quoted literal values to a placeholder, **except** when the quoted string is a Postgres object name (preceded by `column|relation|constraint|table|function|operator|role|schema|type|index|sequence|database|extension|trigger|view|policy`) — those are kept verbatim so e.g. `column "sell_price"` and `column "order_id"` stay distinct signatures.

Example: `column "sell_price" does not exist at character 91` and `... at character 42` both normalize to `ERROR: column "sell_price" does not exist`.

## Seeded known-signature ledger (`backend/scripts/prod-error-signatures.json`)
Only the constraint-violation families that are genuine app/write-path bugs (already tracked, not re-filed):
- `ERROR: duplicate key value violates unique constraint "stock_demand_variety_date_idx"`
- `ERROR: null value in column "date" of relation "stock" violates not-null constraint`
- `ERROR: null value in column "type_name" of relation "stock" violates not-null constraint`

## Dry-run output (live, against real Railway logs, both services)
```
[prod-error-sweep] 0 new signatures (3 known families seen, 13 error lines total — 0 backend, 13 postgres).
```
0 new signatures — the backend service stream is currently clean (0 app errors in the last 1000 lines), and the Postgres constraint-violation stream matched all 3 seeded families exactly, with the ad-hoc-exploration noise (`column ... does not exist`, `operator does not exist`, `function ... does not exist`) correctly excluded by design rather than accidentally suppressed.

Also verified file-driven mode (`--input-backend` / `--input-postgres`) end-to-end against captured samples of both streams — same "0 new signatures" result — confirming the CLI plumbing (not just the pure functions) behaves correctly without shelling out.

## Verification
- `cd backend && npx vitest run src/__tests__/prodErrorSweep.test.js` → **25 passed**
- `node backend/scripts/prod-error-sweep.js --dry-run` (live, railway CLI authenticated) → **0 new signatures** (see above)
- `cd backend && npx vitest run --no-file-parallelism` (full suite) → **106 test files passed, 978 tests passed, 1 todo**

## Design notes
- Pure logic (`normalizeSignature`, `extractBackendErrorLines`, `extractPostgresConstraintLines`, `groupBySignature`, `mergeGroups`, `diffNewSignatures`, `buildIssueContent`, `runSweep`, etc.) is exported; the CLI only runs under `if (isCli) main()` — mirrors `backend/scripts/migrate-stock-y-model.js`'s `runMigration` export pattern so tests never shell out to `railway`/`gh`.
- `runSweep` takes injected `createIssue`/`persistSignatures` functions so the orchestration logic is tested without any real GitHub or filesystem side effects.
- Re-runs are idempotent: a filed signature is appended to `prod-error-signatures.json` in the same pass, so it's never re-filed.
- `--dry-run` never writes the ledger and never calls `gh issue create`.

Not merging — leaving for review per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)