### PR TITLE
fix(stock): florist eval substitute Type autocomplete — request distinct/typeName not /type (#532)

### DIFF
--- a/apps/florist/src/pages/StockEvaluationPage.jsx
+++ b/apps/florist/src/pages/StockEvaluationPage.jsx
@@ -31,7 +31,9 @@ export default function StockEvaluationPage() {
   }, []);
 
   useEffect(() => {
-    client.get('/stock/distinct/type').then(r => setTypeOptions(r.data || [])).catch(() => {});
+    // Column name must match stockRepo.VARIETY_COLUMNS — it's `typeName`, not `type`
+    // (a bare `type` 400s: "column type is not allowed", #532).
+    client.get('/stock/distinct/typeName').then(r => setTypeOptions(r.data || [])).catch(() => {});
     client.get('/stock/distinct/colour').then(r => setColourOptions(r.data || [])).catch(() => {});
   }, []);
 


### PR DESCRIPTION
## What

Fixes **#532** (filed by the daily prod-error watchdog). `StockEvaluationPage` seeded its substitute **Type** autocomplete from `GET /stock/distinct/type`, but the backend allow-list (`stockRepo.VARIETY_COLUMNS`) only accepts `typeName / colour / sizeCm / cultivar`. So the request 400'd (`column "type" is not allowed`) and the `.catch(() => {})` swallowed it — the substitute Type datalist has been **silently empty on prod**. The sibling `colour` fetch was already correct.

One-line fix: request `/stock/distinct/typeName`.

## Pre-existing, not a W4 regression
StockEvaluationPage has requested `distinct/type` since it was written; the W4 flag-strip (#529) only made the fetch unconditional (it already fired under flag-on, which was always true on prod). The watchdog accumulated enough log history to surface it on 2026-07-08.

## Verification
- `grep -rn "distinct/type"` across apps → this was the only occurrence.
- `cd apps/florist && vite build` → succeeded.
- Full UI check (empty→populated Type datalist) needs a seeded Evaluating PO + running stack; the fix is an unambiguous contract match (`VARIETY_COLUMNS`), so the build is the practical gate.

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)