### PR TITLE
chore(stock): strip useStockYModelFlag from florist app — #291 PR2a

### DIFF
--- a/apps/florist/src/components/BouquetEditor.jsx
+++ b/apps/florist/src/components/BouquetEditor.jsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react';
 import {
-  renderStockName, parseBatchName, findAllMatchingVariety,
-  BatchPickerModal, VarietyAllocationPicker, TierSwitchChip, useStockYModelFlag, useAuth,
+  renderStockName, parseBatchName,
+  VarietyAllocationPicker, TierSwitchChip, useAuth,
   groupByVariety, varietyDisplayName, resolveStockLinePrice, resolveVarietySell,
   allocateLinesAgainstVariety, NewVarietyFields,
 } from '@flower-studio/shared';
@@ -9,15 +9,12 @@ import t from '../translations.js';
 import useConfigLists from '../hooks/useConfigLists.js';
 
 export default function BouquetEditor({ editing, saving, detail, isTerminal, isOwner, originalPrice, onSaveClick, doSave }) {
-  const yEnabled = useStockYModelFlag();
   const { role } = useAuth();
   const { targetMarkup } = useConfigLists();
 
   const [showOutOfStock, setShowOutOfStock] = useState(false);
   const [flowerSearch, setFlowerSearch] = useState('');
-  const [pickerModalVariety, setPickerModalVariety] = useState(null);
-  const [pickerModalMatches, setPickerModalMatches] = useState([]);
-  // Y-model picker state: show VarietyAllocationPicker when yEnabled
+  // Y-model picker state: show VarietyAllocationPicker
   const [yPickerOpen, setYPickerOpen] = useState(false);
   const [yPickerQty, setYPickerQty] = useState(1);
   const [yPickerStockItems, setYPickerStockItems] = useState([]);
@@ -52,54 +49,34 @@ export default function BouquetEditor({ editing, saving, detail, isTerminal, isO
     return { key: l.stockItemId ?? l.flowerName, net: Number(si?.['Current Quantity']) || 0 };
   }), [editing.editLines, editing.stockItems]);
 
