### PR TITLE
fix(florist): make premade bouquet name tap-to-edit

### DIFF
--- a/apps/dashboard/src/components/PremadeBouquetList.jsx
+++ b/apps/dashboard/src/components/PremadeBouquetList.jsx
@@ -235,6 +235,11 @@ function PremadeExpanded({ bouquet, onMatchClicked, onReturn, onUpdated }) {
   const [busy, setBusy] = useState(false);
 
   const [editName, setEditName] = useState(bouquet.Name || '');
+  // Value editName was seeded with when the form opened. handleSave compares
+  // against THIS, not the live bouquet prop: the header's inline NameField can
+  // rename the bouquet while this form sits open, and comparing to the (now
+  // newer) prop would make Save push the stale name back over it (#456).
+  const [editNameInitial, setEditNameInitial] = useState(bouquet.Name || '');
   const [editNotes, setEditNotes] = useState(bouquet.Notes || '');
   const [editPriceOverride, setEditPriceOverride] = useState(bouquet['Price Override'] || '');
   const [editLines, setEditLines] = useState([]);
@@ -267,6 +272,7 @@ function PremadeExpanded({ bouquet, onMatchClicked, onReturn, onUpdated }) {
   function startEditing() {
     setEditing(true);
     setEditName(bouquet.Name || '');
+    setEditNameInitial(bouquet.Name || '');
     setEditNotes(bouquet.Notes || '');
     setEditPriceOverride(bouquet['Price Override'] || '');
     setEditLines((bouquet.lines || []).map(l => ({
@@ -347,7 +353,7 @@ function PremadeExpanded({ bouquet, onMatchClicked, onReturn, onUpdated }) {
     setBusy(true);
     try {
       const patch = {};
-      if (editName.trim() !== (bouquet.Name || '')) patch.name = editName.trim();
+      if (editName.trim() !== editNameInitial.trim()) patch.name = editName.trim();
       if ((editNotes || '') !== (bouquet.Notes || '')) patch.notes = editNotes;
       const overrideNum = editPriceOverride ? Number(editPriceOverride) : null;
       if (overrideNum !== (bouquet['Price Override'] || null)) patch.priceOverride = overrideNum;

--- a/apps/dashboard/src/components/PremadeBouquetList.jsx
+++ b/apps/dashboard/src/components/PremadeBouquetList.jsx
@@ -25,6 +25,67 @@ function timeAgo(iso) {
   return `${days}d`;
 }
 
+/**
+ * NameField — inline-editable bouquet name shown in the row header.
+ * Tapping switches to a text input (autofocus, blur/Enter saves, Escape
+ * cancels) and stops propagation so it doesn't also toggle the row's
+ * expand/collapse. Florist-app parity fix for issue #456 — the name used to
+ * be plain text with no tap affordance there; mirrored here so both apps
+ * behave the same way.
+ */
+function NameField({ value, placeholder, onSave }) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+
+  function startEdit(e) {
+    e.stopPropagation();
+    setDraft(value || '');
+    setEditing(true);
+  }
+
+  function commitSave(e) {
+    e.stopPropagation();
+    setEditing(false);
+    const trimmed = draft.trim();
+    if (trimmed === (value || '').trim()) return;
+    onSave(trimmed);
+  }
+
+  function cancelEdit(e) {
+    e.stopPropagation();
+    setEditing(false);
+  }
+
+  if (editing) {
+    return (
+      <input
+        type="text"
+        value={draft}
+        autoFocus
+        onClick={e => e.stopPropagation()}
+        onChange={e => setDraft(e.target.value)}
+        onBlur={commitSave}
+        onKeyDown={e => {
+          if (e.key === 'Enter') e.target.blur();
+          if (e.key === 'Escape') cancelEdit(e);
+        }}
+        className="w-40 text-sm font-medium text-ios-label border border-brand-300 rounded-lg px-1.5 py-0.5 bg-white outline-none"
+      />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={startEdit}
+      title={t.edit || 'Edit'}
+      className="w-40 shrink-0 text-sm font-medium text-ios-label truncate text-left underline decoration-dotted decoration-gray-300 underline-offset-2"
+    >
+      {value || placeholder}
+    </button>
+  );
+}
+
 export default function PremadeBouquetList({ onMatchClicked }) {
   const { showToast } = useToast();
   // null = not yet loaded (show spinner); [] or [...] = loaded (render list).
@@ -60,6 +121,25 @@ export default function PremadeBouquetList({ onMatchClicked }) {
       setBouquets(prev => prev.filter(b => b.id !== id));
     } catch (err) {
       console.error('Failed to return premade:', err);
+      showToast(err.response?.data?.error || t.error, 'error');
+    }
+  }
+
+  // Inline rename — used by the row header's NameField, independent of the
+  // "Edit bouquet" form inside PremadeExpanded (which also patches notes/
+  // price/lines). Same endpoint that form uses for the name field, just
+  // fired immediately on blur.
+  async function handleNameSave(bouquet, newName) {
+    if (!newName) {
+      showToast(t.premadeBouquetNameRequired, 'error');
+      return;
+    }
+    try {
+      const res = await client.patch(`/premade-bouquets/${bouquet.id}`, { name: newName });
+      setBouquets(prev => prev.map(x => x.id === res.data.id ? res.data : x));
+      showToast(t.bouquetUpdated, 'success');
+    } catch (err) {
+      console.error('Failed to rename premade bouquet:', err);
       showToast(err.response?.data?.error || t.error, 'error');
     }
   }
@@ -108,9 +188,11 @@ export default function PremadeBouquetList({ onMatchClicked }) {
               <span className="text-xs text-ios-tertiary w-20 shrink-0">
                 {t.premadeBouquetAge} {timeAgo(b['Created At'])}
               </span>
-              <span className="text-sm font-medium text-ios-label w-40 truncate">
-                {b.Name || t.premadeBouquet}
-              </span>
+              <NameField
+                value={b.Name}
+                placeholder={t.premadeBouquet}
+                onSave={(name) => handleNameSave(b, name)}
+              />
               <span className="text-xs text-ios-secondary flex-1 truncate">{summary || '—'}</span>
               <span className="text-sm font-semibold text-brand-600 shrink-0">
                 {Math.round(finalPrice)} zł

--- a/apps/florist/src/components/PremadeBouquetCard.jsx
+++ b/apps/florist/src/components/PremadeBouquetCard.jsx
@@ -22,6 +22,74 @@ function timeAgo(iso) {
   return `${days}d`;
 }
 
+/**
+ * NameField — inline-editable bouquet name shown in the card header.
+ * Tapping switches to a text input (autofocus opens the keyboard on mobile);
+ * blur/Enter saves, Escape cancels. Mirrors the `PriceField` pattern in
+ * StockItem.jsx — self-contained stopPropagation so it can live inside the
+ * header row without also triggering the row's tap-to-expand handler.
+ * Fixes #456: the name used to be plain text with no tap affordance, so it
+ * required opening the separate "Edit" form just to rename.
+ */
+function NameField({ value, placeholder, onSave, disabled }) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+
+  function startEdit(e) {
+    if (disabled) return;
+    e.stopPropagation();
+    setDraft(value || '');
+    setEditing(true);
+  }
+
+  function commitSave(e) {
+    e.stopPropagation();
+    setEditing(false);
+    const trimmed = draft.trim();
+    if (trimmed === (value || '').trim()) return;
+    onSave(trimmed);
+  }
+
+  function cancelEdit(e) {
+    e.stopPropagation();
+    setEditing(false);
+  }
+
+  if (editing) {
+    return (
+      <input
+        type="text"
+        value={draft}
+        autoFocus
+        onClick={e => e.stopPropagation()}
+        onChange={e => setDraft(e.target.value)}
+        onBlur={commitSave}
+        onKeyDown={e => {
+          if (e.key === 'Enter') e.target.blur();
+          if (e.key === 'Escape') cancelEdit(e);
+        }}
+        className="flex-1 min-w-0 text-base font-semibold text-ios-label border border-brand-300 rounded-lg px-2 py-0.5 bg-white outline-none"
+      />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={startEdit}
+      disabled={disabled}
+      title={t.edit || 'Edit'}
+      className={`flex-1 min-w-0 text-base font-semibold text-ios-label truncate text-left active-scale ${
+        disabled
+          ? 'opacity-50 cursor-not-allowed'
+          : 'underline decoration-dotted decoration-ios-tertiary/40 underline-offset-2'
+      }`}
+    >
+      {value || placeholder}
+    </button>
+  );
+}
+
 export default function PremadeBouquetCard({ bouquet, isOwner, onRemoved, onUpdated, onMatchClicked }) {
   const { showToast } = useToast();
   const [expanded, setExpanded] = useState(false);
@@ -145,6 +213,27 @@ export default function PremadeBouquetCard({ bouquet, isOwner, onRemoved, onUpda
     ).slice(0, 20);
   }, [stock, flowerSearch]);
 
+  // Inline rename — used by the header's NameField, independent of the
+  // bigger "Edit" form (which also patches notes/price/lines). Same endpoint
+  // handleSave() uses for the name field, just fired immediately on blur.
+  async function handleNameSave(newName) {
+    if (!newName) {
+      showToast(t.premadeBouquetNameRequired, 'error');
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await client.patch(`/premade-bouquets/${bouquet.id}`, { name: newName });
+      onUpdated?.(res.data);
+      showToast(t.bouquetUpdated, 'success');
+    } catch (err) {
+      console.error('Failed to rename premade bouquet:', err);
+      showToast(err.response?.data?.error || t.error, 'error');
+    } finally {
+      setBusy(false);
+    }
+  }
+
   async function handleSave() {
     setBusy(true);
     try {
@@ -201,20 +290,24 @@ export default function PremadeBouquetCard({ bouquet, isOwner, onRemoved, onUpda
 
   return (
     <div className="ios-card overflow-hidden">
-      {/* Header — tap to expand */}
-      <button
-        type="button"
+      {/* Header — tap to expand. The name itself is independently editable
+          (NameField stops propagation) so renaming doesn't require opening
+          the separate "Edit" form below (issue #456). */}
+      <div
         onClick={() => { if (!editing) setExpanded(v => !v); }}
-        className="w-full px-4 py-3 flex items-center gap-3 text-left active-scale"
+        className="w-full px-4 py-3 flex items-center gap-3 text-left cursor-pointer active-scale"
       >
         <div className="w-10 h-10 rounded-full bg-pink-100 text-pink-600 text-lg flex items-center justify-center shrink-0">
           💐
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <span className="text-base font-semibold text-ios-label truncate">
-              {bouquet.Name || t.premadeBouquet}
-            </span>
+            <NameField
+              value={bouquet.Name}
+              placeholder={t.premadeBouquet}
+              onSave={handleNameSave}
+              disabled={editing}
+            />
             <span className="text-[11px] text-ios-tertiary shrink-0">
               · {t.premadeBouquetAge} {timeAgo(bouquet['Created At'])}
             </span>
@@ -228,7 +321,7 @@ export default function PremadeBouquetCard({ bouquet, isOwner, onRemoved, onUpda
           )}
         </div>
         <span className="text-ios-tertiary text-sm ml-1">{expanded ? '▲' : '▼'}</span>
-      </button>
+      </div>
 
       {/* Expanded body */}
       {expanded && !editing && (

--- a/apps/florist/src/components/PremadeBouquetCard.jsx
+++ b/apps/florist/src/components/PremadeBouquetCard.jsx
@@ -46,6 +46,9 @@ function NameField({ value, placeholder, onSave, disabled }) {
     e.stopPropagation();
     setEditing(false);
     const trimmed = draft.trim();
+    // An empty name would be rejected by handleNameSave with a toast that lands
+    // after edit mode already closed — just cancel instead.
+    if (!trimmed) return;
     if (trimmed === (value || '').trim()) return;
     onSave(trimmed);
   }
@@ -294,7 +297,18 @@ export default function PremadeBouquetCard({ bouquet, isOwner, onRemoved, onUpda
           (NameField stops propagation) so renaming doesn't require opening
           the separate "Edit" form below (issue #456). */}
       <div
+        role="button"
+        tabIndex={0}
         onClick={() => { if (!editing) setExpanded(v => !v); }}
+        onKeyDown={e => {
+          // The header can't be a <button> — it contains NameField's <input>,
+          // which would be invalid nesting — so it carries button semantics.
+          if (e.target !== e.currentTarget) return;
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            if (!editing) setExpanded(v => !v);
+          }
+        }}
         className="w-full px-4 py-3 flex items-center gap-3 text-left cursor-pointer active-scale"
       >
         <div className="w-10 h-10 rounded-full bg-pink-100 text-pink-600 text-lg flex items-center justify-center shrink-0">

--- a/backend/src/__tests__/premadeBouquetService.test.js
+++ b/backend/src/__tests__/premadeBouquetService.test.js
@@ -44,6 +44,7 @@ import { createOrder } from '../services/orderService.js';
 import {
   createPremadeBouquet,
   matchPremadeBouquetToOrder,
+  updatePremadeBouquet,
 } from '../services/premadeBouquetService.js';
 
 beforeEach(() => {
@@ -79,6 +80,39 @@ describe('createPremadeBouquet', () => {
       lines: [{ stockItemId: 'x', flowerName: 'Rose', quantity: 0 }],
     })).rejects.toThrow(/quantity must be a positive number/);
     expect(premadeBouquetRepo.create).not.toHaveBeenCalled();
+  });
+});
+
+// Regression lock for issue #456 (florist "mix name" tap-to-edit fix):
+// PATCH /api/premade-bouquets/:id already accepted `name`, but it had no
+// direct test — a name-only rename would have silently regressed if a future
+// change to updatePremadeBouquet's field-mapping dropped it.
+describe('updatePremadeBouquet', () => {
+  it('maps patch.name onto the repo Name field and returns the refreshed bouquet', async () => {
+    premadeBouquetRepo.update.mockResolvedValue(undefined);
+    premadeBouquetRepo.getById.mockResolvedValue({
+      id: 'recBouquet1', _pgId: 'uuid-bouquet-1', Name: 'Renamed Mix', 'Price Override': null,
+    });
+    premadeBouquetRepo.getLinesByBouquetId.mockResolvedValue([]);
+
+    const result = await updatePremadeBouquet('recBouquet1', { name: 'Renamed Mix' });
+
+    expect(premadeBouquetRepo.update).toHaveBeenCalledWith('recBouquet1', { Name: 'Renamed Mix' });
+    expect(result.Name).toBe('Renamed Mix');
+  });
+
+  it('leaves other fields untouched when only the name is patched', async () => {
+    premadeBouquetRepo.update.mockResolvedValue(undefined);
+    premadeBouquetRepo.getById.mockResolvedValue({
+      id: 'recBouquet1', _pgId: 'uuid-bouquet-1', Name: 'Renamed Mix', Notes: 'kept', 'Price Override': 99,
+    });
+    premadeBouquetRepo.getLinesByBouquetId.mockResolvedValue([]);
+
+    await updatePremadeBouquet('recBouquet1', { name: 'Renamed Mix' });
+
+    // Only Name should be present in the patch sent to the repo — a name-only
+    // rename must not clobber notes/price with undefined.
+    expect(premadeBouquetRepo.update).toHaveBeenCalledWith('recBouquet1', { Name: 'Renamed Mix' });
   });
 });
 


### PR DESCRIPTION
## What
The premade-bouquet ("mix of the day") name in both the florist and dashboard apps now supports tap-to-edit directly in the card/row header: tap the name, a keyboard opens, type the new name, blur (or Enter) saves. Escape cancels.

- `apps/florist/src/components/PremadeBouquetCard.jsx` — new `NameField` sub-component (mirrors the `PriceField` pattern in `StockItem.jsx`) + `handleNameSave`. The header wrapper changed from `<button>` to `<div onClick>` (matching the collapsed-row pattern already used in `StockItem.jsx`) so the nested inline-edit `<input>` is valid, working HTML.
- `apps/dashboard/src/components/PremadeBouquetList.jsx` — same fix, mirrored for cross-app parity (root CLAUDE.md pairs these two files as the premade-bouquet parity pair). The row header there was already a `<div>`, so no wrapper change was needed.
- `backend/src/__tests__/premadeBouquetService.test.js` — 2 new tests locking in `updatePremadeBouquet`'s `name` → `Name` field mapping.

## Root cause
The bouquet name was rendered as plain, non-interactive text nested inside the card/row header's own `onClick` (tap-to-expand) handler. It had no tap affordance and no handler of its own, so tapping it only ever expanded/collapsed the card — never opened a keyboard, matching the owner's report exactly ("doesn't appear disabled, but tapping does nothing"). The only existing way to rename a bouquet was to expand the card, tap the separate "Edit" button, and use the name field buried inside that larger multi-field form (name/notes/price/lines) — non-obvious and easy to miss.

## Verification
- `cd apps/florist && ./node_modules/.bin/vite build` → **PASS** (2184 modules transformed, built in 2.15s)
- `cd apps/dashboard && ./node_modules/.bin/vite build` → **PASS** (1276 modules transformed, built in 2.78s)
- `cd backend && npx vitest run src/__tests__/premadeBouquetService.test.js` → **PASS** (8/8 tests, including the 2 new ones)
- `cd backend && npx vitest run --no-file-parallelism` (full suite) → **PASS** (110 test files, 994 tests, exit 0; 539s under heavy local CPU contention from concurrent sibling sessions on the same machine)

## Deviations from the task brief
- Investigated both candidate surfaces named in the brief. The Wix-storefront `BouquetsPage`/`BouquetCard` ("mono"/"mix" Product Type) already routes name editing through the shared `ProductTranslationEditor` (ADR-0008) and works fine — confirmed **not** the broken surface. The broken surface is the premade bouquet ("mixes of the day") card/row, confirmed by the issue's own "Made X ago" freshness framing and the fact `PremadeBouquetCard.jsx` is the only place in the florist app with a prominent, editable-looking name that had no tap handler.
- Backend needed no new field — `PATCH /premade-bouquets/:id` already accepted `name` end-to-end (route → service → repo); added the missing regression test instead of new production code.
- Did not touch `packages/shared` — both fixes are app-local, matching how `PriceField`/`InlineEdit` are already duplicated per-app rather than shared.

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)