### PR TITLE
fix(stock): clamp broken qty to received in PO evaluation (#537)

### DIFF
--- a/apps/florist/src/pages/StockEvaluationPage.jsx
+++ b/apps/florist/src/pages/StockEvaluationPage.jsx
@@ -8,6 +8,24 @@ import { useToast } from '../context/ToastContext.jsx';
 import client from '../api/client.js';
 import t from '../translations.js';
 
+// Broken/write-off and accept are two views of one pool of received stems
+// (received === accepted + writeOff). Editing either field recomputes the
+// other so they can never drift apart — this is the auto-decrement behavior
+// issue #537 asks for ("10 arrived, florist enters 1 broken -> accept
+// auto-updates 10 -> 9"), and it works the same way in reverse (editing
+// accept adjusts write-off) so a manual accept edit is never left
+// contradicting a stale write-off count. Both clamp to [0, received].
+// Shared by the primary line and the alt/substitute line below.
+function recomputeFromWriteOff(received, writeOffInput) {
+  const writeOff = Math.max(0, Math.min(Number(writeOffInput) || 0, received));
+  return { writeOff, accepted: Math.max(0, received - writeOff) };
+}
+
+function recomputeFromAccepted(received, acceptedInput) {
+  const accepted = Math.max(0, Math.min(Number(acceptedInput) || 0, received));
+  return { accepted, writeOff: Math.max(0, received - accepted) };
+}
+
 export default function StockEvaluationPage() {
   const navigate = useNavigate();
   const { showToast } = useToast();
@@ -93,15 +111,14 @@ export default function StockEvaluationPage() {
   }
 
   function handleWriteOffChange(lineId, writeOff, field = 'writeOff') {
-    const raw = Number(writeOff) || 0;
     if (field === 'writeOff') {
       const found = Number(orders.flatMap(o => o.lines).find(l => l.id === lineId)?.['Quantity Found']) || 0;
-      const wo = Math.max(0, Math.min(raw, found));
-      updateEval(lineId, { writeOff: wo, accepted: Math.max(0, found - wo) });
+      const { writeOff: wo, accepted } = recomputeFromWriteOff(found, writeOff);
+      updateEval(lineId, { writeOff: wo, accepted });
     } else {
       const altFound = Number(orders.flatMap(o => o.lines).find(l => l.id === lineId)?.['Alt Quantity Found']) || 0;
-      const wo = Math.max(0, Math.min(raw, altFound));
-      updateEval(lineId, { altWriteOff: wo, altAccepted: Math.max(0, altFound - wo) });
+      const { writeOff: wo, accepted: altAccepted } = recomputeFromWriteOff(altFound, writeOff);
+      updateEval(lineId, { altWriteOff: wo, altAccepted });
     }
   }
 
@@ -373,8 +390,8 @@ export default function StockEvaluationPage() {
                                 reason={ev.reason || 'Damaged'}
                                 max={found}
                                 onAcceptChange={val => {
-                                  const v = Math.max(0, Math.min(Number(val) || 0, found));
-                                  updateEval(line.id, { accepted: v, writeOff: Math.max(0, found - v) });
+                                  const { accepted: v, writeOff } = recomputeFromAccepted(found, val);
+                                  updateEval(line.id, { accepted: v, writeOff });
                                 }}
                                 onWriteOffChange={val => handleWriteOffChange(line.id, val, 'writeOff')}
                                 onReasonChange={val => updateEval(line.id, { reason: val })}
@@ -445,8 +462,8 @@ export default function StockEvaluationPage() {
                                     max={altFound}
                                     borderColor="border-indigo-200"
                                     onAcceptChange={val => {
-                                      const v = Math.max(0, Math.min(Number(val) || 0, altFound));
-                                      updateEval(line.id, { altAccepted: v, altWriteOff: Math.max(0, altFound - v) });
+                                      const { accepted: v, writeOff: altWriteOff } = recomputeFromAccepted(altFound, val);
+                                      updateEval(line.id, { altAccepted: v, altWriteOff });
                                     }}
                                     onWriteOffChange={val => handleWriteOffChange(line.id, val, 'altWriteOff')}
                                     onReasonChange={val => updateEval(line.id, { altReason: val })}
@@ -554,7 +571,7 @@ function AcceptWriteOffRow({ accepted, writeOff, reason, max, borderColor = 'bor
           value={writeOff}
           onChange={e => onWriteOffChange(e.target.value)}
           className="w-full text-center text-sm font-semibold border-amber-200 border rounded-xl px-2 py-2.5 bg-white outline-none"
-          min="0"
+          min="0" max={max}
         />
       </div>
       <div>


### PR DESCRIPTION
## What

- Added the missing `max={max}` clamp to the broken/write-off `<input>` in `AcceptWriteOffRow` (`apps/florist/src/pages/StockEvaluationPage.jsx`) — it had `min="0"` but no upper bound, unlike its sibling accept input which already clamps via `max={max}`.
- Extracted the accept/write-off recompute math (duplicated 4x: accept↔write-off, ×2 for the primary line and the alt/substitute line) into two named, documented helpers: `recomputeFromWriteOff(received, writeOffInput)` and `recomputeFromAccepted(received, acceptedInput)`. Purely behavior-preserving — same formulas, same clamps, verified equivalent line-by-line against the code being replaced.
- No other files touched.

## Why

**Diagnosis first (per the repo's bug workflow):** issue #537 asks for "when the florist enters a broken quantity, the amount-to-accept field auto-decreases by that amount (received − broken), in real time." Tracing `StockEvaluationPage.jsx`, this exact behavior **already exists** — `handleWriteOffChange` has computed `accepted = max(0, found - writeOff)` on every write-off keystroke since commit `a4da7a0b` (2026-03-12), wired into the row since `f245e802` (2026-04-09) — about four months before the issue was filed (2026-07-08). It works for both the primary line and the alt/substitute line, and works in reverse too (editing accept adjusts write-off back), which is a *stronger* guarantee than the one-way rule the issue describes (it keeps `accepted + writeOff === received` as an invariant no matter which field is edited, rather than only recomputing on broken-qty change). I could not reproduce "the full amount remains, requiring manual adjustment" via code trace, and chose not to re-implement or weaken already-correct behavior.

There is no field literally labeled "broken" — "broken" is one of five values (`Arrived Broken` / Сломаны при доставке) in the shared write-off Reason dropdown (`packages/shared/utils/lossReasons.js`); the quantity itself lives in the generic Write-off (✗) field, which already drives the recompute regardless of which reason is selected. If the owner still sees the reported symptom after this ships, my best guess at a next diagnostic step is watching an actual evaluation live to confirm which field is being typed into, since the UI's "broken" concept is that reason value, not a dedicated field.

What I did find and fix: the write-off input's missing `max` attribute (a real, verifiable asymmetry vs. the accept input) and the 4x-duplicated formula (a legitimate consolidation risk — four copies of the same clamp logic can drift). Both changes are safe, small, and directly serve the "clamp broken to received" requirement even though the auto-decrement itself needed no new code.

**Parity:** Dashboard's `apps/dashboard/src/components/StockOrderPanel.jsx` has no evaluation entry UI — its own code comment says "Editable POs: Draft + Sent + Shopping. Reviewing/Evaluating/Complete stay read-only," and it only renders a read-only `✓ Accepted: {line['Quantity Accepted']}` line once evaluation is done elsewhere. Evaluation (accept/write-off entry) is **florist-app-only**; no dashboard change needed.

**Backend:** confirmed `evaluatePurchaseOrder` (`backend/src/services/stockOrderService.js`) trusts whatever `quantityAccepted`/`writeOffQty` the client submits (only a narrow "Not Found" double-book guard overrides it) — the recompute has only ever lived client-side. No server change made or needed.

## Verification

- `cd apps/florist && ./node_modules/.bin/vite build` — clean, 2184 modules transformed, no errors/warnings:
  ```
  vite v5.4.21 building for production...
  ✓ 2184 modules transformed.
  ✓ built in 4.75s
  ```
- Dashboard not touched (confirmed no evaluation UI exists there to build/verify against); backend not touched; `packages/shared` not touched — per the repo's pre-PR matrix, no other build/test targets apply to this diff.
- Live browser click-through was attempted (harness backend seeded via direct API calls to a Draft→Sent→Shopping→Reviewing→Evaluating PO, PIN 2222 florist login) but the shared Browser-pane tool was contended by what appears to be another concurrent session on this machine (tabs from unrequested origins kept appearing/closing independent of my actions) — I stopped rather than risk interfering with someone else's session. Verification for the "already-working" diagnosis therefore rests on static code trace + git-blame history (dated evidence above), not a fresh green browser run — flagging this explicitly rather than silently skipping it.

Refs #537 (kept open — see needs-info triage note on the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
