### PR TITLE
fix(orders): Completed-tab date filter uses fulfilment date (#390) + filters survive navigation (#338)

### DIFF
--- a/apps/dashboard/src/components/OrdersTab.jsx
+++ b/apps/dashboard/src/components/OrdersTab.jsx
@@ -114,11 +114,45 @@ function monthStart() {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`;
 }
 
+// Session-scoped persistence for the filter/sort state (#338): the owner
+// filters Orders, navigates to a customer, comes back — the filter must
+// still be applied. sessionStorage (not localStorage) so a stale filter from
+// days ago doesn't silently reappear in a fresh browser session; it clears
+// naturally when the tab/window closes, same lifetime as the rest of the
+// owner's working session.
+const ORDERS_TAB_SESSION_KEY = 'dashboard_orders_tab_state';
+
+function loadPersistedState() {
+  try {
+    const raw = sessionStorage.getItem(ORDERS_TAB_SESSION_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function savePersistedState(state) {
+  try {
+    sessionStorage.setItem(ORDERS_TAB_SESSION_KEY, JSON.stringify(state));
+  } catch { /* sessionStorage unavailable (private mode, quota) — filters just won't persist */ }
+}
+
 export default function OrdersTab({ initialFilter, onNavigate, isActive = true }) {
   const STATUS_OPTIONS = getStatusOptions();
   // Seed filter from cross-tab initialFilter to avoid a double-fetch race —
   // state is set before the first render so the first fetch uses the right params.
   const f = initialFilter || {};
+  // An explicit incoming filter (Today-tab widget click, Ask Blossom deep
+  // link, etc.) always WINS over whatever was persisted from a previous
+  // session visit (#338) — otherwise a deep link into a specific status/date
+  // could get silently overridden by leftover state from an earlier look
+  // at the Orders tab.
+  const hasIncomingFilter = !!(
+    f.status || f.source || f.deliveryType || f.payment || f.paymentMethod || f.excludeCancelled ||
+    f.dateFrom || f.dateTo || f.orderDateFrom || f.orderDateTo || f.orderId ||
+    f.orderIdQuery || f.customerQuery || f.bouquetQuery || f.priceMin != null || f.priceMax != null
+  );
+  const persisted = hasIncomingFilter ? null : loadPersistedState();
   const [orders, setOrders]       = useState([]);
   const [loading, setLoading]     = useState(true);
   const [fetchError, setFetchError] = useState(false);
@@ -129,27 +163,30 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
   // placed in June" with only orderDateFrom set) would get silently re-narrowed
   // to the current month on the fulfilment-date dimension it never asked about.
   const hasIncomingDateFilter = !!(f.dateFrom || f.dateTo || f.orderDateFrom || f.orderDateTo);
-  const [filter, setFilter] = useState(() => ({
-    ...EMPTY_ORDER_FILTER,
-    status: f.status || '',
-    source: f.source || '',
-    deliveryType: f.deliveryType || '',
-    paymentStatus: f.payment || '',            // legacy cross-tab key was `payment`
-    paymentMethod: f.paymentMethod || '',
-    excludeCancelled: !!f.excludeCancelled,
-    requiredByFrom: f.dateFrom || (hasIncomingDateFilter ? '' : monthStart()), // fulfilment date
-    requiredByTo: f.dateTo || (hasIncomingDateFilter ? '' : todayStr()),
-    orderDateFrom: f.orderDateFrom || '',      // order/submission date — distinct dimension
-    orderDateTo: f.orderDateTo || '',
-    // Client-only contains/range filters (Ask Blossom deep links, #review CR) —
-    // applied in memory below via orderMatchesClientFilter, never as the UUID
-    // `orderId` focus key (see focusOrderId/expandedId below).
-    orderIdQuery: f.orderIdQuery || '',
-    customerQuery: f.customerQuery || '',
-    bouquetQuery: f.bouquetQuery || '',
-    priceMin: f.priceMin ?? null,
-    priceMax: f.priceMax ?? null,
-  }));
+  const [filter, setFilter] = useState(() => {
+    if (persisted?.filter) return persisted.filter;
+    return {
+      ...EMPTY_ORDER_FILTER,
+      status: f.status || '',
+      source: f.source || '',
+      deliveryType: f.deliveryType || '',
+      paymentStatus: f.payment || '',            // legacy cross-tab key was `payment`
+      paymentMethod: f.paymentMethod || '',
+      excludeCancelled: !!f.excludeCancelled,
+      requiredByFrom: f.dateFrom || (hasIncomingDateFilter ? '' : monthStart()), // fulfilment date
+      requiredByTo: f.dateTo || (hasIncomingDateFilter ? '' : todayStr()),
+      orderDateFrom: f.orderDateFrom || '',      // order/submission date — distinct dimension
+      orderDateTo: f.orderDateTo || '',
+      // Client-only contains/range filters (Ask Blossom deep links, #review CR) —
+      // applied in memory below via orderMatchesClientFilter, never as the UUID
+      // `orderId` focus key (see focusOrderId/expandedId below).
+      orderIdQuery: f.orderIdQuery || '',
+      customerQuery: f.customerQuery || '',
+      bouquetQuery: f.bouquetQuery || '',
+      priceMin: f.priceMin ?? null,
+      priceMax: f.priceMax ?? null,
+    };
+  });
   const setFilterField = useCallback((key, value) => setFilter(prev => ({ ...prev, [key]: value })), []);
   // Editing a date-column filter switches off upcoming mode so the new date
   // range actually takes effect (upcoming owns the date scope; they're mutually exclusive).
@@ -163,10 +200,13 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
   // in the date range. A dismissable banner lets them return to the full list.
   const [focusOrderId, setFocusOrderId] = useState(f.orderId || null);
   const [selected, setSelected]   = useState(new Set());
-  const [upcomingMode, setUpcoming] = useState(!hasIncomingDateFilter && !f.orderId);
+  const [upcomingMode, setUpcoming] = useState(() => {
+    if (persisted?.filter) return persisted.upcomingMode ?? false;
+    return !hasIncomingDateFilter && !f.orderId;
+  });
   const [showPremade, setShowPremade] = useState(false);
-  const [sortBy, setSortBy]       = useState('deliveryDate');
-  const [sortDir, setSortDir]     = useState('asc'); // 'asc' | 'desc' — bidirectional sort
+  const [sortBy, setSortBy]       = useState(() => (hasIncomingFilter ? 'deliveryDate' : (persisted?.sortBy || 'deliveryDate')));
+  const [sortDir, setSortDir]     = useState(() => (hasIncomingFilter ? 'asc' : (persisted?.sortDir || 'asc'))); // 'asc' | 'desc' — bidirectional sort
   const [noDateOnly, setNoDateOnly] = useState(false); // surface orphan-date orders
   const { showToast }             = useToast();
 
@@ -233,6 +273,17 @@ export default function OrdersTab({ initialFilter, onNavigate, isActive = true }
     document.addEventListener('visibilitychange', onVisible);
     return () => { clearInterval(interval); document.removeEventListener('visibilitychange', onVisible); };
   }, [fetchOrders, fetchKey, isActive]);
+
+  // Persist filter + sort to sessionStorage on every change (#338) — so the
+  // state the owner set up survives both a collateral remount (a different
+  // tab's cross-tab navigation — see filterKeys in DashboardPage.jsx) and a
+  // genuine remount (navigating away and later back to Orders with no
+  // explicit incoming filter). Session-scoped, not localStorage — clears
+  // naturally at the end of the working session rather than persisting
+  // indefinitely across days.
+  useEffect(() => {
+    savePersistedState({ filter, sortBy, sortDir, upcomingMode });
+  }, [filter, sortBy, sortDir, upcomingMode]);
 
   // Derive distinct payment-method and source values from the loaded orders for
   // use in the Status column's bundled popover. No memoization needed — only

--- a/apps/dashboard/src/pages/DashboardPage.jsx
+++ b/apps/dashboard/src/pages/DashboardPage.jsx
@@ -63,11 +63,21 @@ export default function DashboardPage() {
   // Track whether the financial tab has ever been opened, so we only mount
   // the lazy-loaded Recharts bundle on first visit (not on initial page load).
   const [financialMounted, setFinancialMounted] = useState(activeTab === 'financial');
-  // filterKey increments on every cross-tab navigation, forcing the target tab
-  // to fully remount with a clean state. Without this, React may reuse the
-  // previous component instance and old filter state "leaks" across navigations.
-  // Think of it like resetting a workstation between different job orders.
-  const [filterKey, setFilterKey] = useState(0);
+  // Per-tab remount keys — one counter PER keyed tab, not a single shared one.
+  // A cross-tab navigateTo() bumps ONLY the destination tab's key, forcing
+  // just that tab to remount and pick up its fresh initialFilter. Other
+  // keyed tabs keep their key unchanged so they are NOT remounted and their
+  // local state (filters, sort, selection) survives.
+  //
+  // History (#338): all four keyed tabs (orders/stock/customers/explorer)
+  // used to share one `filterKey` counter, so navigating to e.g. Customers
+  // from an order's detail panel bumped the SAME key read by OrdersTab —
+  // remounting Orders too and silently wiping its filter/sort state even
+  // though the owner never touched that tab. Splitting the counter per tab
+  // fixes that collateral remount; OrdersTab additionally persists its
+  // filter/sort to sessionStorage so it also survives a genuine remount
+  // (e.g. the Orders tab itself is later navigated to fresh).
+  const [filterKeys, setFilterKeys] = useState({ orders: 0, stock: 0, customers: 0, explorer: 0 });
   const [showHelp, setShowHelp] = useState(false);
   const [reportOpen, setReportOpen] = useState(false);
   // New-order speed-dial FAB (bottom-right) — mirrors the florist app's FAB.
@@ -88,14 +98,15 @@ export default function DashboardPage() {
   const navigateTo = useCallback(({ tab, filter }) => {
     setActiveTab(tab);
     setTabFilter(filter || null);
-    setFilterKey(k => k + 1);
+    // Only bump the destination tab's own key — see filterKeys comment above.
+    setFilterKeys(prev => (tab in prev ? { ...prev, [tab]: prev[tab] + 1 } : prev));
     if (tab === 'financial') setFinancialMounted(true);
     try { localStorage.setItem('dashboard_tab', tab); } catch {}
   }, []);
 
   // When user clicks a tab pill manually, clear any navigation filter.
-  // Don't increment filterKey here — CSS hiding keeps tabs alive, so we only
-  // force remount on cross-tab navigation (navigateTo) with a new filter.
+  // Don't bump any filterKeys entry here — CSS hiding keeps tabs alive, so we
+  // only force a remount on cross-tab navigation (navigateTo) with a new filter.
   function handleTabClick(key) {
     setActiveTab(key);
     setTabFilter(null);
@@ -174,11 +185,11 @@ export default function DashboardPage() {
           <DayToDayTab isActive={activeTab === 'today'} onNavigate={navigateTo} />
         )}
         {renderMountedTab('orders',
-          <OrdersTab key={filterKey} isActive={activeTab === 'orders'} initialFilter={tabFilter} onNavigate={navigateTo} />
+          <OrdersTab key={filterKeys.orders} isActive={activeTab === 'orders'} initialFilter={tabFilter} onNavigate={navigateTo} />
         )}
         {renderMountedTab('newOrder',
           <>
-            {/* No key={filterKey}: the wizard must NOT remount when an unrelated
+            {/* No remount key: the wizard must NOT remount when an unrelated
                 tab triggers a cross-tab navigation, otherwise an in-progress
                 order is wiped. The matchPremadeId effect inside NewOrderTab
                 handles Match-Premade re-entries without a remount. */}
@@ -189,16 +200,16 @@ export default function DashboardPage() {
           </>
         )}
         {renderMountedTab('stock',
-          <StockTab key={filterKey} isActive={activeTab === 'stock'} initialFilter={tabFilter} onNavigate={navigateTo} />
+          <StockTab key={filterKeys.stock} isActive={activeTab === 'stock'} initialFilter={tabFilter} onNavigate={navigateTo} />
         )}
         {renderMountedTab('customers',
-          <CustomersTab key={filterKey} initialFilter={tabFilter} onNavigate={navigateTo} />
+          <CustomersTab key={filterKeys.customers} initialFilter={tabFilter} onNavigate={navigateTo} />
         )}
         {renderMountedTab('products',
           <ProductsTab />
         )}
         {renderMountedTab('explorer',
-          <ExplorerTab key={filterKey} isActive={activeTab === 'explorer'} initialFilter={tabFilter} onNavigate={navigateTo} />
+          <ExplorerTab key={filterKeys.explorer} isActive={activeTab === 'explorer'} initialFilter={tabFilter} onNavigate={navigateTo} />
         )}
         {renderMountedTab('issues',
           <IssuesTab />

--- a/apps/florist/src/pages/OrderListPage.jsx
+++ b/apps/florist/src/pages/OrderListPage.jsx
@@ -81,6 +81,30 @@ function todayISO() {
   return new Date().toISOString().split('T')[0];
 }
 
+// Session-scoped persistence for filter/view state (#338 parity — dashboard
+// OrdersTab persists the same way). /orders is a normal React Router route,
+// so navigating to an order's customer (or anywhere else) fully unmounts
+// this page; without this, the filter/view the florist just set up resets
+// to defaults the moment they come back. sessionStorage (not localStorage)
+// so it clears at the end of the working session rather than sticking
+// around across days.
+const ORDER_LIST_SESSION_KEY = 'florist_order_list_state';
+
+function loadPersistedListState() {
+  try {
+    const raw = sessionStorage.getItem(ORDER_LIST_SESSION_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function savePersistedListState(state) {
+  try {
+    sessionStorage.setItem(ORDER_LIST_SESSION_KEY, JSON.stringify(state));
+  } catch { /* sessionStorage unavailable (private mode, quota) — filters just won't persist */ }
+}
+
 export default function OrderListPage() {
   const navigate         = useNavigate();
   const location         = useLocation();
@@ -96,14 +120,28 @@ export default function OrderListPage() {
   // forced activeOnly=true would silently return zero rows for e.g. Cancelled.
   const seedsCompletedView = COMPLETED_STATUSES.includes(seededStatus) && seededStatus !== '';
 
+  // An explicit incoming filter (deep link) always WINS over persisted state
+  // from a previous visit this session (#338) — see ORDER_LIST_SESSION_KEY comment.
+  const hasIncomingFilter = !!(
+    navState.status || navState.source || navState.deliveryType || navState.payment ||
+    navState.paymentMethod || navState.excludeCancelled || navState.dateFrom || navState.dateTo ||
+    navState.orderDateFrom || navState.orderDateTo || navState.orderId ||
+    navState.orderIdQuery || navState.customerQuery || navState.bouquetQuery ||
+    navState.priceMin != null || navState.priceMax != null
+  );
+  const persistedList = hasIncomingFilter ? null : loadPersistedListState();
+
   const [orders, setOrders]         = useState([]);
   const [premadeBouquets, setPremadeBouquets] = useState([]);
   const [loading, setLoading]       = useState(true);
   const [ordersReady, setOrdersReady] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
-  const [viewMode, setViewMode]     = useState(() => (seedsCompletedView ? VIEW_MODES.COMPLETED : VIEW_MODES.ACTIVE));
-  const [date, setDate]             = useState(''); // only used in completed view
-  const [status, setStatus]         = useState(() => seededStatus);
+  const [viewMode, setViewMode]     = useState(() => {
+    if (persistedList?.viewMode) return persistedList.viewMode;
+    return seedsCompletedView ? VIEW_MODES.COMPLETED : VIEW_MODES.ACTIVE;
+  });
+  const [date, setDate]             = useState(() => persistedList?.date || ''); // only used in completed view
+  const [status, setStatus]         = useState(() => (hasIncomingFilter ? seededStatus : (persistedList?.status ?? seededStatus)));
   const [noDateOnly, setNoDateOnly] = useState(false); // surface orphan-date orders
   const [fabOpen, setFabOpen]       = useState(false);
   const [showImport, setShowImport] = useState(false);
@@ -114,26 +152,29 @@ export default function OrderListPage() {
 
   // Shared order filter model (mirrors dashboard per-column filters).
   // status is kept in sync with the status tab so active count stays consistent.
-  const [filter, setFilter] = useState(() => ({
-    ...EMPTY_ORDER_FILTER,
-    status: seededStatus,
-    source: navState.source || '',
-    deliveryType: navState.deliveryType || '',
-    paymentStatus: navState.payment || '',        // legacy cross-tab key
-    paymentMethod: navState.paymentMethod || '',
-    excludeCancelled: !!navState.excludeCancelled,
-    requiredByFrom: navState.dateFrom || '',       // legacy cross-tab key — fulfilment date
-    requiredByTo: navState.dateTo || '',           // legacy cross-tab key
-    orderDateFrom: navState.orderDateFrom || '',   // order/submission date — distinct dimension
-    orderDateTo: navState.orderDateTo || '',
-    // Client-only contains/range filters (Ask Blossom deep links) — applied in
-    // memory via orderMatchesClientFilter below, never as the UUID focus key.
-    orderIdQuery: navState.orderIdQuery || '',
-    customerQuery: navState.customerQuery || '',
-    bouquetQuery: navState.bouquetQuery || '',
-    priceMin: navState.priceMin ?? null,
-    priceMax: navState.priceMax ?? null,
-  }));
+  const [filter, setFilter] = useState(() => {
+    if (persistedList?.filter) return persistedList.filter;
+    return {
+      ...EMPTY_ORDER_FILTER,
+      status: seededStatus,
+      source: navState.source || '',
+      deliveryType: navState.deliveryType || '',
+      paymentStatus: navState.payment || '',        // legacy cross-tab key
+      paymentMethod: navState.paymentMethod || '',
+      excludeCancelled: !!navState.excludeCancelled,
+      requiredByFrom: navState.dateFrom || '',       // legacy cross-tab key — fulfilment date
+      requiredByTo: navState.dateTo || '',           // legacy cross-tab key
+      orderDateFrom: navState.orderDateFrom || '',   // order/submission date — distinct dimension
+      orderDateTo: navState.orderDateTo || '',
+      // Client-only contains/range filters (Ask Blossom deep links) — applied in
+      // memory via orderMatchesClientFilter below, never as the UUID focus key.
+      orderIdQuery: navState.orderIdQuery || '',
+      customerQuery: navState.customerQuery || '',
+      bouquetQuery: navState.bouquetQuery || '',
+      priceMin: navState.priceMin ?? null,
+      priceMax: navState.priceMax ?? null,
+    };
+  });
   const [filterOpen, setFilterOpen] = useState(false);
 
   // Stock shortfall data: { stockId: { committed, name, currentQty, effective, orders } }
@@ -281,6 +322,13 @@ export default function OrderListPage() {
     return () => { clearInterval(interval); document.removeEventListener('visibilitychange', onVisible); };
   }, [fetchOrders]);
 
+  // Persist filter + view state to sessionStorage on every change (#338) —
+  // this is a normal React Router route, so navigating away (e.g. tapping a
+  // customer from an order card) fully unmounts this page; without this the
+  // florist's filter/view resets to defaults the moment they come back.
+  useEffect(() => {
+    savePersistedListState({ filter, viewMode, status, date });
+  }, [filter, viewMode, status, date]);
 
   // Owner: fetch dashboard data for today's summary + stock alerts
   useEffect(() => {

--- a/backend/src/__tests__/orderRepo.integration.test.js
+++ b/backend/src/__tests__/orderRepo.integration.test.js
@@ -720,6 +720,40 @@ describe('list + getById', () => {
   it('getById throws 404 when order missing', async () => {
     await expect(orderRepo.getById('rec-does-not-exist')).rejects.toMatchObject({ statusCode: 404 });
   });
+
+  // Regression for #390: the Completed tab's single-date filter must match
+  // orders by FULFILMENT date (Required By), not by when they were placed
+  // (Order Date) — an order placed on the selected day but delivered on a
+  // different day must NOT appear.
+  it('pg.completedForDate matches Required By only, not Order Date', async () => {
+    // Placed on the 1st, delivered on the 5th — must show up under forDate=5th,
+    // NOT under forDate=1st.
+    const [placedOn1st] = await harness.db.insert(orders).values({
+      appOrderId: 'BLO-390-A', customerId: 'cust-390', orderDate: '2026-06-01',
+      requiredBy: '2026-06-05', deliveryType: 'Delivery', status: ORDER_STATUS.DELIVERED,
+      paymentStatus: 'Paid',
+    }).returning();
+    // Placed AND delivered on the 1st — should show up under forDate=1st.
+    const [placedAndDeliveredOn1st] = await harness.db.insert(orders).values({
+      appOrderId: 'BLO-390-B', customerId: 'cust-390', orderDate: '2026-06-01',
+      requiredBy: '2026-06-01', deliveryType: 'Pickup', status: ORDER_STATUS.PICKED_UP,
+      paymentStatus: 'Paid',
+    }).returning();
+
+    const forJune1 = await orderRepo.list({
+      pg: { statuses: [ORDER_STATUS.DELIVERED, ORDER_STATUS.PICKED_UP], completedForDate: '2026-06-01' },
+    });
+    const ids = forJune1.map(o => o.id);
+    expect(ids).toContain(placedAndDeliveredOn1st.id);
+    expect(ids).not.toContain(placedOn1st.id);
+
+    const forJune5 = await orderRepo.list({
+      pg: { statuses: [ORDER_STATUS.DELIVERED, ORDER_STATUS.PICKED_UP], completedForDate: '2026-06-05' },
+    });
+    const ids5 = forJune5.map(o => o.id);
+    expect(ids5).toContain(placedOn1st.id);
+    expect(ids5).not.toContain(placedAndDeliveredOn1st.id);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────

--- a/backend/src/repos/orderRepo.js
+++ b/backend/src/repos/orderRepo.js
@@ -267,6 +267,12 @@ async function listFromPg(options = {}) {
   if (pg.sourceOther)       filters.push(or(eq(orders.source, 'Other'), isNull(orders.source)));
   else if (pg.source)       filters.push(eq(orders.source, pg.source));
   if (pg.forDate)           filters.push(or(eq(orders.orderDate, pg.forDate), eq(orders.requiredBy, pg.forDate)));
+  // Completed-tab date filter — fulfilment date ONLY (Required By), never
+  // OR'd with Order Date. Matches the order-card display convention
+  // (Delivery Date || Required By) and fixes #390: a completed order that
+  // was merely *placed* on the selected date but delivered/picked-up on a
+  // different one must not appear.
+  if (pg.completedForDate) filters.push(eq(orders.requiredBy, pg.completedForDate));
   if (pg.orderDateFrom)     filters.push(gte(orders.orderDate, pg.orderDateFrom));
   if (pg.completedSinceFallback) {
     // "Completed in last N days" — prefer Required By; fall back to Order Date

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -31,6 +31,9 @@ const ORDERS_PATCH_ALLOWED = [
 
 // GET /api/orders?status=New&dateFrom=2025-01-01&dateTo=2025-01-31&source=Instagram&forDate=2025-01-15
 // forDate: unified date filter — returns orders placed on OR due on that date (OR logic).
+//          EXCEPTION: combined with completedOnly, forDate matches Required By
+//          ONLY (fulfilment date) — the Completed tab means "delivered/picked
+//          up on this day", not "placed or due" (#390).
 // dateFrom/dateTo: legacy Order Date range filter (AND logic).
 // activeOnly: returns all non-terminal orders (excludes Delivered, Picked Up, Cancelled), sorted by Required By asc.
 router.get('/', async (req, res, next) => {
@@ -57,9 +60,15 @@ router.get('/', async (req, res, next) => {
       // Terminal orders only. If no date filter, show last 30 days.
       filters.push(`OR({Status} = '${ORDER_STATUS.DELIVERED}', {Status} = '${ORDER_STATUS.PICKED_UP}', {Status} = '${ORDER_STATUS.CANCELLED}')`);
       if (forDate) {
-        // Apply date filter inside completedOnly mode (was previously ignored — bug fix)
+        // Completed view shows terminal orders by FULFILMENT date (Required
+        // By — the same field the order cards display as "Delivery Date"),
+        // never by Order Date. Unlike the general `forDate` OR-search below
+        // (deliberately "placed OR due" for the default/active list), a
+        // Completed-tab date filter means "delivered/picked-up on this day" —
+        // matching an unrelated Order Date here surfaced orders that were
+        // merely *placed* that day but fulfilled on a different one (#390).
         const d = sanitizeFormulaValue(forDate);
-        filters.push(`OR(DATESTR({Order Date}) = '${d}', DATESTR({Required By}) = '${d}')`);
+        filters.push(`DATESTR({Required By}) = '${d}'`);
       } else if (!dateFrom) {
         // Legacy orders (imported or created before the requiredBy validation)
         // may have a blank Required By. Fall back to Order Date for the cutoff
@@ -124,7 +133,10 @@ router.get('/', async (req, res, next) => {
     } else if (completedOnly) {
       pgFilter.statuses = [ORDER_STATUS.DELIVERED, ORDER_STATUS.PICKED_UP, ORDER_STATUS.CANCELLED];
       if (forDate) {
-        pgFilter.forDate = forDate;
+        // Fulfilment-date-only match (Required By) — see the Airtable-formula
+        // comment above for why this must NOT reuse the general `forDate`
+        // OR-with-Order-Date key (#390).
+        pgFilter.completedForDate = forDate;
       } else if (!dateFrom) {
         pgFilter.completedSinceFallback = new Date(Date.now() - 30 * 86400000).toISOString().split('T')[0];
       }


### PR DESCRIPTION
Plan W7 (docs/superpowers/plans/2026-07-06-fable-improvement-plan.md). Implementation by a Sonnet subagent; diff reviewed and verification re-run by the orchestrator after the agent was cut off pre-commit.

## #390 (priority:high) — root cause
The Completed tab passed the generic `forDate` param, which the backend deliberately treats as "placed OR due on this date" (`orderRepo.listFromPg`: `orderDate = d OR requiredBy = d`). Correct for the active list, wrong for Completed — an order *placed* on the selected day but fulfilled another day appeared in the list. Fix: new `pg.completedForDate` key matching `Required By` only, mapped in `routes/orders.js` under `completedOnly`. Regression test in `orderRepo.integration.test.js` (placed-1st/delivered-5th appears under the 5th, not the 1st).

## #338 — two root causes
1. `DashboardPage.jsx`: all four keyed tabs shared one `filterKey` remount counter — navigating to Customers remounted Orders too, wiping its state. Split into per-tab keys.
2. Genuine remounts still lose state, so `OrdersTab` (dashboard) + `OrderListPage` (florist — full route unmount) persist filter/view/sort to sessionStorage. Explicit deep-link filters (Today widgets, Ask Blossom `open_orders_view`) always take precedence over persisted state.

## #444 verification (third task in this batch)
Already verified + closed during the sweep: shipped by PR #466 via `orderStatusOptions.js`, consumed at florist `OrderCard.jsx:887` / `OrderDetailPage.jsx:721` and dashboard `OrderDetailPanel.jsx:306`.

## Verification
- Backend: `npx vitest run --no-file-parallelism` → 954 passed, 1 pre-existing todo (includes the new #390 regression test)
- E2E harness suite: 253/253
- `vite build` green for florist + dashboard (packages/shared untouched)

Closes #390
Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)