### PR TITLE
fix(stock): full flower-identity fields on add-line for sent/shopping POs

### DIFF
--- a/apps/dashboard/src/components/StockOrderPanel.jsx
+++ b/apps/dashboard/src/components/StockOrderPanel.jsx
@@ -309,16 +309,30 @@ export default function StockOrderPanel({ negativeStock, poSuggestions, stock, a
   // present up front (flower name, supplier, qty, cost). POSTs straight to
   // the backend; no "temp local line" that can silently vanish on refresh.
   // Returns true on success so the inline form can collapse itself.
-  async function addPersistedLine(orderId, { flowerName, supplier, quantity, costPrice, lotSize }) {
+  // Issue #550: identity now mirrors DraftLineEditor — either an existing
+  // Stock Item link (stockItemId) or a new-Variety Type/Colour/Size/Cultivar,
+  // in addition to a plain typed Flower Name. The backend endpoint already
+  // accepted all of these (see stockOrders.js POST /:id/lines) — only the
+  // frontend form was missing the fields.
+  async function addPersistedLine(orderId, {
+    flowerName, stockItemId, supplier, quantity, costPrice, sellPrice, lotSize,
+    type, colour, size, cultivar,
+  }) {
     try {
       const poStatus = orders.find(o => o.id === orderId)?.Status;
       const stems = Number(quantity) || 0;
       const created = await client.post(`/stock-orders/${orderId}/lines`, {
-        flowerName: flowerName.trim(),
-        supplier: supplier.trim(),
+        flowerName: (flowerName || '').trim(),
+        stockItemId: stockItemId || '',
+        supplier: (supplier || '').trim(),
         quantity: stems,
         costPrice: Number(costPrice) || 0,
+        sellPrice: Number(sellPrice) || 0,
         lotSize: Number(lotSize) || 0,
+        type: (type || '').trim(),
+        colour: (colour || '').trim(),
+        size: size ? Number(size) : null,
+        cultivar: (cultivar || '').trim(),
       });
       // If the PO is already in Shopping, the owner adds lines because the
       // flowers have been physically bought — mark Found All so the florist
@@ -790,10 +804,14 @@ export default function StockOrderPanel({ negativeStock, poSuggestions, stock, a
                         </button>
                       ) : (
                         // Sent/Shopping: off-plan flower, all fields required up front.
+                        // Full field set (issue #550) — Stock Item search +
+                        // new-Variety identity, same as DraftLineEditor.
                         <AddLineInlineForm
                           orderId={order.id}
                           onAdd={addPersistedLine}
                           suppliers={SUPPLIERS}
+                          stock={stock}
+                          targetMarkup={targetMarkup}
                           status={order.Status}
                         />
                       )}
@@ -1419,33 +1437,68 @@ function DraftLineEditor({ line, stock, onUpdate, onRemove, targetMarkup, suppli
 // the "qty" input means LOTS (total stems = lots × lot size); otherwise
 // qty is raw stems. Cost is explicitly per-stem with a live total preview
 // so the owner sees exactly what she's committing before submit.
-// All fields required up front; POST only fires on submit — no silent drops.
+// Flower identity mirrors DraftLineEditor too (issue #550): pick an existing
+// Stock Item via search (auto-fills cost/sell/lot size/supplier), or type a
+// new Variety's Type/Colour/Size/Cultivar when nothing is linked — the exact
+// same StockSearchInput + Variety-identity block DraftLineEditor already
+// uses, so a line added to a Sent/Shopping PO carries the same identity a
+// Draft-PO line would (repo pitfall #6: every PO line needs a Stock Item
+// link or a Flower Name). All fields required up front; POST only fires on
+// submit — no silent drops.
 // Sent/Shopping-only: an "off-plan" line bought at the supplier. Draft uses
 // the one-tap add button + DraftLineEditor instead — see the call site.
-function AddLineInlineForm({ orderId, onAdd, suppliers = [], status }) {
+function AddLineInlineForm({ orderId, onAdd, suppliers = [], stock, targetMarkup, status }) {
   const [open, setOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [form, setForm] = useState({
-    flowerName: '',
-    supplier: '',
-    lotSize: '',
-    qty: '',
-    costPerStem: '',
+    flowerName: '', stockItemId: '', supplier: '', lotSize: '', qty: '',
+    costPerStem: '', sellPerStem: '',
+    // Y-model new-Variety identity (#304) — populated when no stockItemId
+    type: '', colour: '', size: '', cultivar: '',
   });
 
   const lotSizeNum = Number(form.lotSize) || 0;
   const qtyNum = Number(form.qty) || 0;
   const costPerStemNum = Number(form.costPerStem) || 0;
+  const sellPerStemNum = Number(form.sellPerStem) || 0;
   const totalStems = lotSizeNum > 1 ? qtyNum * lotSizeNum : qtyNum;
   const totalCost = totalStems * costPerStemNum;
+  const computedMarkup = costPerStemNum > 0 && sellPerStemNum > 0 ? (sellPerStemNum / costPerStemNum).toFixed(1) : null;
+  const stockItemLinked = !!form.stockItemId;
 
   function reset() {
-    setForm({ flowerName: '', supplier: '', lotSize: '', qty: '', costPerStem: '' });
+    setForm({
+      flowerName: '', stockItemId: '', supplier: '', lotSize: '', qty: '',
+      costPerStem: '', sellPerStem: '', type: '', colour: '', size: '', cultivar: '',
+    });
     setOpen(false);
   }
 
+  // Picking an existing Stock Item auto-fills cost/sell/lot size/supplier and
+  // clears any in-progress new-Variety fields — mirrors DraftLineEditor's
+  // handleStockSelect exactly.
+  function handleStockSelect(item) {
+    const itemCost = Number(item['Current Cost Price']) || 0;
+    const itemSell = Number(item['Current Sell Price']) || 0;
+    const itemLotSize = Number(item['Lot Size']) || 0;
+    setForm(f => ({
+      ...f,
+      flowerName: item['Display Name'],
+      stockItemId: item.id,
+      supplier: item.Supplier || '',
+      costPerStem: itemCost > 0 ? String(itemCost) : '',
+      sellPerStem: itemSell > 0 ? String(itemSell) : (itemCost > 0 && targetMarkup ? String(Math.round(itemCost * targetMarkup)) : ''),
+      lotSize: itemLotSize > 0 ? String(itemLotSize) : '',
+      type: '', colour: '', size: '', cultivar: '',
+    }));
+  }
+
+  // Identity rule mirrors DraftLineEditor's isBlank check + the backend's own
+  // gate on POST /:id/lines (pitfall #6): a Stock Item link, an explicit
+  // Flower Name, or a new-Variety Type all count as identity.
+  const hasIdentity = !!(form.stockItemId || form.flowerName.trim() || form.type.trim());
   const ready =
-    form.flowerName.trim() &&
+    hasIdentity &&
     form.supplier.trim() &&
     totalStems > 0 &&
     costPerStemNum > 0;
@@ -1455,10 +1508,16 @@ function AddLineInlineForm({ orderId, onAdd, suppliers = [], status }) {
     setSubmitting(true);
     const ok = await onAdd(orderId, {
       flowerName: form.flowerName,
+      stockItemId: form.stockItemId,
       supplier: form.supplier,
       quantity: totalStems,
       costPrice: costPerStemNum,
+      sellPrice: sellPerStemNum,
       lotSize: lotSizeNum,
+      type: form.type,
+      colour: form.colour,
+      size: form.size,
+      cultivar: form.cultivar,
     });
     setSubmitting(false);
     if (ok) reset();
@@ -1478,12 +1537,11 @@ function AddLineInlineForm({ orderId, onAdd, suppliers = [], status }) {
   return (
     <div className="bg-brand-50/50 border border-brand-200 rounded-lg p-3 space-y-2">
       <p className="text-[11px] text-ios-tertiary">{t.addExtraHint}</p>
-      <input
-        type="text"
+      <StockSearchInput
+        stock={stock}
         value={form.flowerName}
-        onChange={e => setForm(f => ({ ...f, flowerName: e.target.value }))}
-        placeholder={t.flowerNameLabel || 'Flower name'}
-        className="field-input w-full text-sm"
+        onChange={name => setForm(f => ({ ...f, flowerName: name, stockItemId: '' }))}
+        onSelect={handleStockSelect}
       />
       <input
         type="text"
@@ -1496,6 +1554,31 @@ function AddLineInlineForm({ orderId, onAdd, suppliers = [], status }) {
       <datalist id={`sup-list-${orderId}`}>
         {suppliers.map(s => <option key={s} value={s} />)}
       </datalist>
+
+      {/* Variety identity — only when no Stock Item is linked. Same block as
+          DraftLineEditor's new-Variety row (issue #550). */}
+      {!stockItemLinked && (
+        <div className="rounded-lg border border-indigo-100 bg-indigo-50/40 p-2 space-y-1.5">
+          <p className="text-[10px] uppercase tracking-wide text-indigo-600 font-semibold">
+            {t.newVariety ?? 'New variety'}
+          </p>
+          <div className="grid grid-cols-4 gap-2">
+            <input type="text" value={form.type}
+              onChange={e => setForm(f => ({ ...f, type: e.target.value }))}
+              className="field-input text-sm py-1" placeholder={t.varietyType ?? 'Type *'} />
+            <input type="text" value={form.colour}
+              onChange={e => setForm(f => ({ ...f, colour: e.target.value }))}
+              className="field-input text-sm py-1" placeholder={t.varietyColour ?? 'Colour'} />
+            <input type="number" value={form.size}
+              onChange={e => setForm(f => ({ ...f, size: e.target.value }))}
+              className="field-input text-sm py-1" placeholder={t.varietySize ?? 'Size (cm)'} />
+            <input type="text" value={form.cultivar}
+              onChange={e => setForm(f => ({ ...f, cultivar: e.target.value }))}
+              className="field-input text-sm py-1" placeholder={t.varietyCultivar ?? 'Cultivar'} />
+          </div>
+        </div>
+      )}
+
       {/* Lot size · qty (lots when lotSize > 1) · cost per stem */}
       <div className="grid grid-cols-3 gap-2">
         <div>
@@ -1532,6 +1615,22 @@ function AddLineInlineForm({ orderId, onAdd, suppliers = [], status }) {
           />
         </div>
       </div>
+
+      {/* Sell price — optional, mirrors DraftLineEditor's markup badge */}
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1 flex-1">
+          <span className="text-[10px] text-ios-tertiary shrink-0">{t.sellPrice || 'Sell'}:</span>
+          <input type="number" step="0.01" value={form.sellPerStem}
+            onChange={e => setForm(f => ({ ...f, sellPerStem: e.target.value }))}
+            className="field-input w-full text-sm text-right py-1" placeholder="0" />
+        </div>
+        {computedMarkup && (
+          <span className={`text-[11px] font-medium px-1.5 py-0.5 rounded-full shrink-0 ${
+            Number(computedMarkup) >= targetMarkup ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700'
+          }`}>×{computedMarkup}</span>
+        )}
+      </div>
+
       {totalStems > 0 && (
         <div className="flex items-center justify-between bg-brand-50 rounded-lg px-3 py-1.5">
           <span className="text-xs text-brand-700">= {totalStems} {t.stems || 'stems'}</span>

--- a/apps/dashboard/src/components/StockOrderPanel.jsx
+++ b/apps/dashboard/src/components/StockOrderPanel.jsx
@@ -329,10 +329,10 @@ export default function StockOrderPanel({ negativeStock, poSuggestions, stock, a
         costPrice: Number(costPrice) || 0,
         sellPrice: Number(sellPrice) || 0,
         lotSize: Number(lotSize) || 0,
-        type: (type || '').trim(),
-        colour: (colour || '').trim(),
+        type: (type || '').trim() || null,
+        colour: (colour || '').trim() || null,
         size: size ? Number(size) : null,
-        cultivar: (cultivar || '').trim(),
+        cultivar: (cultivar || '').trim() || null,
       });
       // If the PO is already in Shopping, the owner adds lines because the
       // flowers have been physically bought — mark Found All so the florist
@@ -1507,7 +1507,10 @@ function AddLineInlineForm({ orderId, onAdd, suppliers = [], stock, targetMarkup
     if (!ready || submitting) return;
     setSubmitting(true);
     const ok = await onAdd(orderId, {
-      flowerName: form.flowerName,
+      // When the owner filled the new-Variety block, drop the free-typed search
+      // text so the backend composes the name from Type/Colour/Size/Cultivar —
+      // otherwise a partial search string ("peo") becomes the Variety name.
+      flowerName: form.type.trim() ? '' : form.flowerName,
       stockItemId: form.stockItemId,
       supplier: form.supplier,
       quantity: totalStems,

--- a/apps/florist/src/pages/PurchaseOrderPage.jsx
+++ b/apps/florist/src/pages/PurchaseOrderPage.jsx
@@ -316,10 +316,10 @@ export default function PurchaseOrderPage() {
         costPrice: Number(costPrice) || 0,
         sellPrice: Number(sellPrice) || 0,
         lotSize: Number(lotSize) || 0,
-        type: (type || '').trim(),
-        colour: (colour || '').trim(),
+        type: (type || '').trim() || null,
+        colour: (colour || '').trim() || null,
         size: size ? Number(size) : null,
-        cultivar: (cultivar || '').trim(),
+        cultivar: (cultivar || '').trim() || null,
       });
       // Lines added during Shopping are for flowers already physically bought,
       // so mark Found All and stamp Quantity Found so the florist can see them.
@@ -1191,7 +1191,10 @@ function AddLineInlineForm({ orderId, onAdd, suppliers = [], stock, targetMarkup
     if (!ready || submitting) return;
     setSubmitting(true);
     const ok = await onAdd(orderId, {
-      flowerName: form.flowerName,
+      // When the owner filled the new-Variety block, drop the free-typed search
+      // text so the backend composes the name from Type/Colour/Size/Cultivar —
+      // otherwise a partial search string ("peo") becomes the Variety name.
+      flowerName: form.type.trim() ? '' : form.flowerName,
       stockItemId: form.stockItemId,
       supplier: form.supplier,
       quantity: totalStems,

--- a/apps/florist/src/pages/PurchaseOrderPage.jsx
+++ b/apps/florist/src/pages/PurchaseOrderPage.jsx
@@ -296,16 +296,30 @@ export default function PurchaseOrderPage() {
   // the line is persisted immediately. Returns true on success so the inline
   // form can collapse. Supersedes the old temp-local-line pattern which could
   // silently drop the line if the owner didn't enter a flower name.
-  async function addPersistedLine(orderId, { flowerName, supplier, quantity, costPrice, lotSize }) {
+  // Issue #550: identity now mirrors DraftLineEditor — either an existing
+  // Stock Item link (stockItemId) or a new-Variety Type/Colour/Size/Cultivar,
+  // in addition to a plain typed Flower Name. The backend endpoint already
+  // accepted all of these (see stockOrders.js POST /:id/lines) — only the
+  // frontend form was missing the fields.
+  async function addPersistedLine(orderId, {
+    flowerName, stockItemId, supplier, quantity, costPrice, sellPrice, lotSize,
+    type, colour, size, cultivar,
+  }) {
     try {
       const poStatus = orders.find(o => o.id === orderId)?.Status;
       const stems = Number(quantity) || 0;
       const created = await client.post(`/stock-orders/${orderId}/lines`, {
-        flowerName: flowerName.trim(),
-        supplier: supplier.trim(),
+        flowerName: (flowerName || '').trim(),
+        stockItemId: stockItemId || '',
+        supplier: (supplier || '').trim(),
         quantity: stems,
         costPrice: Number(costPrice) || 0,
+        sellPrice: Number(sellPrice) || 0,
         lotSize: Number(lotSize) || 0,
+        type: (type || '').trim(),
+        colour: (colour || '').trim(),
+        size: size ? Number(size) : null,
+        cultivar: (cultivar || '').trim(),
       });
       // Lines added during Shopping are for flowers already physically bought,
       // so mark Found All and stamp Quantity Found so the florist can see them.
@@ -688,10 +702,14 @@ export default function PurchaseOrderPage() {
                           </button>
                         ) : (
                           // Sent/Shopping: off-plan flower, all fields required up front.
+                          // Full field set (issue #550) — Stock Item search +
+                          // new-Variety identity, same as DraftLineEditor.
                           <AddLineInlineForm
                             orderId={order.id}
                             onAdd={addPersistedLine}
                             suppliers={SUPPLIERS}
+                            stock={stock}
+                            targetMarkup={targetMarkup}
                             status={order.Status}
                           />
                         )}
@@ -1103,33 +1121,68 @@ function DraftLineEditor({ line, stock, onUpdate, onRemove, targetMarkup, suppli
 // Same logic as the DraftLineEditor qty/lotSize handling: when lot size > 1
 // the "qty" field means LOTS and total stems = lots × lot size; otherwise
 // qty is raw stems. Cost is explicitly per-stem with a live total preview.
-// All fields required up front; POST only fires on submit — no silent drops.
+// Flower identity mirrors DraftLineEditor (issue #550): pick an existing
+// Stock Item via search (auto-fills cost/sell/lot size/supplier), or type a
+// new Variety's Type/Colour/Size/Cultivar when nothing is linked — the exact
+// same StockSearchInput + Variety-identity block DraftLineEditor already
+// uses, so a line added to a Sent/Shopping PO carries the same identity a
+// Draft-PO line would (repo pitfall #6: every PO line needs a Stock Item
+// link or a Flower Name). All fields required up front; POST only fires on
+// submit — no silent drops.
 // Sent/Shopping-only: an "off-plan" line bought at the supplier. Draft uses
 // the one-tap add button + DraftLineEditor instead — see the call site.
-function AddLineInlineForm({ orderId, onAdd, suppliers = [], status }) {
+function AddLineInlineForm({ orderId, onAdd, suppliers = [], stock, targetMarkup, status }) {
   const [open, setOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [form, setForm] = useState({
-    flowerName: '',
-    supplier: '',
-    lotSize: '',
-    qty: '',
-    costPerStem: '',
+    flowerName: '', stockItemId: '', supplier: '', lotSize: '', qty: '',
+    costPerStem: '', sellPerStem: '',
+    // Y-model new-Variety identity (#304) — populated when no stockItemId
+    type: '', colour: '', size: '', cultivar: '',
   });
 
   const lotSizeNum = Number(form.lotSize) || 0;
   const qtyNum = Number(form.qty) || 0;
   const costPerStemNum = Number(form.costPerStem) || 0;
+  const sellPerStemNum = Number(form.sellPerStem) || 0;
   const totalStems = lotSizeNum > 1 ? qtyNum * lotSizeNum : qtyNum;
   const totalCost = totalStems * costPerStemNum;
+  const computedMarkup = costPerStemNum > 0 && sellPerStemNum > 0 ? (sellPerStemNum / costPerStemNum).toFixed(1) : null;
+  const stockItemLinked = !!form.stockItemId;
 
   function reset() {
-    setForm({ flowerName: '', supplier: '', lotSize: '', qty: '', costPerStem: '' });
+    setForm({
+      flowerName: '', stockItemId: '', supplier: '', lotSize: '', qty: '',
+      costPerStem: '', sellPerStem: '', type: '', colour: '', size: '', cultivar: '',
+    });
     setOpen(false);
   }
 
+  // Picking an existing Stock Item auto-fills cost/sell/lot size/supplier and
+  // clears any in-progress new-Variety fields — mirrors DraftLineEditor's
+  // handleStockSelect exactly.
+  function handleStockSelect(item) {
+    const itemCost = Number(item['Current Cost Price']) || 0;
+    const itemSell = Number(item['Current Sell Price']) || 0;
+    const itemLotSize = Number(item['Lot Size']) || 0;
+    setForm(f => ({
+      ...f,
+      flowerName: item['Display Name'],
+      stockItemId: item.id,
+      supplier: item.Supplier || '',
+      costPerStem: itemCost > 0 ? String(itemCost) : '',
+      sellPerStem: itemSell > 0 ? String(itemSell) : (itemCost > 0 && targetMarkup ? String(Math.round(itemCost * targetMarkup)) : ''),
+      lotSize: itemLotSize > 0 ? String(itemLotSize) : '',
+      type: '', colour: '', size: '', cultivar: '',
+    }));
+  }
+
+  // Identity rule mirrors DraftLineEditor's isBlank check + the backend's own
+  // gate on POST /:id/lines (pitfall #6): a Stock Item link, an explicit
+  // Flower Name, or a new-Variety Type all count as identity.
+  const hasIdentity = !!(form.stockItemId || form.flowerName.trim() || form.type.trim());
   const ready =
-    form.flowerName.trim() &&
+    hasIdentity &&
     form.supplier.trim() &&
     totalStems > 0 &&
     costPerStemNum > 0;
@@ -1139,10 +1192,16 @@ function AddLineInlineForm({ orderId, onAdd, suppliers = [], status }) {
     setSubmitting(true);
     const ok = await onAdd(orderId, {
       flowerName: form.flowerName,
+      stockItemId: form.stockItemId,
       supplier: form.supplier,
       quantity: totalStems,
       costPrice: costPerStemNum,
+      sellPrice: sellPerStemNum,
       lotSize: lotSizeNum,
+      type: form.type,
+      colour: form.colour,
+      size: form.size,
+      cultivar: form.cultivar,
     });
     setSubmitting(false);
     if (ok) reset();
@@ -1162,12 +1221,11 @@ function AddLineInlineForm({ orderId, onAdd, suppliers = [], status }) {
   return (
     <div className="bg-brand-50/50 border border-brand-200 rounded-xl p-3 space-y-2">
       <p className="text-[11px] text-ios-tertiary">{t.shopping?.addExtraHint}</p>
-      <input
-        type="text"
+      <StockSearchInput
+        stock={stock}
         value={form.flowerName}
-        onChange={e => setForm(f => ({ ...f, flowerName: e.target.value }))}
-        placeholder={t.shopping?.flowerName || 'Flower name'}
-        className="field-input w-full text-sm"
+        onChange={name => setForm(f => ({ ...f, flowerName: name, stockItemId: '' }))}
+        onSelect={handleStockSelect}
       />
       <input
         type="text"
@@ -1180,6 +1238,31 @@ function AddLineInlineForm({ orderId, onAdd, suppliers = [], status }) {
       <datalist id={`po-sup-${orderId}`}>
         {suppliers.map(s => <option key={s} value={s} />)}
       </datalist>
+
+      {/* Variety identity — only when no Stock Item is linked. Same block as
+          DraftLineEditor's new-Variety row (issue #550). */}
+      {!stockItemLinked && (
+        <div className="rounded-xl border border-indigo-100 bg-indigo-50/40 p-2 space-y-1.5">
+          <p className="text-[10px] uppercase tracking-wide text-indigo-600 font-semibold">
+            {t.po?.newVariety ?? 'New variety'}
+          </p>
+          <div className="grid grid-cols-2 gap-2">
+            <input type="text" value={form.type}
+              onChange={e => setForm(f => ({ ...f, type: e.target.value }))}
+              className="field-input text-sm py-1" placeholder={t.po?.type ?? 'Type *'} />
+            <input type="text" value={form.colour}
+              onChange={e => setForm(f => ({ ...f, colour: e.target.value }))}
+              className="field-input text-sm py-1" placeholder={t.po?.colour ?? 'Colour'} />
+            <input type="number" value={form.size}
+              onChange={e => setForm(f => ({ ...f, size: e.target.value }))}
+              className="field-input text-sm py-1" placeholder={t.po?.size ?? 'Size (cm)'} />
+            <input type="text" value={form.cultivar}
+              onChange={e => setForm(f => ({ ...f, cultivar: e.target.value }))}
+              className="field-input text-sm py-1" placeholder={t.po?.cultivar ?? 'Cultivar'} />
+          </div>
+        </div>
+      )}
+
       {/* Lot size + qty + cost/stem — qty auto-means lots when lotSize > 1 */}
       <div className="grid grid-cols-3 gap-2">
         <div>
@@ -1216,6 +1299,22 @@ function AddLineInlineForm({ orderId, onAdd, suppliers = [], status }) {
           />
         </div>
       </div>
+
+      {/* Sell price — optional, mirrors DraftLineEditor's markup badge */}
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1 flex-1">
+          <span className="text-[10px] text-ios-tertiary shrink-0">{t.sellPrice || 'Sell'}:</span>
+          <input type="number" step="0.01" value={form.sellPerStem}
+            onChange={e => setForm(f => ({ ...f, sellPerStem: e.target.value }))}
+            className="field-input w-full text-sm text-right py-1" placeholder="0" />
+        </div>
+        {computedMarkup && (
+          <span className={`text-[11px] font-medium px-1.5 py-0.5 rounded-full shrink-0 ${
+            Number(computedMarkup) >= targetMarkup ? 'bg-emerald-100 text-emerald-700' : 'bg-amber-100 text-amber-700'
+          }`}>×{computedMarkup}</span>
+        )}
+      </div>
+
       {totalStems > 0 && (
         <div className="flex items-center justify-between bg-brand-50 rounded-lg px-3 py-1.5">
           <span className="text-xs text-brand-700">= {totalStems} {t.stems}</span>

--- a/backend/src/__tests__/stockOrders.addLineIdentity.integration.test.js
+++ b/backend/src/__tests__/stockOrders.addLineIdentity.integration.test.js
@@ -1,0 +1,169 @@
+// Regression tests for issue #550 — "cannot select flower details when adding
+// to a sent Stock Order". The owner reported that adding a line to a PO that
+// had already been sent to a driver only let her fill quantity + lot size —
+// no flower type, size, variety, or Stock Item link.
+//
+// Root cause: this was a FRONTEND-only gap. `POST /:id/lines` below already
+// accepted `stockItemId` and the Y-model new-Variety `type/colour/size/
+// cultivar` fields for any editable-status PO (Draft/Sent/Shopping) — the
+// reduced `AddLineInlineForm` component (florist PurchaseOrderPage.jsx /
+// dashboard StockOrderPanel.jsx) just never sent them. The fix widened that
+// form to match `DraftLineEditor`'s field set; the backend contract these
+// tests lock in was already correct and required NO changes. These tests
+// exist so a future refactor of this endpoint can't silently narrow it back
+// down to "Draft only", and so the Variety-attrs-survive-to-Batch guarantee
+// (pitfall #9 / batch-variety-attrs, #327) is proven for a line added AFTER
+// send, not just at Draft-time (already covered by
+// stockOrders.receiveIntoStock.integration.test.js for the Draft path).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../services/driverNotifyService.js', () => ({
+  notifyDeliveryAssigned: vi.fn().mockResolvedValue(undefined),
+  notifyDeliveryDigest:   vi.fn().mockResolvedValue(undefined),
+  notifyPoAssigned:       vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../services/notifications.js', () => ({ broadcast: vi.fn() }));
+vi.mock('../services/orderService.js', () => ({
+  createOrder: vi.fn(),
+  autoMatchStock: vi.fn(),
+  findOrdersNeedingSubstitution: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('../services/configService.js', () => ({
+  getConfig:      vi.fn((k) => ({ targetMarkup: 2.5 }[k] ?? 0)),
+  getDriverOfDay: () => 'Timur',
+  getActiveSeasonalCategory: () => null,
+}));
+
+import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
+import express from 'express';
+import supertest from 'supertest';
+import { stock } from '../db/schema.js';
+import { eq, and } from 'drizzle-orm';
+
+const dbHolder = { db: null };
+vi.mock('../db/index.js', () => ({
+  get db() { return dbHolder.db; },
+  isPostgresConfigured: true,
+  pool: null,
+  connectPostgres: async () => {},
+  disconnectPostgres: async () => {},
+}));
+
+import stockOrdersRouter from '../routes/stockOrders.js';
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => { req.role = 'owner'; next(); });
+  app.use('/api/stock-orders', stockOrdersRouter);
+  app.use((err, _req, res, _next) => res.status(err.statusCode || 500).json({ error: err.message }));
+  return app;
+}
+
+let harness, app;
+const agent = () => supertest(app);
+
+beforeEach(async () => {
+  harness = await setupPgHarness();
+  dbHolder.db = harness.db;
+  vi.clearAllMocks();
+  app = buildApp();
+});
+afterEach(async () => {
+  await teardownPgHarness(harness);
+  dbHolder.db = null;
+});
+
+// Create a Draft PO with one seed line (so /send has a valid identity to
+// check) and immediately send it to a driver.
+async function createSentPO() {
+  const created = await agent().post('/api/stock-orders').send({
+    notes: '#550-regression',
+    lines: [{ flowerName: 'Seed Line', quantity: 1, costPrice: 1 }],
+  });
+  expect(created.status).toBe(201);
+  const poId = created.body.id;
+  const sent = await agent().post(`/api/stock-orders/${poId}/send`).send({ driverName: 'Timur' });
+  expect(sent.status).toBe(200);
+  expect(sent.body.Status).toBe('Sent');
+  return poId;
+}
+
+describe('POST /stock-orders/:id/lines — post-send identity (#550)', () => {
+  it('accepts a new-Variety line (Type/Colour/Size/Cultivar, no Flower Name) on a Sent PO', async () => {
+    const poId = await createSentPO();
+
+    const added = await agent().post(`/api/stock-orders/${poId}/lines`).send({
+      type: 'Tulip', colour: 'Yellow', size: 40, cultivar: null,
+      quantity: 20, costPrice: 3, supplier: 'Stefan',
+    });
+
+    expect(added.status).toBe(200);
+    expect(added.body.Type).toBe('Tulip');
+    expect(added.body.Colour).toBe('Yellow');
+    expect(added.body.Size).toBe(40);
+    expect(String(added.body['Flower Name'] || '').trim()).not.toBe('');
+    expect(added.body['Quantity Needed']).toBe(20);
+  });
+
+  it('accepts an existing Stock Item link on a Sent PO', async () => {
+    const [item] = await harness.db.insert(stock).values({
+      displayName: 'Rose Red', purchaseName: 'Rose Red', currentQuantity: 0, active: true,
+    }).returning();
+    const poId = await createSentPO();
+
+    const added = await agent().post(`/api/stock-orders/${poId}/lines`).send({
+      stockItemId: item.id, flowerName: 'Rose Red', quantity: 10, costPrice: 4, supplier: 'Stefan',
+    });
+
+    expect(added.status).toBe(200);
+    expect(added.body['Stock Item']).toEqual([item.id]);
+    expect(added.body['Flower Name']).toBe('Rose Red');
+  });
+
+  it('still rejects a genuinely blank line (no stock item, no name, no Type) on a Sent PO', async () => {
+    const poId = await createSentPO();
+
+    const added = await agent().post(`/api/stock-orders/${poId}/lines`).send({
+      quantity: 5, costPrice: 3, supplier: 'Stefan',
+    });
+
+    expect(added.status).toBe(400);
+    expect(added.body.error).toMatch(/stock item or flower name/i);
+  });
+
+  it('a new-Variety line added AFTER send carries its attrs onto the received Batch (pitfall #9)', async () => {
+    const poId = await createSentPO();
+    const added = await agent().post(`/api/stock-orders/${poId}/lines`).send({
+      type: 'Peony', colour: 'Pink', size: 55, cultivar: 'Sarah Bernhardt',
+      quantity: 12, costPrice: 8, sellPrice: 20, supplier: 'Stefan',
+    });
+    expect(added.status).toBe(200);
+    const lineId = added.body.id;
+
+    // Progress the PO to Evaluating (Sent → Reviewing is a direct allowed
+    // transition — no need to hop through Shopping for this test).
+    await agent().patch(`/api/stock-orders/${poId}`).send({ Status: 'Reviewing' });
+    await agent().patch(`/api/stock-orders/${poId}/lines/${lineId}`).send({ 'Quantity Found': 12 });
+    const approved = await agent().post(`/api/stock-orders/${poId}/approve-review`);
+    expect(approved.status).toBe(200);
+
+    const evaluated = await agent().post(`/api/stock-orders/${poId}/evaluate`).send({
+      lines: [{ lineId, quantityAccepted: 12, writeOffQty: 0 }],
+    });
+    expect(evaluated.status).toBe(200);
+    expect(evaluated.body.success).toBe(true);
+
+    // Two stock rows now carry these Variety attrs: the auto-created
+    // qty-0 template (linked at evaluate time) and the new dated Batch that
+    // actually received the 12 accepted stems. Find the Batch by quantity.
+    const rows = await harness.db.select().from(stock).where(
+      and(eq(stock.typeName, 'Peony'), eq(stock.colour, 'Pink'), eq(stock.sizeCm, 55)),
+    );
+    const batchRow = rows.find(r => r.currentQuantity === 12);
+    expect(batchRow, 'received Batch should exist and carry the line Variety attrs').toBeDefined();
+    expect(batchRow.cultivar).toBe('Sarah Bernhardt');
+    expect(batchRow.displayName).toMatch(/^Peony Pink 55cm Sarah Bernhardt \(\d{1,2}\.\w{3,4}\.\)$/);
+  });
+});


### PR DESCRIPTION
## What

Adding a Stock Item to a Purchase Order that has already been **Sent** or is in **Shopping** only exposed *quantity* and *lot size* in the add-line form — flower type, size, variety, and Stock Item search were missing, unlike the pre-send Draft form (`DraftLineEditor`). This blocked full flower specification on in-transit POs.

Fixed in both apps by widening `AddLineInlineForm` (florist `PurchaseOrderPage.jsx`, dashboard `StockOrderPanel.jsx`) to carry the same identity fields as `DraftLineEditor`:
- `StockSearchInput` to pick an existing Stock Item (auto-fills cost/sell/lot size/supplier), same component `DraftLineEditor` already uses.
- The same new-Variety `Type/Colour/Size/Cultivar` block, shown only when no Stock Item is linked (repo pitfall #6 — a PO line needs a Stock Item link or a Flower Name).
- Sell price + markup badge, for full field parity with the pre-send form.
- `qty` × `lotSize` semantics are **untouched** (still lots-when-lotSize>1, same as `DraftLineEditor`) — the New-PO form's separate Qty/Pkgs override was deliberately NOT imported into this editor.

`addPersistedLine` in both apps now forwards `stockItemId`, `sellPrice`, `type`, `colour`, `size`, `cultivar` to `POST /stock-orders/:id/lines` in addition to the existing fields.

## Root cause

Purely a **frontend** gap. `POST /stock-orders/:id/lines` (`backend/src/routes/stockOrders.js:343-397`) already accepted `stockItemId` and the Y-model `type/colour/size/cultivar` fields for **any** editable-status PO (`Draft`/`Sent`/`Shopping` — `EDITABLE_PO_STATUSES`), with the exact same new-Variety-intent handling as the Draft-PO create path. `stockOrderRepo.createLine`/`updateLine` already map `Type/Colour/Size/Cultivar` to the `stock_order_lines` schema columns, and `evaluatePurchaseOrder` → `receiveIntoStock` already reads those attrs straight off the line regardless of when/how it was created — so pitfall #9 (batch-variety-attrs) was never at risk. Only the reduced `AddLineInlineForm` component never sent these fields. No backend code changes were needed — confirmed by 4 new regression tests (see Verification) that pass against the **unmodified** endpoint.

## Verification

- `cd backend && npx vitest run --no-file-parallelism` → **111 files / 996 tests passed**, including the new `backend/src/__tests__/stockOrders.addLineIdentity.integration.test.js` (4 tests: new-Variety line added to a Sent PO persists Type/Colour/Size + composed Flower Name; an existing Stock Item link is accepted; a genuinely blank line is still rejected with 400; a line added *after* send carries its Variety attrs all the way onto the received Batch at evaluate time — pitfall #9 closed for the post-send path specifically, not just Draft-created lines).
- `cd apps/florist && ./node_modules/.bin/vite build` → clean build (2184 modules, no errors).
- `cd apps/dashboard && ./node_modules/.bin/vite build` → clean build (1276 modules, no errors).
- All new UI strings reuse **existing** translation keys already exercised by `DraftLineEditor` (`t.po.type/colour/size/cultivar/newVariety` florist, `t.varietyType/varietyColour/varietySize/varietyCultivar/newVariety` dashboard, plus `t.sellPrice`) — both `en` and `ru` blocks already had every key, so no translation-file changes were needed.
- Live browser click-through was attempted against the pglite harness but the shared Browser pane in this environment was being used by another concurrent session (tabs kept jumping to a different app's origin); abandoned in favor of the task's explicitly-required checks above, all green.

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)