-  // Group catalog: Y-model = one row per Variety 4-tuple; legacy = one row per base name
+  // Group catalog: one row per Variety 4-tuple
   const catalogVarieties = useMemo(() => {
     const q = flowerSearch.toLowerCase().trim();
-    if (yEnabled) {
-      const adapted = catalogItems.map(s => ({
-        ...s,
-        type_name: s.Type ?? null,
-        colour:    s.Colour ?? null,
-        size_cm:   s.Size ?? null,
-        cultivar:  s.Cultivar ?? null,
-        current_quantity: Number(s['Current Quantity']) || 0,
-      }));
-      const groups = [...groupByVariety(adapted).values()].map(g => ({
-        key:         g.key,
-        displayName: varietyDisplayName(g),
-        type_name:   g.type_name,
-        colour:      g.colour,
-        size_cm:     g.size_cm,
-        cultivar:    g.cultivar,
-        rows:        g.rows,
-        totalQty:    g.rows.reduce((s, r) => s + (Number(r['Current Quantity']) || 0), 0),
-        // Pending-PO Variety shows its PO sell, not the stale card sell (#377).
-        sell:        resolveVarietySell(g.rows, editing.pendingPO),
-        poQty:       g.rows.reduce((s, r) => s + (editing.pendingPO?.[r.id]?.ordered || 0), 0),
-        inCart:      g.rows.some(r => editing.editLines.some(l => l.stockItemId === r.id)),
-      }));
-      if (!q) return groups;
-      return groups.filter(g => g.displayName.toLowerCase().includes(q));
-    }
-    // Legacy: group by parseBatchName base name
-    const map = new Map();
-    for (const s of catalogItems) {
-      const { name: base } = parseBatchName(s['Display Name'] || '');
-      const key = base.toLowerCase();
-      if (!q || key.includes(q) || (s['Category'] || '').toLowerCase().includes(q)) {
-        if (!map.has(key)) {
-          map.set(key, { key, displayName: base, totalQty: 0, sell: Number(s['Current Sell Price']) || 0, poQty: 0, inCart: false, rows: [] });
-        }
-        const entry = map.get(key);
-        entry.totalQty += Number(s['Current Quantity']) || 0;
-        entry.poQty += editing.pendingPO?.[s.id]?.ordered || 0;
-        if (editing.editLines.find(l => l.stockItemId === s.id)) entry.inCart = true;
-        entry.rows.push(s);
-      }
-    }
-    // Pending-PO Variety shows its PO sell, not the stale card sell (#377).
-    return [...map.values()].map(e => ({ ...e, sell: resolveVarietySell(e.rows, editing.pendingPO) }));
-  }, [catalogItems, flowerSearch, yEnabled, editing.pendingPO, editing.editLines]);
+    const adapted = catalogItems.map(s => ({
+      ...s,
+      type_name: s.Type ?? null,
+      colour:    s.Colour ?? null,
+      size_cm:   s.Size ?? null,
+      cultivar:  s.Cultivar ?? null,
+      current_quantity: Number(s['Current Quantity']) || 0,
+    }));
+    const groups = [...groupByVariety(adapted).values()].map(g => ({
+      key:         g.key,
+      displayName: varietyDisplayName(g),
+      type_name:   g.type_name,
+      colour:      g.colour,
+      size_cm:     g.size_cm,
+      cultivar:    g.cultivar,
+      rows:        g.rows,
+      totalQty:    g.rows.reduce((s, r) => s + (Number(r['Current Quantity']) || 0), 0),
+      // Pending-PO Variety shows its PO sell, not the stale card sell (#377).
+      sell:        resolveVarietySell(g.rows, editing.pendingPO),
+      poQty:       g.rows.reduce((s, r) => s + (editing.pendingPO?.[r.id]?.ordered || 0), 0),
+      inCart:      g.rows.some(r => editing.editLines.some(l => l.stockItemId === r.id)),
+    }));
+    if (!q) return groups;
+    return groups.filter(g => g.displayName.toLowerCase().includes(q));
+  }, [catalogItems, flowerSearch, editing.pendingPO, editing.editLines]);
 
   function addFromCatalog(s) {
     const existing = editing.editLines.findIndex(l => l.stockItemId === s.id);
@@ -214,15 +191,9 @@ export default function BouquetEditor({ editing, saving, detail, isTerminal, isO
                       key={key}
                       type="button"
                       onClick={() => {
-                        if (yEnabled) {
-                          setYPickerStockItems(v.rows);
-                          setYPickerOpen(true);
-                          setYPickerQty(1);
-                        } else {
-                          const allMatches = findAllMatchingVariety(editing.stockItems, displayName);
-                          setPickerModalVariety(displayName);
-                          setPickerModalMatches(allMatches);
-                        }
+                        setYPickerStockItems(v.rows);
+                        setYPickerOpen(true);
+                        setYPickerQty(1);
                       }}
                       className={`w-full flex items-center px-3 py-2.5 gap-2 text-left transition-colors active-scale
                                   ${out ? 'bg-amber-50/60' : inCart ? 'bg-brand-50/70' : 'active:bg-gray-50'}`}
@@ -255,15 +226,13 @@ export default function BouquetEditor({ editing, saving, detail, isTerminal, isO
           {editing.newFlowerForm && (
             <div className="bg-indigo-50 rounded-xl px-3 py-3 space-y-2">
               <p className="text-sm font-semibold text-indigo-800">{t.addNewFlower}: {editing.newFlowerForm.name}</p>
-              {yEnabled && (
-                <NewVarietyFields
-                  form={editing.newFlowerForm}
-                  onChange={editing.setNewFlowerForm}
-                  t={t}
-                  stockItems={editing.stockItems}
-                  idPrefix="nv-florist"
-                />
-              )}
+              <NewVarietyFields
+                form={editing.newFlowerForm}
+                onChange={editing.setNewFlowerForm}
+                t={t}
+                stockItems={editing.stockItems}
+                idPrefix="nv-florist"
+              />
               <div className="grid grid-cols-2 gap-2">
                 <input
                   type="number"
@@ -345,14 +314,12 @@ export default function BouquetEditor({ editing, saving, detail, isTerminal, isO
                         <div className="flex-1 min-w-0">
                           <span className="text-sm font-medium text-ios-label truncate block">{line.flowerName}</span>
                           <span className="text-xs text-ios-tertiary inline-flex items-baseline gap-1">
-                            {yEnabled
-                              ? <TierSwitchChip
-                                  currentSell={liveSell}
-                                  tiers={editing.getLineTiers(line)}
-                                  onPick={(stockId) => editing.switchLineTier(idx, stockId)}
-                                  t={t}
-                                />
-                              : <span>{liveSell.toFixed(0)} zł</span>}
+                            <TierSwitchChip
+                              currentSell={liveSell}
+                              tiers={editing.getLineTiers(line)}
+                              onPick={(stockId) => editing.switchLineTier(idx, stockId)}
+                              t={t}
+                            />
                             <span>× {line.quantity} =</span>
                             <strong className="text-brand-700">{lineSell.toFixed(0)} zł</strong>
                           </span>
@@ -435,42 +402,8 @@ export default function BouquetEditor({ editing, saving, detail, isTerminal, isO
             ) : null;
           })()}
 
-          {/* Legacy picker — only rendered when flag is off (Pitfall #4: never gate out valid paths) */}
-          {!yEnabled && pickerModalVariety && (
-            <BatchPickerModal
-              baseName={pickerModalVariety}
-              matches={pickerModalMatches}
-              pendingPO={editing.pendingPO}
-              onSelectStock={s => {
-                const existing = editing.editLines.findIndex(l => l.stockItemId === s.id);
-                if (existing >= 0) {
-                  editing.incrementQty(existing);
-                } else {
-                  editing.addFlowerFromStock(s);
-                }
-                setPickerModalVariety(null);
-                setFlowerSearch('');
-              }}
-              onCreateDemand={() => {
-                editing.createDemandEntry(pickerModalVariety);
-                setPickerModalVariety(null);
-                setFlowerSearch('');
-              }}
-              onClose={() => setPickerModalVariety(null)}
-              t={{
-                batchPickerTitle:  t.batchPickerTitle,
-                demandEntry:       t.demandEntry,
-                demandEntryHint:   t.demandEntryHint,
-                demandEntryCreate: t.demandEntryCreate,
-                onOrder:           t.onOrder,
-                cancel:            t.cancel,
-                stems:             t.stems,
-              }}
-            />
-          )}
-
-          {/* Y-model picker — only rendered when flag is on */}
-          {yEnabled && yPickerOpen && (
+          {/* Y-model picker */}
+          {yPickerOpen && (
             <VarietyAllocationPicker
               stockItems={yPickerStockItems}
               reservations={new Map(

--- a/apps/florist/src/components/ReceiveStockForm.jsx
+++ b/apps/florist/src/components/ReceiveStockForm.jsx
@@ -3,7 +3,7 @@
 
 import { useState } from 'react';
 import client from '../api/client.js';
-import { renderStockName, useStockYModelFlag, NewVarietyFields } from '@flower-studio/shared';
+import { renderStockName, NewVarietyFields } from '@flower-studio/shared';
 import t from '../translations.js';
 import useConfigLists from '../hooks/useConfigLists.js';
 
@@ -37,7 +37,6 @@ export default function ReceiveStockForm({ stock, onSave, onCancel }) {
   const [newName, setNewName]         = useState('');
   const [newCategory, setNewCategory] = useState('Other');
   const [newAttrs, setNewAttrs]       = useState({ typeName: '', colour: '', sizeCm: '', cultivar: '' });
-  const yEnabled = useStockYModelFlag();
   const [qty, setQty]                 = useState('');
   const [price, setPrice]             = useState('');
   const [sellPrice, setSellPrice]     = useState('');
@@ -154,17 +153,15 @@ export default function ReceiveStockForm({ stock, onSave, onCancel }) {
               </select>
             </Row>
           </div>
-          {yEnabled && (
-            <div className="mt-2">
-              <NewVarietyFields
-                form={newAttrs}
-                onChange={setNewAttrs}
-                t={t}
-                stockItems={stock}
-                idPrefix="nv-florist-receive"
-              />
-            </div>
-          )}
+          <div className="mt-2">
+            <NewVarietyFields
+              form={newAttrs}
+              onChange={setNewAttrs}
+              t={t}
+              stockItems={stock}
+              idPrefix="nv-florist-receive"
+            />
+          </div>
         </div>
       )}
 

--- a/apps/florist/src/components/steps/Step2Bouquet.jsx
+++ b/apps/florist/src/components/steps/Step2Bouquet.jsx
@@ -10,14 +10,7 @@ import { useToast } from '../../context/ToastContext.jsx';
 import { useAuth } from '../../context/AuthContext.jsx';
 import t from '../../translations.js';
 import useConfigLists from '../../hooks/useConfigLists.js';
-import { renderStockName, VarietyAllocationPicker, VarietyAvailabilityLine, useStockYModelFlag, varietyDisplayName, groupByVariety, resolveStockLinePrice, resolveVarietySell, getVarietyAvailability, arrivalsForVariety, allocateLinesAgainstVariety, NewVarietyFields } from '@flower-studio/shared';
-
-const PO_MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-function formatPoDate(dateStr) {
-  const d = new Date(dateStr);
-  if (isNaN(d)) return null;
-  return `${d.getDate()}.${PO_MONTHS[d.getMonth()]}.`;
-}
+import { VarietyAllocationPicker, VarietyAvailabilityLine, varietyDisplayName, groupByVariety, resolveStockLinePrice, resolveVarietySell, getVarietyAvailability, arrivalsForVariety, allocateLinesAgainstVariety, NewVarietyFields } from '@flower-studio/shared';
 
 // Isolated cart row — holds local input state so typing multi-digit numbers
 // doesn't re-render the parent and kill focus. Like a sub-assembly station
@@ -212,7 +205,6 @@ export default function Step2Bouquet({
 }) {
   const { showToast } = useToast();
   const { role } = useAuth();
-  const yEnabled = useStockYModelFlag();
   // Determine if the order is for a future date (not today).
   // Future orders allow toggling between "use current stock" and "order new" per line.
   const todayIso = new Date().toISOString().split('T')[0];
@@ -342,9 +334,8 @@ export default function Step2Bouquet({
     );
   }, [visibleStock, flowerQuery, showOutOfStock, pendingPO]);
 
-  // Y-model: group filteredStock by Variety 4-tuple for the catalog list.
+  // Group filteredStock by Variety 4-tuple for the catalog list.
   const varGroups = useMemo(() => {
-    if (!yEnabled) return [];
     const groups = [...groupByVariety(adaptedStock.filter(a =>
       filteredStock.some(s => s.id === a.id)
     )).values()];
@@ -370,7 +361,7 @@ export default function Step2Bouquet({
     // (q) still reaches them so deliberate over-promising creates a buy signal.
     // A Variety already in the cart always stays visible so it can be adjusted.
     .filter(g => !!q || g.inCart || g.availability.effective > 0);
-  }, [yEnabled, adaptedStock, filteredStock, flowerQuery, pendingPO, orderLines, reservations, todayIso]);
+  }, [adaptedStock, filteredStock, flowerQuery, pendingPO, orderLines, reservations, todayIso]);
 
   // CR-27: a cart line bound to one sub-row (e.g. a −8 Demand Entry) must reflect
   // the WHOLE Variety's availability, not that one row — otherwise it falsely
@@ -378,14 +369,13 @@ export default function Step2Bouquet({
   // every stock row id → its Variety availability (over ALL varieties, including
   // ones hidden from the catalog).
   const varietyAvailById = useMemo(() => {
-    if (!yEnabled) return {};
     const map = {};
     for (const [, group] of groupByVariety(adaptedStock)) {
       const avail = getVarietyAvailability(group.rows, reservations, arrivalsForVariety(group.rows, pendingPO, todayIso));
       for (const r of group.rows) map[r.id] = avail;
     }
     return map;
-  }, [yEnabled, adaptedStock, pendingPO, reservations, todayIso]);
+  }, [adaptedStock, pendingPO, reservations, todayIso]);
 
   // Net each cart line's available stock against earlier lines of the SAME
   // Variety so two lines never both claim the same on-hand stems (the "3 not in
@@ -393,11 +383,11 @@ export default function Step2Bouquet({
   // left for line i after earlier same-Variety lines took their share.
   const lineNets = useMemo(() => allocateLinesAgainstVariety(orderLines, (l) => {
     if (l.stockDeferred) return null; // future-PO lines don't pull current stock
-    const a = yEnabled ? varietyAvailById[l.stockItemId] : null;
+    const a = varietyAvailById[l.stockItemId];
     if (a) return { key: a, net: a.net };
     const si = stock.find(s => s.id === l.stockItemId);
     return { key: l.stockItemId ?? l.flowerName, net: Number(si?.['Current Quantity']) || 0 };
-  }), [orderLines, varietyAvailById, yEnabled, stock]);
+  }), [orderLines, varietyAvailById, stock]);
 
   function addOne(stockItem, amount = 1) {
     const add = Math.max(1, Number(amount) || 1);
@@ -617,9 +607,9 @@ export default function Step2Bouquet({
               <span className="text-sm font-medium text-indigo-700">+ {t.addNewFlower || 'Add new'} "{flowerQuery}"</span>
             </button>
           )}
-          {(yEnabled ? varGroups.length === 0 : filteredStock.length === 0) && !showCustomFlower ? (
+          {varGroups.length === 0 && !showCustomFlower ? (
             <p className="text-ios-tertiary text-sm text-center py-8">{t.noStockFound}</p>
-          ) : yEnabled ? (
+          ) : (
             varGroups.map(v => {
               const { key, displayName, availability, sell, inCart } = v;
               const out = availability.net <= 0;
@@ -653,54 +643,6 @@ export default function Step2Bouquet({
                 </button>
               );
             })
-          ) : (
-            filteredStock.map(s => {
-              const qty    = Number(s['Current Quantity']) || 0;
-              const inCart = orderLines.find(l => l.stockItemId === s.id);
-              const low    = qty > 0 && qty <= (s['Reorder Threshold'] || 5);
-              const out    = qty <= 0;
-              const poQty  = pendingPO[s.id]?.ordered || 0;
-              const poDate = pendingPO[s.id]?.plannedDate || null;
-              const poDateLabel = poDate ? formatPoDate(poDate) : null;
-              // Pending-PO flowers show their PO price, not the stale card sell (#377).
-              const rowPrice = resolveStockLinePrice(s, pendingPO[s.id]);
-              const rowSell = rowPrice.sellPricePerUnit || Number(s['Current Sell Price']) || 0;
-              const rowCost = rowPrice.costPricePerUnit || Number(s['Current Cost Price']) || 0;
-
-              return (
-                <button
-                  key={s.id}
-                  type="button"
-                  onClick={() => addOne(s)}
-                  className={`w-full flex items-center px-4 py-3 gap-3 text-left transition-colors active-scale
-                              ${out ? 'bg-amber-50/60' : inCart ? 'bg-brand-50/70' : 'active:bg-gray-50'}`}
-                >
-                  <div className="flex-1 min-w-0">
-                    <div className={`text-base font-medium truncate ${inCart ? 'text-brand-700' : out ? 'text-amber-700' : 'text-ios-label'}`}>
-                      {renderStockName(s['Display Name'], qty > 0 ? s['Last Restocked'] : null)}
-                    </div>
-                    <div className="text-sm text-ios-tertiary">
-                      <span className="font-bold text-brand-700">{rowSell.toFixed(0)} zł</span>
-                      {isOwner && <span> · {rowCost.toFixed(0)} zł {t.costPrice}</span>}
-                      <span> · {qty} pcs</span>
-                      {low && !out && <span className="text-ios-orange"> · low</span>}
-                      {qty < 0 && !poQty && (
-                        <span className="text-orange-600 font-medium"> · {t.addsToNextPO || 'next PO'}</span>
-                      )}
-                      {qty === 0 && !poQty && (
-                        <span className="text-amber-600 font-medium"> · {t.outOfStock || 'out'}</span>
-                      )}
-                      {poQty > 0 && <span className="text-blue-600 font-medium"> · +{poQty} {poDateLabel ? `→ ${poDateLabel}` : (t.onOrder || 'on order')}</span>}
-                    </div>
-                  </div>
-                  {inCart && (
-                    <span className="min-w-[24px] h-[24px] px-1.5 rounded-full bg-brand-600 text-white text-xs font-bold flex items-center justify-center">
-                      {inCart.quantity}
-                    </span>
-                  )}
-                </button>
-              );
-            })
           )}
         </div>
       </div>
@@ -716,15 +658,13 @@ export default function Step2Bouquet({
             placeholder={t.flowerName || 'Flower name'}
             className="field-input w-full text-sm"
           />
-          {yEnabled && (
-            <NewVarietyFields
-              form={customFlower}
-              onChange={setCustomFlower}
-              t={t}
-              stockItems={stock}
-              idPrefix="nv-florist-step2"
-            />
-          )}
+          <NewVarietyFields
+            form={customFlower}
+            onChange={setCustomFlower}
+            t={t}
+            stockItems={stock}
+            idPrefix="nv-florist-step2"
+          />
           <div className="grid grid-cols-2 gap-2">
             <select
               value={customFlower.supplier}
@@ -888,7 +828,7 @@ export default function Step2Bouquet({
                   isFutureOrder={isFutureOrder}
                   onToggleDeferred={(key) => toggleDeferred(key)}
                   pendingPO={pendingPO}
-                  varietyAvail={yEnabled ? varietyAvailById[l.stockItemId] : null}
+                  varietyAvail={varietyAvailById[l.stockItemId]}
                   siblingNet={lineNets[idx]}
                 />
               ))
@@ -938,8 +878,8 @@ export default function Step2Bouquet({
         </div>
       </div>
 
-      {/* Y-model picker — only when flag-on AND user tapped a multi-batch variety */}
-      {yEnabled && yPickerOpen && (
+      {/* Y-model picker — only when user tapped a multi-batch variety */}
+      {yPickerOpen && (
         <VarietyAllocationPicker
           stockItems={yPickerStockItems}
           reservations={reservations}

--- a/apps/florist/src/pages/PurchaseOrderPage.jsx
+++ b/apps/florist/src/pages/PurchaseOrderPage.jsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 import client from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import useConfigLists from '../hooks/useConfigLists.js';
-import { useStockYModelFlag, DateTag, buildPoSuggestions } from '@flower-studio/shared';
+import { DateTag, buildPoSuggestions } from '@flower-studio/shared';
 import t from '../translations.js';
 
 const STATUS_COLORS = {
@@ -31,9 +31,6 @@ export default function PurchaseOrderPage() {
   const navigate = useNavigate();
   const { suppliers: SUPPLIERS, targetMarkup, drivers: configDrivers } = useConfigLists();
   const { showToast } = useToast();
-  // Y-model new-Variety fields (#304) only show when the flag is on. Off in prod
-  // → owner uses the plain Flower Name flow; the Variety row never "creeps in".
-  const yModelOn = useStockYModelFlag();
 
   const [orders, setOrders] = useState([]);
   const [stock, setStock] = useState([]);
@@ -78,10 +75,8 @@ export default function PurchaseOrderPage() {
     client.get('/settings').then(r => setDrivers(r.data.drivers || [])).catch(() => {});
   }, [fetchOrders]);
 
-  // Y-model only: grouped Varieties + pending POs + premade reservations feed
-  // buildPoSuggestions. Keyed on yModelOn so it runs once the flag resolves.
+  // Grouped Varieties + pending POs + premade reservations feed buildPoSuggestions.
   useEffect(() => {
-    if (!yModelOn) return;
     Promise.all([
       client.get('/stock?grouped=true').catch(() => ({ data: {} })),
       client.get('/stock/pending-po').catch(() => ({ data: {} })),
@@ -91,7 +86,7 @@ export default function PurchaseOrderPage() {
       setPendingPO(p.data || {});
       setPremadeMap(pm.data || {});
     });
-  }, [yModelOn]);
+  }, []);
 
   // Negative stock items for pre-filling new POs
   const negativeStock = stock.filter(s => (Number(s['Current Quantity']) || 0) < 0);
@@ -131,30 +126,9 @@ export default function PurchaseOrderPage() {
   // owner's demand reading). Pkgs stays 0 — owner decides how many lots she
   // actually wants to buy. Stored Quantity Needed = pkgs > 0 ? pkgs*lot : qty.
   function startNewPO() {
-    // Y-model: pre-fill from netted per-Variety shortfalls (drops Varieties
-    // covered by on-hand stock or already on an open PO, incl. late ones).
-    // Legacy: one line per negative stock row (unchanged).
-    const lines = yModelOn
-      ? buildPoSuggestions(groups, pendingPO, premadeMap)
-      : negativeStock.map(item => {
-      const lotSize = Number(item['Lot Size']) || 0;
-      const quantity = Math.abs(Number(item['Current Quantity']) || 0);
-      const cost = Number(item['Current Cost Price']) || 0;
-      const sell = Number(item['Current Sell Price']) || 0;
-      return {
-        stockItemId: item.id,
-        flowerName: item['Display Name'],
-        quantity,
-        lotSize,
-        packages: 0,
-        supplier: item.Supplier || '',
-        costPrice: cost > 0 ? String(cost) : '',
-        sellPrice: sell > 0 ? String(sell) : '',
-        sellPriceManual: sell > 0,
-        farmer: item.Farmer || '',
-        notes: '',
-      };
-    });
+    // Pre-fill from netted per-Variety shortfalls (drops Varieties covered by
+    // on-hand stock or already on an open PO, incl. late ones).
+    const lines = buildPoSuggestions(groups, pendingPO, premadeMap);
     setFormLines(lines.length > 0 ? lines : [emptyLine()]);
     setFormNotes('');
     setFormDriver('Nikita');
@@ -533,8 +507,8 @@ export default function PurchaseOrderPage() {
                       onChange={e => updateFormLine(idx, { notes: e.target.value })}
                       className="field-input flex-1 text-sm" placeholder={t.po?.notes || 'Notes'} />
                   </div>
-                  {/* Variety identity row — Y-model (#304), only when no Stock Item link */}
-                  {yModelOn && !line.stockItemId && (
+                  {/* Variety identity row — only when no Stock Item link */}
+                  {!line.stockItemId && (
                     <div className="rounded-xl border border-indigo-100 bg-indigo-50/40 p-2 space-y-1.5">
                       <p className="text-[10px] uppercase tracking-wide text-indigo-600 font-semibold">
                         {t.po?.newVariety ?? 'New variety'}
@@ -599,11 +573,9 @@ export default function PurchaseOrderPage() {
 
             {/* Actions */}
             <div className="flex gap-2">
-              {/* PG-6: a Y-model line may be Type-only (no Flower Name) — the
-                  submit filter already accepts `l.flowerName || l.type`, so the
-                  guard must mirror it. Inert under STOCK_Y_MODEL off (the Type
-                  input is flag-gated, so l.type stays '' → collapses to the
-                  legacy !l.flowerName check). */}
+              {/* PG-6: a line may be Type-only (no Flower Name) — the submit
+                  filter already accepts `l.flowerName || l.type`, so the
+                  disabled-guard must mirror it. */}
               <button onClick={createPO}
                 disabled={submitting || formLines.every(l => !l.flowerName && !l.type)}
                 className="flex-1 py-3 rounded-2xl bg-brand-600 text-white text-sm font-semibold disabled:opacity-50 active-scale">
@@ -702,7 +674,6 @@ export default function PurchaseOrderPage() {
                             onRemove={(lineId) => removeDraftLine(order.id, lineId)}
                             targetMarkup={targetMarkup}
                             suppliers={SUPPLIERS}
-                            yModelOn={yModelOn}
                           />
                         ))}
                         {order.Status === 'Draft' ? (
@@ -922,7 +893,7 @@ function StockSearchInput({ stock, value, onChange, onSelect, onBlur: onBlurCb }
 }
 
 // ── Draft line editor (mobile layout) ──
-function DraftLineEditor({ line, stock, onUpdate, onRemove, targetMarkup, suppliers, yModelOn }) {
+function DraftLineEditor({ line, stock, onUpdate, onRemove, targetMarkup, suppliers }) {
   const storedLs = Number(line['Lot Size']) || 0;
   const storedQty = Number(line['Quantity Needed']) || 1;
   // Display qty as lots (user enters lots, not stems)
@@ -1080,8 +1051,8 @@ function DraftLineEditor({ line, stock, onUpdate, onRemove, targetMarkup, suppli
           className="field-input flex-1 text-sm py-1" placeholder={t.po?.notes || 'Notes'} />
       </div>
 
-      {/* Variety identity row — Y-model (#304), only when no Stock Item link */}
-      {yModelOn && !stockItemLinked && (
+      {/* Variety identity row — only when no Stock Item link */}
+      {!stockItemLinked && (
         <div className="rounded-xl border border-indigo-100 bg-indigo-50/40 p-2 space-y-1.5">
           <p className="text-[10px] uppercase tracking-wide text-indigo-600 font-semibold">
             {t.po?.newVariety ?? 'New variety'}

--- a/apps/florist/src/pages/StockEvaluationPage.jsx
+++ b/apps/florist/src/pages/StockEvaluationPage.jsx
@@ -5,16 +5,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useToast } from '../context/ToastContext.jsx';
-import { useStockYModelFlag } from '@flower-studio/shared';
 import client from '../api/client.js';
 import t from '../translations.js';
 
 export default function StockEvaluationPage() {
   const navigate = useNavigate();
   const { showToast } = useToast();
-  // C13: under the Y-model, a new substitute flower needs a Variety identity or
-  // it is invisible in the grouped Stock view — capture it here at evaluation.
-  const yModelOn = useStockYModelFlag();
   const [orders, setOrders] = useState([]);
   const [loading, setLoading] = useState(true);
   const [submittingId, setSubmittingId] = useState(null);
@@ -35,10 +31,9 @@ export default function StockEvaluationPage() {
   }, []);
 
   useEffect(() => {
-    if (!yModelOn) return;
     client.get('/stock/distinct/type').then(r => setTypeOptions(r.data || [])).catch(() => {});
     client.get('/stock/distinct/colour').then(r => setColourOptions(r.data || [])).catch(() => {});
-  }, [yModelOn]);
+  }, []);
 
   useEffect(() => {
     client.get('/stock-orders/meta/lookups')
@@ -129,25 +124,23 @@ export default function StockEvaluationPage() {
   async function handleSubmitClick(orderId) {
     const order = orders.find(o => o.id === orderId);
     if (!order) return;
-    // C13: under the Y-model a brand-new substitute must be classified (Type) —
-    // an unattributed card is invisible in the grouped stock view. The input
-    // marks Type required (asterisk); enforce it before submit.
-    if (yModelOn) {
-      const unclassified = [];
-      for (const line of order.lines) {
-        if (line['Eval Status'] === 'Processed') continue;
-        const ev = evalState[line.id] || {};
-        const altAccepted = Number(ev.altAccepted) || 0;
-        const altFlowerName = (line['Alt Flower Name'] || '').trim();
-        const isNew = altFlowerName && !knownStockNames.has(altFlowerName.toLowerCase());
-        if (altAccepted > 0 && isNew && !(ev.altType || '').trim()) {
-          unclassified.push(altFlowerName);
-        }
+    // C13: a brand-new substitute must be classified (Type) — an unattributed
+    // card is invisible in the grouped stock view. The input marks Type
+    // required (asterisk); enforce it before submit.
+    const unclassified = [];
+    for (const line of order.lines) {
+      if (line['Eval Status'] === 'Processed') continue;
+      const ev = evalState[line.id] || {};
+      const altAccepted = Number(ev.altAccepted) || 0;
+      const altFlowerName = (line['Alt Flower Name'] || '').trim();
+      const isNew = altFlowerName && !knownStockNames.has(altFlowerName.toLowerCase());
+      if (altAccepted > 0 && isNew && !(ev.altType || '').trim()) {
+        unclassified.push(altFlowerName);
       }
-      if (unclassified.length > 0) {
-        showToast(`${t.substituteTypeRequired}: ${unclassified.join(', ')}`, 'error');
-        return;
-      }
+    }
+    if (unclassified.length > 0) {
+      showToast(`${t.substituteTypeRequired}: ${unclassified.join(', ')}`, 'error');
+      return;
     }
     const newOnes = collectNewSubstitutes(order);
     if (newOnes.length > 0) {
@@ -411,9 +404,8 @@ export default function StockEvaluationPage() {
                                   )}
                                   {/* C13: classify a brand-new substitute so the new
                                       stock card carries a Variety identity and shows
-                                      in the grouped Y-model stock list. Flag-gated —
-                                      hidden in the legacy flat-stock world. */}
-                                  {isNewSubstitute && yModelOn && (
+                                      in the grouped stock list. */}
+                                  {isNewSubstitute && (
                                     <div className="space-y-1.5">
                                       <p className="text-[11px] text-indigo-600">{t.substituteVarietyHint}</p>
                                       <div className="grid grid-cols-2 gap-1.5">

--- a/apps/florist/src/pages/StockPanelPage.jsx
+++ b/apps/florist/src/pages/StockPanelPage.jsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import { Truck, ShoppingCart, ClipboardCheck, Trash2 } from 'lucide-react';
 import {
   useDebouncedValue,
-  useStockYModelFlag,
   TypeGroupHeader,
   VarietyListItem,
   ShortfallSummary,
@@ -25,19 +24,9 @@ import StockFilterDrawer from '../components/StockFilterDrawer.jsx';
 import client from '../api/client.js';
 import { useToast } from '../context/ToastContext.jsx';
 import { useAuth } from '../context/AuthContext.jsx';
-import StockItem from '../components/StockItem.jsx';
 import ReceiveStockForm from '../components/ReceiveStockForm.jsx';
 import HelpPanel from '../components/HelpPanel.jsx';
-import PendingArrivalsSection from '../components/PendingArrivalsSection.jsx';
 import t from '../translations.js';
-
-const SORT_OPTIONS = [
-  { key: 'name',     label: () => t.sortByName },
-  { key: 'qty',      label: () => t.sortByQty },
-  { key: 'sell',     label: () => t.sortBySell },
-  { key: 'supplier', label: () => t.sortBySupplier },
-  { key: 'received', label: () => t.sortByReceived || 'Date' },
-];
 
 const VIEW_OPTIONS = [
   { key: 'all',       label: () => t.viewAll },
@@ -46,26 +35,15 @@ const VIEW_OPTIONS = [
   { key: 'slow',      label: () => t.viewSlowMovers },
 ];
 
-const SORT_FNS = {
-  name:     (a, b) => (a['Display Name'] || '').localeCompare(b['Display Name'] || ''),
-  qty:      (a, b) => (Number(a['Current Quantity']) || 0) - (Number(b['Current Quantity']) || 0),
-  sell:     (a, b) => (Number(a['Current Sell Price']) || 0) - (Number(b['Current Sell Price']) || 0),
-  supplier: (a, b) => (a.Supplier || '').localeCompare(b.Supplier || ''),
-  received: (a, b) => (a['Last Restocked'] || '').localeCompare(b['Last Restocked'] || ''),
-};
-
 export default function StockPanelPage() {
   const navigate          = useNavigate();
   const { showToast }     = useToast();
   const { role }          = useAuth();
-  const yEnabled          = useStockYModelFlag();
   const [stock, setStock] = useState([]);
-  const [groups, setGroups] = useState([]); // Y-model: array from /stock?grouped=true
+  const [groups, setGroups] = useState([]); // array from /stock?grouped=true
   const [loading, setLoading]     = useState(true);
   const [showReceive, setShowReceive] = useState(false);
-  const [editMode, setEditMode]       = useState(false);
   const [showHelp, setShowHelp]       = useState(false);
-  const [committedMap, setCommittedMap] = useState({}); // stockId → { committed, orders }
   const [pendingPO, setPendingPO] = useState({}); // stockId → { ordered, plannedDate, pos[] }
   // Premade-bouquet reservations: { stockId: { qty, bouquets: [{ bouquetId, name, qty }] } }
   const [premadeMap, setPremadeMap] = useState({});
@@ -103,8 +81,6 @@ export default function StockPanelPage() {
   // Debounce so the filter+sort compute over ~300 stock rows doesn't run on
   // every keystroke. Input stays responsive; results settle after 300ms.
   const debouncedSearch       = useDebouncedValue(search, 300);
-  const [sortKey, setSortKey] = useState('name');
-  const [sortAsc, setSortAsc] = useState(true);
   const [view, setView]       = useState('all');
   const [hideZero, setHideZero] = useState(true);
   // Layout: flat ungrouped list (default) vs grouped by Type. The owner wanted
@@ -129,42 +105,26 @@ export default function StockPanelPage() {
   const fetchStock = useCallback(async () => {
     setLoading(true);
     try {
-      if (yEnabled) {
-        // Y-model: fetch grouped stock + premade reservations + pending POs.
-        const [groupedRes, premadeRes, pendingPoRes] = await Promise.all([
-          client.get('/stock?grouped=true'),
-          client.get('/stock/premade-committed').catch(() => ({ data: {} })),
-          client.get('/stock/pending-po').catch(() => ({ data: {} })),
-        ]);
-        setGroups(groupedRes.data.groups || []);
-        setPremadeMap(premadeRes.data || {});
-        setPendingPO(pendingPoRes.data || {});
-      } else {
-        // Legacy flat list
-        const [stockRes, committedRes, premadeRes] = await Promise.all([
-          client.get('/stock?includeEmpty=true'),
-          client.get('/stock/committed'),
-          client.get('/stock/premade-committed').catch(() => ({ data: {} })),
-        ]);
-        setStock(stockRes.data);
-        setCommittedMap(committedRes.data);
-        setPremadeMap(premadeRes.data || {});
-      }
+      // Grouped stock (Variety view) + flat stock (feeds ReceiveStockForm's
+      // flower picker) + premade reservations + pending POs.
+      const [groupedRes, stockRes, premadeRes, pendingPoRes] = await Promise.all([
+        client.get('/stock?grouped=true'),
+        client.get('/stock?includeEmpty=true'),
+        client.get('/stock/premade-committed').catch(() => ({ data: {} })),
+        client.get('/stock/pending-po').catch(() => ({ data: {} })),
+      ]);
+      setGroups(groupedRes.data.groups || []);
+      setStock(stockRes.data);
+      setPremadeMap(premadeRes.data || {});
+      setPendingPO(pendingPoRes.data || {});
     } catch (err) { showToast(err.response?.data?.error || t.adjustError, 'error'); }
     finally   { setLoading(false); }
-  }, [yEnabled]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => { fetchStock(); }, [fetchStock]);
 
-  async function handleAdjust(id, delta) {
-    try {
-      const res = await client.post(`/stock/${id}/adjust`, { delta });
-      setStock(prev => prev.map(s => s.id === id ? { ...s, ...res.data } : s));
-    } catch (err) { showToast(err.response?.data?.error || t.adjustError, 'error'); }
-  }
-
-  // Y-model quick-adjust: qty lives on the per-Batch row inside `groups`.
-  // Optimistically bump current_quantity, POST the delta, revert on failure.
+  // Quick-adjust: qty lives on the per-Batch row inside `groups`. Optimistically
+  // bump current_quantity, POST the delta, revert on failure.
   async function handleAdjustGroup(id, delta) {
     const bump = (rows, d) =>
       (rows || []).map(r =>
@@ -179,14 +139,6 @@ export default function StockPanelPage() {
     }
   }
 
-  async function handleWriteOff(id, quantity, reason) {
-    try {
-      const res = await client.post(`/stock/${id}/write-off`, { quantity, reason: reason || undefined });
-      setStock(prev => prev.map(s => s.id === id ? { ...s, ...res.data } : s));
-      showToast(`${quantity} stems written off`, 'success');
-    } catch (err) { showToast(err.response?.data?.error || t.writeOffError, 'error'); }
-  }
-
   async function handleReceive(data) {
     try {
       await client.post('/stock-purchases', data);
@@ -194,21 +146,6 @@ export default function StockPanelPage() {
       setShowReceive(false);
       fetchStock();
     } catch (err) { showToast(err.response?.data?.error || t.receiveError, 'error'); }
-  }
-
-  async function handlePatch(id, fields) {
-    try {
-      const res = await client.patch(`/stock/${id}`, fields);
-      setStock(prev => prev.map(s => s.id === id ? { ...s, ...res.data } : s));
-    } catch (err) { showToast(err.response?.data?.error || t.adjustError, 'error'); }
-  }
-
-  async function handlePatchPrice(id, fields) {
-    try {
-      const res = await client.patch(`/stock/${id}`, fields);
-      setStock(prev => prev.map(s => s.id === id ? { ...s, ...res.data } : s));
-      showToast(t.stockUpdated, 'success');
-    } catch (err) { showToast(err.response?.data?.error || t.adjustError, 'error'); }
   }
 
   // E2b: owner bulk-patch of a Variety-level field (Reorder Threshold / Lot Size)
@@ -236,12 +173,7 @@ export default function StockPanelPage() {
     } catch (err) { showToast(err.response?.data?.error || t.adjustError, 'error'); }
   }
 
-  function toggleSort(key) {
-    if (sortKey === key) setSortAsc(v => !v);
-    else { setSortKey(key); setSortAsc(true); }
-  }
-
-  // ── Y-model: derived Maps from premadeMap ──
+  // ── Derived Maps from premadeMap ──
   // premadesByStockId: Map<stockId (string), Array<{ id, name, qty }>>
   // reservations:      Map<stockId (string), number>
   // Both are derived from the same /stock/premade-committed response.
@@ -323,9 +255,8 @@ export default function StockPanelPage() {
   // hideZero=true  → hide zero-qty groups (same semantics as today)
   // hideZero=false → show all groups including zero-qty
 
-  // Filtered group list for Y-model path
+  // Filtered group list
   const filteredGroups = useMemo(() => {
-    if (!yEnabled) return [];
     let list = groups;
     // Search across Variety identity + every row's display name + supplier.
     const q = debouncedSearch.trim().toLowerCase();
@@ -345,9 +276,8 @@ export default function StockPanelPage() {
       list = list.filter(g => varietyMatchesFilter(g, reservationsMap, varietyFilter));
     }
     // View pills (Negative / Low / Slow) filter by per-Variety net — the same
-    // number the row badge shows. hideZero only applies in the 'all' view (the
-    // legacy flat list does the same: `hideZero && view === 'all'`), so a short
-    // variety with no on-hand stems still surfaces under Negative.
+    // number the row badge shows. hideZero only applies in the 'all' view, so a
+    // short variety with no on-hand stems still surfaces under Negative.
     if (view !== 'all') {
       list = list.filter(g => varietyGroupMatchesView(g, view, reservationsMap));
     } else if (hideZero) {
@@ -358,7 +288,7 @@ export default function StockPanelPage() {
       });
     }
     return list;
-  }, [groups, hideZero, view, yEnabled, reservationsMap, debouncedSearch, varietyFilter, varietyFilterCount]);
+  }, [groups, hideZero, view, reservationsMap, debouncedSearch, varietyFilter, varietyFilterCount]);
 
   // A Variety's age = its OLDEST dated on-hand batch (longest-sitting stems).
   // Only positive-qty batches count — Demand Entries (negative qty) are future
@@ -395,83 +325,15 @@ export default function StockPanelPage() {
     return arr.sort((a, b) => varietyLabel(a).localeCompare(varietyLabel(b)));
   }, [filteredGroups, flatSort, reservationsMap]);
 
-  // Filtered + sorted stock (legacy path)
-  const filteredStock = useMemo(() => {
-    const now = Date.now();
-    const SLOW_DAYS = 14;
 
-    let items = stock;
-
-    // Hide zero-stock items (default on, same as dashboard)
-    if (hideZero && view === 'all') {
-      // Keep zero-qty rows when premade bouquets still hold stems — those
-      // stems physically exist on the shelf and must stay visible so the
-      // owner/florist can reconcile them.
-      items = items.filter(s => {
-        const qty = Number(s['Current Quantity']) || 0;
-        if (qty !== 0) return true;
-        return (premadeMap[s.id]?.qty || 0) > 0;
-      });
-    }
-
-    // View filter
-    if (view === 'negative') {
-      items = items.filter(s => (Number(s['Current Quantity']) || 0) < 0);
-    } else if (view === 'low') {
-      items = items.filter(s => {
-        const qty = Number(s['Current Quantity']) || 0;
-        const threshold = Number(s['Reorder Threshold']) || 5;
-        return qty > 0 && qty <= threshold;
-      });
-    } else if (view === 'slow') {
-      items = items.filter(s => {
-        const qty = Number(s['Current Quantity']) || 0;
-        if (qty <= 0) return false;
-        const last = s['Last Restocked'];
-        if (!last) return true; // never restocked = slow
-        const age = now - new Date(last).getTime();
-        return age > SLOW_DAYS * 86400000;
-      });
-    }
-
-    // Search filter
-    if (debouncedSearch.trim()) {
-      const q = debouncedSearch.toLowerCase().trim();
-      items = items.filter(s =>
-        (s['Display Name'] || '').toLowerCase().includes(q) ||
-        (s.Supplier || '').toLowerCase().includes(q) ||
-        (s.Farmer || '').toLowerCase().includes(q)
-      );
-    }
-
-    // Sort — negative items pinned to top (they're the true "owe stems" signal)
-    const sortFn = SORT_FNS[sortKey] || SORT_FNS.name;
-    const sorted = [...items].sort((a, b) => {
-      const aNeg = (Number(a['Current Quantity']) || 0) < 0;
-      const bNeg = (Number(b['Current Quantity']) || 0) < 0;
-      if (aNeg !== bNeg) return aNeg ? -1 : 1;
-      const cmp = sortFn(a, b);
-      return sortAsc ? cmp : -cmp;
-    });
-
-    return sorted;
-  }, [stock, debouncedSearch, sortKey, sortAsc, view, hideZero, premadeMap]);
-
-  // Counts for view badges — under the Y-model the signal is the per-Variety net
-  // (matches the Negative/Low pills + the row badge), not a flat per-row qty<0.
+  // Counts for view badges — the signal is the per-Variety net (matches the
+  // Negative/Low pills + the row badge), not a flat per-row qty<0.
   const negativeCount = useMemo(() =>
-    yEnabled
-      ? groups.filter(g => varietyGroupMatchesView(g, 'negative', reservationsMap)).length
-      : stock.filter(s => (Number(s['Current Quantity']) || 0) < 0).length,
-  [yEnabled, groups, reservationsMap, stock]);
+    groups.filter(g => varietyGroupMatchesView(g, 'negative', reservationsMap)).length,
+  [groups, reservationsMap]);
   const lowCount = useMemo(() =>
-    yEnabled
-      ? groups.filter(g => varietyGroupMatchesView(g, 'low', reservationsMap)).length
-      : stock.filter(s => {
-          const qty = Number(s['Current Quantity']) || 0;
-          return qty > 0 && qty <= (Number(s['Reorder Threshold']) || 5);
-        }).length,
-  [yEnabled, groups, reservationsMap, stock]);
+    groups.filter(g => varietyGroupMatchesView(g, 'low', reservationsMap)).length,
+  [groups, reservationsMap]);
 
   // D3 round-2: reserve the Planned column only when at least one visible
   // Variety actually has pending order demand. Otherwise collapse it so
@@ -586,17 +448,6 @@ export default function StockPanelPage() {
           </button>
         )}
 
-        {/* Legacy per-stockId pending table (flag off). Under Y-model the
-            date-grouped PendingArrivalsPanel renders directly above the
-            ShortfallSummary instead — see below (CR-34). */}
-        {!yEnabled && (
-          <PendingArrivalsSection
-            stock={stock}
-            committedMap={committedMap}
-            onOrderClick={(id) => navigate(`/orders/${id}`)}
-          />
-        )}
-
         {/* Receive stock */}
         <button
           onClick={() => setShowReceive(!showReceive)}
@@ -653,59 +504,55 @@ export default function StockPanelPage() {
           ))}
         </div>
 
-        {/* Layout toggle (Flat ⇄ By type) + age sort on the left (Y-model);
+        {/* Layout toggle (Flat ⇄ By type) + age sort on the left;
             hide-zero / show-cleared on the right. */}
         <div className="flex items-center gap-2 mb-2">
-          {yEnabled && (
-            <>
-              {/* Flat ⇄ By-type segmented control — flat is the shop-floor default */}
-              <div className="inline-flex rounded-full bg-gray-100 dark:bg-gray-700 p-0.5">
-                <button
-                  onClick={() => setFlatView(true)}
-                  className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
-                    flatView ? 'bg-brand-600 text-white' : 'text-ios-secondary dark:text-gray-300'
-                  }`}
-                >{t.stockFlat || 'Flat'}</button>
-                <button
-                  onClick={() => setFlatView(false)}
-                  className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
-                    !flatView ? 'bg-brand-600 text-white' : 'text-ios-secondary dark:text-gray-300'
-                  }`}
-                >{t.stockByType || 'By type'}</button>
-              </div>
-              {/* Sort — flat layout only. One compact pill that cycles
-                  A–Z → longest in stock → stock level (kept minimal so the
-                  control row doesn't overfill on a phone). */}
-              {flatView && (
-                <button
-                  onClick={() => setFlatSort(s => FLAT_SORTS[(FLAT_SORTS.indexOf(s) + 1) % FLAT_SORTS.length])}
-                  className="px-3 py-1.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-ios-secondary dark:text-gray-300 active-scale inline-flex items-center gap-1"
-                  aria-label={t.stockSortLabel || 'Sort'}
-                >
-                  <span className="text-ios-tertiary">⇅</span>
-                  {flatSort === 'name'
-                    ? (t.stockSortName || 'A–Z')
-                    : flatSort === 'age'
-                      ? (t.stockSortAge || 'Longest in stock')
-                      : (t.stockSortStock || 'Stock level')}
-                </button>
-              )}
-              {/* E1b: Variety filter drawer trigger (applies to Flat + By-type). */}
-              <button
-                data-testid="stock-filter-open"
-                onClick={() => setFilterDrawerOpen(true)}
-                className={`px-3 py-1.5 rounded-full text-xs font-medium active-scale inline-flex items-center gap-1 ${
-                  varietyFilterCount > 0
-                    ? 'bg-brand-100 text-brand-700 ring-1 ring-brand-200'
-                    : 'bg-gray-100 dark:bg-gray-700 text-ios-secondary dark:text-gray-300'
-                }`}
-                aria-label={t.filters}
-              >
-                <span className="text-ios-tertiary">⚲</span>
-                {t.filters}{varietyFilterCount > 0 ? ` (${varietyFilterCount})` : ''}
-              </button>
-            </>
+          {/* Flat ⇄ By-type segmented control — flat is the shop-floor default */}
+          <div className="inline-flex rounded-full bg-gray-100 dark:bg-gray-700 p-0.5">
+            <button
+              onClick={() => setFlatView(true)}
+              className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                flatView ? 'bg-brand-600 text-white' : 'text-ios-secondary dark:text-gray-300'
+              }`}
+            >{t.stockFlat || 'Flat'}</button>
+            <button
+              onClick={() => setFlatView(false)}
+              className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                !flatView ? 'bg-brand-600 text-white' : 'text-ios-secondary dark:text-gray-300'
+              }`}
+            >{t.stockByType || 'By type'}</button>
+          </div>
+          {/* Sort — flat layout only. One compact pill that cycles
+              A–Z → longest in stock → stock level (kept minimal so the
+              control row doesn't overfill on a phone). */}
+          {flatView && (
+            <button
+              onClick={() => setFlatSort(s => FLAT_SORTS[(FLAT_SORTS.indexOf(s) + 1) % FLAT_SORTS.length])}
+              className="px-3 py-1.5 rounded-full text-xs font-medium bg-gray-100 dark:bg-gray-700 text-ios-secondary dark:text-gray-300 active-scale inline-flex items-center gap-1"
+              aria-label={t.stockSortLabel || 'Sort'}
+            >
+              <span className="text-ios-tertiary">⇅</span>
+              {flatSort === 'name'
+                ? (t.stockSortName || 'A–Z')
+                : flatSort === 'age'
+                  ? (t.stockSortAge || 'Longest in stock')
+                  : (t.stockSortStock || 'Stock level')}
+            </button>
           )}
+          {/* E1b: Variety filter drawer trigger (applies to Flat + By-type). */}
+          <button
+            data-testid="stock-filter-open"
+            onClick={() => setFilterDrawerOpen(true)}
+            className={`px-3 py-1.5 rounded-full text-xs font-medium active-scale inline-flex items-center gap-1 ${
+              varietyFilterCount > 0
+                ? 'bg-brand-100 text-brand-700 ring-1 ring-brand-200'
+                : 'bg-gray-100 dark:bg-gray-700 text-ios-secondary dark:text-gray-300'
+            }`}
+            aria-label={t.filters}
+          >
+            <span className="text-ios-tertiary">⚲</span>
+            {t.filters}{varietyFilterCount > 0 ? ` (${varietyFilterCount})` : ''}
+          </button>
           <button
             onClick={() => setHideZero(!hideZero)}
             className={`ml-auto px-3 py-1.5 rounded-full text-xs font-medium transition-colors active-scale ${
@@ -714,37 +561,16 @@ export default function StockPanelPage() {
                 : 'bg-gray-200 dark:bg-gray-600 text-ios-label dark:text-gray-200'
             }`}
           >
-            {yEnabled
-              ? (hideZero ? (t.showClearedRows || 'Show cleared') : (t.showClearedRows || 'Show cleared'))
-              : (hideZero ? (t.inStockOnly || 'In stock') : (t.showAll || 'All stock'))}
+            {t.showClearedRows || 'Show cleared'}
           </button>
         </div>
-
-        {/* Sort pills — legacy only; Y-model groups by type, then variety */}
-        {!yEnabled && (
-          <div className="flex gap-2 mb-4 overflow-x-auto">
-            {SORT_OPTIONS.map(s => (
-              <button
-                key={s.key}
-                onClick={() => toggleSort(s.key)}
-                className={`px-2.5 py-1 rounded-full text-[11px] font-medium whitespace-nowrap transition-colors active-scale ${
-                  sortKey === s.key
-                    ? 'bg-brand-100 text-brand-700'
-                    : 'bg-gray-50 text-ios-tertiary'
-                }`}
-              >
-                {s.label()} {sortKey === s.key && (sortAsc ? '↑' : '↓')}
-              </button>
-            ))}
-          </div>
-        )}
 
         {loading ? (
           <div className="flex items-center justify-center mt-20">
             <div className="w-8 h-8 border-2 border-brand-300 border-t-brand-600 rounded-full animate-spin" />
           </div>
-        ) : yEnabled ? (
-          /* ── Y-model: grouped Type → Variety list ── */
+        ) : (
+          /* ── Grouped Type → Variety list ── */
           filteredGroups.length === 0 ? (
             <p className="text-ios-tertiary text-sm text-center py-12">{t.noStockFound || 'No items found'}</p>
           ) : (
@@ -821,59 +647,13 @@ export default function StockPanelPage() {
             )}
             </>
           )
-        ) : (
-          /* ── Legacy flat list ── */
-          filteredStock.length === 0 ? (
-            <p className="text-ios-tertiary text-sm text-center py-12">{t.noStockFound || 'No items found'}</p>
-          ) : (
-            <div className="ios-card overflow-hidden divide-y divide-ios-separator/40">
-              {filteredStock.map(item => (
-                <StockItem
-                  key={item.id}
-                  item={item}
-                  editMode={editMode}
-                  onAdjust={delta => handleAdjust(item.id, delta)}
-                  onWriteOff={(qty, reason) => handleWriteOff(item.id, qty, reason)}
-                  onPatch={fields => handlePatch(item.id, fields)}
-                  onPatchPrice={fields => handlePatchPrice(item.id, fields)}
-                  committedData={committedMap[item.id]}
-                  premadeData={premadeMap[item.id]}
-                  role={role}
-                />
-              ))}
-            </div>
-          )
-        )}
-
-        {/* Summary bar — legacy path only */}
-        {!loading && !yEnabled && filteredStock.length > 0 && (
-          <div className="mt-3 flex items-center justify-between px-2 text-xs text-ios-tertiary">
-            <span>{filteredStock.length} {t.stems}</span>
-            <span>
-              {filteredStock.reduce((s, i) => s + (Number(i['Current Quantity']) || 0), 0)} {t.stems} {t.sortByQty?.toLowerCase()}
-            </span>
-          </div>
-        )}
-
-        {/* Owner-only edit mode toggle — legacy path only */}
-        {role === 'owner' && !loading && !yEnabled && (
-          <button
-            onClick={() => setEditMode(!editMode)}
-            className={`w-full mt-4 h-11 rounded-2xl text-sm font-semibold transition-colors ${
-              editMode
-                ? 'bg-brand-600 text-white active:bg-brand-700'
-                : 'bg-ios-fill2 text-ios-secondary active:bg-ios-separator'
-            }`}
-          >
-            {editMode ? `✓ ${t.doneEditing}` : `✎ ${t.editStock}`}
-          </button>
         )}
       </main>
 
       {showHelp && <HelpPanel onClose={() => setShowHelp(false)} />}
 
-      {/* ── Y-model: Batch trace modal ── */}
-      {yEnabled && traceStockId && (
+      {/* Batch trace modal */}
+      {traceStockId && (
         <BatchTraceModal
           trail={traceLoading ? [] : (traceTrail || [])}
           t={t}
@@ -882,8 +662,8 @@ export default function StockPanelPage() {
         />
       )}
 
-      {/* ── Y-model: Variety trace modal — mirrors BatchTraceModal UX ── */}
-      {yEnabled && varietyTraceKey && (
+      {/* Variety trace modal — mirrors BatchTraceModal UX */}
+      {varietyTraceKey && (
         <div
           data-testid="variety-trace-modal-backdrop"
           className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4"
@@ -928,15 +708,13 @@ export default function StockPanelPage() {
       />
 
       {/* E1b: Variety filter drawer (Type / colour·cultivar / status / net). */}
-      {yEnabled && (
-        <StockFilterDrawer
-          open={filterDrawerOpen}
-          onClose={() => setFilterDrawerOpen(false)}
-          filter={varietyFilter}
-          onApply={(next) => setVarietyFilter(next)}
-          onReset={() => setVarietyFilter(clearVarietyFilter())}
-        />
-      )}
+      <StockFilterDrawer
+        open={filterDrawerOpen}
+        onClose={() => setFilterDrawerOpen(false)}
+        filter={varietyFilter}
+        onApply={(next) => setVarietyFilter(next)}
+        onReset={() => setVarietyFilter(clearVarietyFilter())}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## What

**PR2a** of the W4 frontend flag-strip (issue #291). `STOCK_Y_MODEL` is LIVE=true on prod (owner-approved cutover); PR1 (#528) removed the backend branches. This removes the flag from the **florist app** — Y-model UI is now unconditional. Migrating one app at a time is safe because the shared `useStockYModelFlag` hook still returns `true` (PR1 left `settings.stockYModelEnabled: true` as a literal); it's removed in PR2c after the dashboard is migrated.

## Files (6 florist consumers)
- `BouquetEditor.jsx` — dropped legacy flat-name grouping + the `BatchPickerModal` open path & its JSX/state; keeps `VarietyAllocationPicker`.
- `ReceiveStockForm.jsx` — `NewVarietyFields` gate → unconditional.
- `steps/Step2Bouquet.jsx` — removed the ~48-line legacy flat-stock catalog render; keeps the Variety-grouped catalog.
- `PurchaseOrderPage.jsx` — removed the legacy one-PO-line-per-negative-row path; keeps `buildPoSuggestions`.
- `StockPanelPage.jsx` — removed the entire legacy flat `StockItem` list, legacy `PendingArrivalsSection`, sort pills, summary bar, edit-mode toggle, and their now-dead handlers/state/`/stock/committed` fetch; keeps the grouped-Variety view.
- `StockEvaluationPage.jsx` — Type-required validation + substitute-Variety classification fields → unconditional.

## Deliberately kept (load-bearing — #291's list is stale on this)
The **substitute-reconciliation** flow is NOT flag-gated and stays entirely untouched: `SubstituteReconciliationPage.jsx`, the `/reconcile-substitutes` route in `App.jsx`, and the `substitute_reconciliation_needed` handling in `useNotifications.js` (driven by the PO-evaluate flow). Confirmed absent from the diff.

## Verification
- `cd apps/florist && vite build` → **succeeded** (2182 modules, no unresolved-import/undefined-var errors).
- `grep -rn "useStockYModelFlag\|yEnabled\|yModelOn" apps/florist/src` → **0**.
- Zero dangling references to any removed symbol (handlers, state, imports).
- florist has no vitest suite → the build is the automated gate.

Part of #291. Follow-ups: PR2b (dashboard + premade-repair tooling), PR2c (remove shared hook + settings field), PR3 (docs, closes #291).

🤖 Generated with [Claude Code](https://claude.com/claude-code)