### PR TITLE
[unverified] fix(wix): batch variant price pushes per product (#428)

### DIFF
--- a/backend/src/__tests__/wixProductSync.price.test.js
+++ b/backend/src/__tests__/wixProductSync.price.test.js
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Regression suite for #428 — the price-push phase batching fix.
+//
+// Root cause: runPush()'s price phase fired ONE `PATCH .../products/{id}/
+// variants` call PER (product, variant) pair, all through a single shared
+// PQueue with NO grouping by product. Wix treats that endpoint as a full
+// variant-collection replace, not a per-variant merge — so two concurrent
+// PATCHes for two DIFFERENT variants of the SAME product raced, the later
+// write won, and the earlier variant's new price was silently discarded
+// while `stats.errors` stayed empty and the UI reported clean success
+// (confirmed against sync_log on the 2026-06-23 incident day: every push
+// that afternoon logged `status=success(push)` with a non-zero
+// `price_syncs` count).
+//
+// `updateWixInventory` and `updateWixVariantVisibility` hit the same/an
+// adjacent Wix endpoint shape and already solved this by batching every one
+// of a product's variants into a single call. The fix mirrors that for
+// price: group changed variants BY PRODUCT, send exactly one PATCH per
+// product, keep concurrency ACROSS products (PUSH_CONCURRENCY) — never
+// within one product.
+
+const upsertMock = vi.fn();
+const listMock = vi.fn();
+const softDeleteMock = vi.fn();
+const deactivateMock = vi.fn();
+const notifyWixSyncErrorMock = vi.fn();
+
+vi.mock('../repos/productConfigRepo.js', () => ({
+  list: (...a) => listMock(...a),
+  upsert: (...a) => upsertMock(...a),
+  softDelete: (...a) => softDeleteMock(...a),
+  deactivate: (...a) => deactivateMock(...a),
+}));
+vi.mock('../repos/syncLogRepo.js', () => ({ logSync: vi.fn() }));
+vi.mock('../repos/stockRepo.js', () => ({ list: vi.fn(async () => []) }));
+vi.mock('../services/telegram.js', () => ({
+  sendAlert: vi.fn(),
+  notifyWixSyncError: (...a) => notifyWixSyncErrorMock(...a),
+}));
+vi.mock('../services/configService.js', () => ({
+  getConfig: () => ({}),
+  updateConfig: vi.fn(),
+  getActiveSeasonalSlots: () => [],
+  getActiveSeasonalCategory: () => null,
+}));
+
+/** Wix `/stores/v1/products/query` response: N products, each with managed variants. */
+function wixProductsPayload(products) {
+  return {
+    products: products.map(p => ({
+      id: p.id,
+      name: p.name,
+      visible: true,
+      variants: p.variants.map(v => ({
+        id: v.id,
+        choices: { Size: v.id },
+        variant: { visible: true, priceData: { price: v.wixPrice } },
+      })),
+    })),
+  };
+}
+
+/** product_config row (wire format) driving the price phase comparison. */
+function configRow({ pid, vid, productName, variantName, price }) {
+  return {
+    'Wix Product ID': pid,
+    'Wix Variant ID': vid,
+    'Product Name': productName,
+    'Variant Name': variantName,
+    Price: price,
+    Active: true,
+  };
+}
+
+/**
+ * Matches PATCH .../products/{pid}/variants calls carrying a PRICE body —
+ * distinguishes them from the Visibility phase's PATCH to the SAME URL
+ * (which carries `{variantIds, visible}` with no `priceData`), since both
+ * phases run inside the same `runPush()` call.
+ */
+function priceCallsFor(pid) {
+  return fetch.mock.calls.filter(([url, opts]) => {
+    if (url !== `https://www.wixapis.com/stores/v1/products/${pid}/variants`) return false;
+    const body = JSON.parse(opts.body);
+    return Array.isArray(body.variants) && body.variants.length > 0
+      && body.variants.every(v => v.variant?.priceData !== undefined);
+  });
+}
+
+/** Baseline fetch router shared by all tests — real Wix endpoints touched by runPush(). */
+function baseFetchImpl({ productsResponse, onPricePatch } = {}) {
+  return async (url, opts) => {
+    if (typeof url === 'string' && url.includes('/stores/v1/products/query')) {
+      return productsResponse();
+    }
+    if (typeof url === 'string' && url.includes('/stores/v1/collections/query')) {
+      return { ok: true, json: async () => ({ collections: [] }) };
+    }
+    if (typeof url === 'string' && url.includes('/stores/v2/inventoryItems/product/')) {
+      return { ok: true, json: async () => ({}) }; // Availability phase — irrelevant here
+    }
+    if (typeof url === 'string' && url.endsWith('/variants')) {
+      const body = JSON.parse(opts.body);
+      const isPricePatch = Array.isArray(body.variants) && body.variants.every(v => v.variant?.priceData !== undefined);
+      if (isPricePatch && onPricePatch) return onPricePatch(url, body);
+      return { ok: true, json: async () => ({}) }; // Visibility phase (same URL) — always succeeds
+    }
+    return { ok: true, json: async () => ({}) };
+  };
+}
+
+describe('runPush — price phase batching (#428)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    vi.stubEnv('WIX_API_KEY', 'k');
+    vi.stubEnv('WIX_SITE_ID', 's');
+    listMock.mockReset();
+    upsertMock.mockReset().mockResolvedValue({});
+    softDeleteMock.mockReset().mockResolvedValue({});
+    deactivateMock.mockReset().mockResolvedValue({});
+    notifyWixSyncErrorMock.mockReset();
+  });
+
+  it('batches N changed variants of ONE product into exactly one PATCH', async () => {
+    const products = [{
+      id: 'prod-A',
+      name: 'White Hydrangeas',
+      variants: [
+        { id: 'v-a1', wixPrice: 100 },
+        { id: 'v-a2', wixPrice: 200 },
+        { id: 'v-a3', wixPrice: 300 },
+      ],
+    }];
+    fetch.mockImplementation(baseFetchImpl({
+      productsResponse: async () => ({ ok: true, json: async () => wixProductsPayload(products) }),
+    }));
+    listMock.mockResolvedValue([
+      configRow({ pid: 'prod-A', vid: 'v-a1', productName: 'White Hydrangeas', variantName: '1', price: 110 }),
+      configRow({ pid: 'prod-A', vid: 'v-a2', productName: 'White Hydrangeas', variantName: '2', price: 210 }),
+      configRow({ pid: 'prod-A', vid: 'v-a3', productName: 'White Hydrangeas', variantName: '3', price: 310 }),
+    ]);
+
+    const { runPush } = await import('../services/wixProductSync.js');
+    const stats = await runPush();
+
+    // Exactly ONE PATCH for the product — not one per variant.
+    const calls = priceCallsFor('prod-A');
+    expect(calls).toHaveLength(1);
+
+    // ...carrying ALL 3 variants' new prices in a single body.
+    const [, opts] = calls[0];
+    const body = JSON.parse(opts.body);
+    expect(body.variants).toHaveLength(3);
+    const priceById = Object.fromEntries(body.variants.map(v => [v.id, v.variant.priceData.price]));
+    expect(priceById).toEqual({ 'v-a1': 110, 'v-a2': 210, 'v-a3': 310 });
+
+    expect(stats.pricesSynced).toBe(3);
+    expect(stats.errors).toEqual([]);
+  });
+
+  it('still pushes multiple products concurrently (one batched PATCH each, in flight together)', async () => {
+    const products = [
+      { id: 'prod-A', name: 'Product A', variants: [{ id: 'v-a1', wixPrice: 100 }, { id: 'v-a2', wixPrice: 150 }] },
+      { id: 'prod-B', name: 'Product B', variants: [{ id: 'v-b1', wixPrice: 50 }] },
+    ];
+    const pendingByProduct = new Map(); // pid -> resolve fn, held open until both have arrived
+    fetch.mockImplementation(baseFetchImpl({
+      productsResponse: async () => ({ ok: true, json: async () => wixProductsPayload(products) }),
+      onPricePatch: (url) => new Promise(resolve => {
+        const pid = url.split('/products/')[1].split('/variants')[0];
+        pendingByProduct.set(pid, resolve);
+      }),
+    }));
+    listMock.mockResolvedValue([
+      configRow({ pid: 'prod-A', vid: 'v-a1', productName: 'Product A', variantName: '1', price: 120 }),
+      configRow({ pid: 'prod-A', vid: 'v-a2', productName: 'Product A', variantName: '2', price: 170 }),
+      configRow({ pid: 'prod-B', vid: 'v-b1', productName: 'Product B', variantName: '1', price: 60 }),
+    ]);
+
+    const { runPush } = await import('../services/wixProductSync.js');
+    const runPromise = runPush();
+
+    // Both products' price PATCHes must land BEFORE either resolves — if the
+    // queue serialized across products, prod-B's call would not arrive until
+    // prod-A's promise had already been resolved.
+    await vi.waitFor(() => {
+      expect(pendingByProduct.has('prod-A')).toBe(true);
+      expect(pendingByProduct.has('prod-B')).toBe(true);
+    });
+
+    pendingByProduct.get('prod-A')({ ok: true, json: async () => ({}) });
+    pendingByProduct.get('prod-B')({ ok: true, json: async () => ({}) });
+
+    const stats = await runPromise;
+    expect(stats.pricesSynced).toBe(3);
+    expect(stats.errors).toEqual([]);
+    expect(priceCallsFor('prod-A')).toHaveLength(1);
+    expect(priceCallsFor('prod-B')).toHaveLength(1);
+  });
+
+  it('reports a per-product API error in stats.errors without aborting other products', async () => {
+    const products = [
+      { id: 'prod-A', name: 'Product A', variants: [{ id: 'v-a1', wixPrice: 100 }] },
+      { id: 'prod-B', name: 'Product B', variants: [{ id: 'v-b1', wixPrice: 50 }, { id: 'v-b2', wixPrice: 75 }] },
+    ];
+    fetch.mockImplementation(baseFetchImpl({
+      productsResponse: async () => ({ ok: true, json: async () => wixProductsPayload(products) }),
+      onPricePatch: async (url) => {
+        if (url.includes('prod-B')) {
+          return { ok: false, status: 400, text: async () => 'INVALID_PRICE' };
+        }
+        return { ok: true, json: async () => ({}) };
+      },
+    }));
+    listMock.mockResolvedValue([
+      configRow({ pid: 'prod-A', vid: 'v-a1', productName: 'Product A', variantName: '1', price: 120 }),
+      configRow({ pid: 'prod-B', vid: 'v-b1', productName: 'Product B', variantName: '1', price: 60 }),
+      configRow({ pid: 'prod-B', vid: 'v-b2', productName: 'Product B', variantName: '2', price: 85 }),
+    ]);
+
+    const { runPush } = await import('../services/wixProductSync.js');
+    const stats = await runPush();
+
+    // prod-A succeeded despite prod-B's failure — the batch queue did not abort.
+    expect(stats.pricesSynced).toBe(1);
+    expect(priceCallsFor('prod-A')).toHaveLength(1);
+
+    // prod-B's failure is captured per-item (one line per affected row) —
+    // sync_log stays truthful about which rows failed, not just a job-level flag.
+    expect(stats.errors).toHaveLength(2);
+    expect(stats.errors.every(e => e.includes('prod-B'))).toBe(true);
+    expect(stats.errors.some(e => e.includes('INVALID_PRICE'))).toBe(true);
+
+    // Still exactly ONE PATCH attempt for prod-B — batched, not one per variant,
+    // even on the failure path.
+    expect(priceCallsFor('prod-B')).toHaveLength(1);
+
+    // Errors are still surfaced to the owner via Telegram (pre-existing behavior,
+    // unchanged by this fix).
+    expect(notifyWixSyncErrorMock).toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/wixProductSync.js
+++ b/backend/src/services/wixProductSync.js
@@ -125,30 +125,55 @@ export async function fetchAllWixProducts() {
 }
 
 /**
- * Update a Wix product variant's price.
- * Uses the batch variants endpoint — variant ID goes in the body, not the URL.
+ * Update price for ALL changed variants of a Wix product in a single PATCH.
+ *
+ * Why batched: `PATCH stores/v1/products/{id}/variants` replaces the full
+ * variant collection named in the body — it is not a per-variant merge on
+ * Wix's side. Firing one PATCH per variant (the pre-#428 approach) let
+ * concurrent PQueue workers race on the SAME product: two in-flight calls
+ * for two different variants of one product each returned 200 OK, but Wix
+ * kept only the later write — the earlier variant's new price silently
+ * never landed, while `stats.pricesSynced` and the UI both reported clean
+ * success. `updateWixInventory` and `updateWixVariantVisibility` hit this
+ * exact endpoint shape and already solved it by batching every one of a
+ * product's variants into one call; this mirrors that fix for price.
+ *
+ * No-op (no fetch) when there is nothing to update — mirrors
+ * `updateWixVariantVisibility`'s empty-array guard.
+ *
+ * @param productId Wix product ID
+ * @param variantPrices Array of { variantId, price } — one per CHANGED variant
  */
-async function updateWixVariantPrice(productId, variantId, price) {
-  const res = await fetch(
-    `${WIX_API_URL}/stores/v1/products/${productId}/variants`,
-    {
-      method: 'PATCH',
-      headers: wixHeaders(),
-      body: JSON.stringify({
-        variants: [{
-          id: variantId,
-          variant: {
-            priceData: { price },
-          },
-        }],
-      }),
-    }
-  );
+async function updateWixVariantPrices(productId, variantPrices) {
+  if (variantPrices.length === 0) return;
 
-  if (!res.ok) {
+  const body = {
+    variants: variantPrices.map(v => ({
+      id: v.variantId,
+      variant: {
+        priceData: { price: v.price },
+      },
+    })),
+  };
+
+  // Retry transient 5xx like updateWixInventory / updateWixVariantVisibility —
+  // Wix's catalog write API has been observed returning transient errors
+  // (gRPC "deadline exceeded" on updateProduct, seen in sync_log the day
+  // before #428 was filed).
+  const MAX_ATTEMPTS = 3;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const res = await fetch(
+      `${WIX_API_URL}/stores/v1/products/${productId}/variants`,
+      { method: 'PATCH', headers: wixHeaders(), body: JSON.stringify(body) }
+    );
+    if (res.ok) return;
     const text = await res.text();
     if (isProductNotFound(res.status, text)) throw new WixProductNotFoundError(productId);
-    throw new Error(`Wix price update failed for ${productId}/${variantId}: ${text}`);
+    if (res.status >= 500 && attempt < MAX_ATTEMPTS) {
+      await new Promise(r => setTimeout(r, 1000 * attempt));
+      continue;
+    }
+    throw new Error(`Wix price update failed for ${productId}: ${text}`);
   }
 }
 
@@ -158,7 +183,7 @@ async function updateWixVariantPrice(productId, variantId, price) {
  * Wix represents products in two shapes:
  *   1. Products WITH managed variants (e.g. Small / Medium / Large) — each
  *      variant has a real UUID and its own `priceData`. Use the batch
- *      variants endpoint via `updateWixVariantPrice` above.
+ *      variants endpoint via `updateWixVariantPrices` above.
  *   2. Products WITHOUT managed variants (simple single-SKU products) —
  *      Wix exposes a synthetic "default variant" with ID
  *      00000000-0000-0000-0000-000000000000 on READ, but the price lives
@@ -955,7 +980,8 @@ export async function runPull() {
  *
  * Phases (each runs sequentially relative to the next, but Wix API calls
  * inside a phase fan out with PUSH_CONCURRENCY workers):
- *   1. Prices              — variant or product-level price PATCH per row
+ *   1. Prices              — one batched PATCH per product (or product-level
+ *                            PATCH for simple/unmanaged products)
  *   2. Inventory           — one batched PATCH per product
  *   3. Categories          — permanent / seasonal / Available Today
  *   4. Descriptions + i18n — EN content + PL/RU/UK translation content
@@ -1002,10 +1028,15 @@ export async function runPush(onProgress = NO_PROGRESS) {
       }
     }
 
-    // Zero-UUID (module const) = Wix's default-variant placeholder for
-    // products without managed variants. Those need the product-level price
-    // endpoint, not the variant batch endpoint (see `updateWixProductPrice`).
-    const priceJobs = [];
+    // Grouped BY PRODUCT — same pattern as the Availability and Visibility
+    // phases further down this function (see updateWixVariantPrices'
+    // docblock for why: concurrent per-variant PATCHes against the same
+    // product raced and silently dropped sibling variants' price changes,
+    // #428). Zero-UUID (module const) is Wix's default-variant placeholder
+    // for products without managed variants — those go through the
+    // product-level price endpoint (see `updateWixProductPrice`), never the
+    // variant batch endpoint.
+    const priceJobsByProduct = new Map();
     for (const row of configRows) {
       const pid = row['Wix Product ID'];
       const vid = row['Wix Variant ID'];
@@ -1014,26 +1045,31 @@ export async function runPush(onProgress = NO_PROGRESS) {
       const airtablePrice = Number(row['Price'] || 0);
       const wixPrice = wixPriceMap.get(key);
       if (wixPrice === undefined || Math.abs(airtablePrice - wixPrice) <= 0.01) continue;
-      priceJobs.push({ pid, vid, key, airtablePrice, wixPrice, variantName: row['Variant Name'] });
+      if (!priceJobsByProduct.has(pid)) priceJobsByProduct.set(pid, []);
+      priceJobsByProduct.get(pid).push({ pid, vid, key, airtablePrice, wixPrice, variantName: row['Variant Name'] });
     }
-    log('summary', `Цены к обновлению: ${priceJobs.length}`);
+    const totalPriceJobs = [...priceJobsByProduct.values()].reduce((n, jobs) => n + jobs.length, 0);
+    log('summary', `Цены к обновлению: ${totalPriceJobs}`);
 
-    if (priceJobs.length > 0) {
+    if (priceJobsByProduct.size > 0) {
       const queue = new PQueue({ concurrency: PUSH_CONCURRENCY });
-      await Promise.all(priceJobs.map(job => queue.add(async () => {
-        const productName = wixProductNameById.get(job.pid) || job.pid;
-        const variantSuffix = job.variantName && job.vid !== ZERO_UUID ? ` / ${job.variantName}` : '';
+      await Promise.all([...priceJobsByProduct.entries()].map(([pid, jobs]) => queue.add(async () => {
+        const productName = wixProductNameById.get(pid) || pid;
         try {
-          if (job.vid === ZERO_UUID) {
-            await updateWixProductPrice(job.pid, job.airtablePrice);
-          } else {
-            await updateWixVariantPrice(job.pid, job.vid, job.airtablePrice);
+          const zeroJob = jobs.find(j => j.vid === ZERO_UUID);
+          const variantJobs = jobs.filter(j => j.vid !== ZERO_UUID);
+          if (zeroJob) await updateWixProductPrice(pid, zeroJob.airtablePrice);
+          if (variantJobs.length > 0) {
+            await updateWixVariantPrices(pid, variantJobs.map(j => ({ variantId: j.vid, price: j.airtablePrice })));
           }
-          stats.pricesSynced++;
-          log('item', `Цена · ${productName}${variantSuffix}: ${job.wixPrice}zł → ${job.airtablePrice}zł`);
+          stats.pricesSynced += jobs.length;
+          for (const job of jobs) {
+            const variantSuffix = job.variantName && job.vid !== ZERO_UUID ? ` / ${job.variantName}` : '';
+            log('item', `Цена · ${productName}${variantSuffix}: ${job.wixPrice}zł → ${job.airtablePrice}zł`);
+          }
         } catch (err) {
-          stats.errors.push(`Price ${job.key}: ${err.message}`);
-          log('item', `Ошибка цены · ${productName}${variantSuffix}: ${err.message}`, 'error');
+          for (const job of jobs) stats.errors.push(`Price ${job.key}: ${err.message}`);
+          log('item', `Ошибка цены · ${productName}: ${err.message}`, 'error');
         }
       })));
     }


### PR DESCRIPTION
## What

`runPush()`'s price phase now groups changed variant prices **by product** and sends exactly one `PATCH stores/v1/products/{id}/variants` per product, mirroring `updateWixInventory` / `updateWixVariantVisibility` (same file) — which already solved this same class of bug for inventory and visibility. Concurrency stays **across** products (`PQueue({ concurrency: PUSH_CONCURRENCY })`, unchanged), never within one product.

Scope is deliberately narrow: only the price phase in `backend/src/services/wixProductSync.js` changed (helper renamed `updateWixVariantPrice` → `updateWixVariantPrices`, now batched + retry-on-5xx like its siblings; the price-job loop in `runPush` now groups by `Wix Product ID` before queuing). Pull, `localNameOwned`/ADR-0008 name-ownership logic, the Inventory phase, and the Visibility phase are untouched.

## Root cause

Cited from the AI investigation comment on issue #428 (dated 2026-07-24, read-only triage — code review + `claude_ro` Postgres reads + `railway logs`, no Wix API calls):

> `runPush()`'s price phase (`backend/src/services/wixProductSync.js:1008-1039`) builds one flat `priceJobs` array across every (product, variant) pair needing a price change, then fires them all through a single `PQueue({ concurrency: PUSH_CONCURRENCY })` ... **with no grouping by product.** Each job calls `updateWixVariantPrice(pid, vid, price)`, which PATCHes `stores/v1/products/{productId}/variants` with a body containing just that one variant's new price. ... Critically, `updateWixVariantVisibility` PATCHes the **exact same URL** ... The codebase already learned — and fixed — "one variant per call races and silently drops data" for this endpoint twice (inventory, visibility). Price is the one remaining phase still doing it the old, per-variant, per-call way.

The comment also cites `sync_log` evidence from the 2026-06-23 incident day: every push that afternoon logged `status=success(push)` with a non-zero `price_syncs` count and an empty `error_message` — confirming the failure is silent at the per-item level, exactly matching the owner's report (dashboard says "Отправлено в Wix" / success, storefront price doesn't change).

I independently verified this hypothesis by reading `wixProductSync.js` directly before writing any code: the price phase (now-fixed lines, originally ~993-1039) indeed built a flat unbatched `priceJobs` array, while `updateWixInventory` (~215-255) and `updateWixVariantVisibility` (~290-309) both already batch per product against the identical/adjacent Wix endpoint shape, each with an explicit code comment explaining the "last PATCH wins" race.

## Verification

**New regression test:** `backend/src/__tests__/wixProductSync.price.test.js` (Wix HTTP fully mocked via `vi.stubGlobal('fetch', ...)` — no real Wix calls). Three tests, each first confirmed to **fail against the pre-fix code** (verified via `git stash` before finalizing), then pass against the fix:

1. `batches N changed variants of ONE product into exactly one PATCH` — a product with 3 changed variants produces exactly 1 `PATCH .../variants` call carrying all 3 variants' new prices in one body. (Failed pre-fix: asserted 1, got 3.)
2. `still pushes multiple products concurrently (one batched PATCH each, in flight together)` — two products' price PATCHes are proven to be in-flight simultaneously (both requests arrive before either resolves, via `vi.waitFor` on a deferred-promise fetch mock). (Timed out pre-fix — old code's multiple per-variant calls for the same product collided on the same mock resolver.)
3. `reports a per-product API error in stats.errors without aborting other products` — one product's PATCH returns a 400; its 2 rows both land in `stats.errors`, the OTHER product still succeeds (`stats.pricesSynced` reflects it), and `notifyWixSyncError` still fires. Still exactly 1 PATCH attempt for the failing product. (Failed pre-fix: asserted 1 PATCH for the failing product, got 2.)

**Full verification matrix run locally (this satisfies the repo's Wix "Verification Gate" — an integration test + `npm run harness` + `npm run test:e2e`):**
- `cd backend && npx vitest run --no-file-parallelism` → **111 test files passed, 995 tests passed, 0 failed**
- `npm run harness` + `npm run test:e2e` → **253 passed, 0 failed** (all 29 sections, including §24 Wix webhook replay)
- `npm run lab:test:unit` → **9 files, 77 tests passed**
- `npm run lab:test:api` → **4 files, 18 tests passed**

`packages/shared/` and all three frontend apps are untouched by this diff, so no Vite builds were required per the pre-PR matrix.

## Deviations from the original task scope

None. Per the investigation's "Recommended fix scope," item 3 (a same-session Pull guard against re-clobbering a just-pushed, not-yet-propagated price) and the "secondary risk" section (Pull has no price protection, unlike the ADR-0008 name guard) were explicitly flagged as separate, follow-up concerns — not addressed here, consistent with this task's "do NOT touch the Pull direction" instruction.

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)