### PR TITLE
fix(delivery): humanize next-day delivery date on main screen

### DIFF
--- a/apps/delivery/src/pages/DeliveryListPage.jsx
+++ b/apps/delivery/src/pages/DeliveryListPage.jsx
@@ -25,11 +25,23 @@ function todayStr() {
     String(d.getDate()).padStart(2, '0');
 }
 
-function formatDateHeader() {
-  const d = new Date();
+// Parses a 'YYYY-MM-DD' string into a local Date. Avoids the day-shift that
+// `new Date('YYYY-MM-DD')` can cause in negative-UTC-offset timezones by
+// building the Date from local y/m/d components instead of UTC-parsing.
+function parseISODate(dateStr) {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+// Humanizes a date as "day-of-week day month" (e.g. "Пт 25 июл"), sourced
+// from the driver's current UI language (translations.js Proxy). Defaults to
+// today; pass any Date (e.g. via parseISODate) to format other days — used
+// for both the today header and the upcoming-deliveries date labels so a raw
+// ISO string never reaches the driver (#404).
+function formatDateHeader(date = new Date()) {
   const days = t.dayNamesShort;
   const months = t.monthNamesShort;
-  return `${days[d.getDay()]} ${d.getDate()} ${months[d.getMonth()]}`;
+  return `${days[date.getDay()]} ${date.getDate()} ${months[date.getMonth()]}`;
 }
 
 export default function DeliveryListPage() {
@@ -373,7 +385,7 @@ export default function DeliveryListPage() {
                 {Object.entries(upcomingByDate).map(([date, list]) => (
                   <div key={date} className="space-y-2 mb-4">
                     <p className="text-xs font-semibold text-ios-tertiary uppercase mt-2">
-                      {date} ({list.length})
+                      {formatDateHeader(parseISODate(date))} ({list.length})
                     </p>
                     {list.map(d => (
                       <DeliveryCard


### PR DESCRIPTION
## What

`DeliveryListPage.jsx`'s upcoming-deliveries section (the driver's main screen) rendered the raw `Delivery Date` key (`YYYY-MM-DD`) as the section label for tomorrow/future dates, while today's header used a humanized `formatDateHeader()` — "day-of-week day month" (e.g. "Пт 25 июл").

Fix: generalized `formatDateHeader(date = new Date())` to accept an optional date, and added `parseISODate(dateStr)` to turn a `'YYYY-MM-DD'` string into a local `Date` (built from y/m/d components, so it can't shift a day in any timezone via UTC-parsing). The upcoming-date section header now calls `formatDateHeader(parseISODate(date))` instead of printing the raw string — same `t.dayNamesShort` / `t.monthNamesShort` locale source as today's header, so it automatically follows the driver's language toggle (RU/EN).

No new label text was added, so no `translations.js` changes were needed.

## Why

Closes #404. Reported by a driver (Nikita) via the delivery app's feedback flow: the raw `YYYY-MM-DD` string for next-day deliveries looked like a bouquet/order number and caused confusion. The acceptance criteria call for the next-day date to match today's "Day Name, Day Number Month Name" format exactly.

## Scan for other raw-date leaks

Checked the rest of the delivery app's main-screen family (`DeliveryCard.jsx`, `DeliverySheet.jsx`, `MapView.jsx`, `StockPickupPage.jsx`) for other user-facing `YYYY-MM-DD` leaks:
- `Courier Time` / `Delivery Time` fields are `HH:MM` time strings, not dates — rendered as-is, not a leak.
- `deliveredAt` renders via `new Date(deliveredAt).toLocaleTimeString(...)` — time only, already humanized.
- `StockPickupPage.jsx` has no date-shaped strings rendered (only "Driver Status" fields matched the earlier grep for `date`, as a substring of "update").

No other leaks found — none deliberately left unfixed.

## Verification

```
$ cd apps/delivery && ./node_modules/.bin/vite build
vite v5.4.21 building for production...
transforming...
✓ 437 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                   0.89 kB │ gzip:  0.47 kB
dist/assets/index-CK9tRmGX.css   45.28 kB │ gzip:  8.34 kB
dist/assets/index-Bvb3gViK.js   267.38 kB │ gzip: 86.58 kB
✓ built in 1.05s
```

Single-file change scoped to `apps/delivery`, no backend/shared/lab touch — no other pre-PR matrix items apply.

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)