### PR TITLE
feat(crm): Instagram + Telegram fields on Key Person records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,28 @@ No schema change.
 **Verification:** backend Vitest full suite (994 tests, 111 files) + new regression test `backend/src/__tests__/orders.pickupConversion.integration.test.js` (route-level, real pglite DB) green; API E2E 253/253; lab-unit 77/77; lab-api 18/18; `apps/florist` + `apps/dashboard` Vite builds green.
 
 ---
+## 2026-07-24 — feat(crm): Instagram + Telegram fields on Key Person records (#553)
+
+Owner request: when adding a recipient as a key person on a new Order, she wants dedicated inputs for their Instagram link and Telegram nickname, stored once and retrievable from the key person's profile — same shape as the phone/address address-book fields (CR-30, migration 0018). Both fields are optional and never block Order or Customer creation.
+
+**Schema:** `key_people` gains nullable `instagram` + `telegram` text columns, migration `0023_key_people_instagram_telegram.sql`. Additive → safe on prod, no backfill required.
+
+**Backend:** `customerRepo.createKeyPerson` / `listKeyPeople` / `updateKeyPerson` read + write both fields (empty string → null, same normalization as phone/address); `POST /api/customers/:id/key-people` and `PATCH /api/customers/:id/key-people/:personId` accept them.
+
+**Frontend (both apps, parity-locked):**
+- `Step1Customer.jsx` (dashboard + florist New Order wizard, Step 1) — the "add new recipient" form (shown while typing a brand-new key-person name with no autocomplete match) gains Instagram + Telegram inputs alongside phone/address; `POST`s them when set, and pre-fills them when picking an existing saved recipient from the autocomplete list.
+- `CustomerDetailView.jsx` / `KeyPersonChips.jsx` (dashboard + florist CRM) — Instagram + Telegram shown and inline-editable per key person (persist on blur via the existing key-person PATCH route, no new endpoint). Instagram renders as a clickable new-tab link when the stored value looks like a URL (`https?://…`); otherwise (e.g. a bare `@handle`) as plain text — no strict validation, the owner's paste is stored as-is. Telegram always renders as plain nickname text. Florist's `!canEdit` (non-owner) view-only branch mirrors the same display rules.
+- New translation keys `keyPersonInstagram` / `keyPersonTelegram` (ru + en, both apps) — brand names kept latin, matching the existing `sourceInstagram`/`sourceTelegram`/`instagram` convention.
+- `Step3Details.jsx` deliberately **not** touched — Instagram/Telegram are key-person profile fields, not delivery-fulfilment fields (unlike phone/address, which the courier needs), so there's nothing for the Step3 delivery pre-fill effect to consume. Also avoids any diff overlap with the concurrent recipient-auto-save work landing on that file.
+
+**Lab harness check:** grepped `lab/` for `key_people`/`keyPeople` — no factory exists (only prose in `lab/WORKFLOW.md`); `lab/factories/customer.js` doesn't reference key people either. Both new columns are nullable `ADD COLUMN`, so no factory update is required.
+
+**Tests / verification:**
+- `customerRepo.keyPeople.integration.test.js` (pglite, applies migration 0023) — extended with instagram/telegram create + list round-trip, back-compat null default, empty-string→null normalization, independence from phone/address, and full `updateKeyPerson` coverage (full update, partial update, explicit clear-to-null).
+- Backend `vitest run --no-file-parallelism`: **110 files / 999 tests passed**.
+- `npm run lab:test:unit`: **9 files / 77 tests passed**.
+- API E2E suite (`npm run harness` + `npm run test:e2e`, run on an isolated port to avoid colliding with a concurrent worktree session already holding the default harness port): **253/253 passed**.
+- Dashboard + florist `vite build`: both green.
 
 ## 2026-07-23 — fix(stock): settled Demand Entries kept visible; editing a delivered order no longer crashes (#556, ADR-0013)
 

--- a/apps/dashboard/src/components/KeyPersonChips.jsx
+++ b/apps/dashboard/src/components/KeyPersonChips.jsx
@@ -13,6 +13,12 @@ const SLOTS = [
   { nameField: 'Key person 2', dateField: 'Key person 2 (important DATE)' },
 ];
 
+// #553 — Instagram is stored as whatever the owner pastes (full URL or bare
+// @handle), no strict validation. Only render it as a clickable link when it
+// already looks like a URL; otherwise show it as plain text.
+const URL_RE = /^https?:\/\//i;
+const looksLikeUrl = v => URL_RE.test(v || '');
+
 export default function KeyPersonChips({ cust, onPatch, onPatchPerson }) {
   // Index of the slot currently being filled via the "+ Add" button.
   const [addingSlot, setAddingSlot] = useState(null);
@@ -137,6 +143,40 @@ function KeyPersonSlot({ slot, cust, onPatch, person, onPatchPerson, autoFocus, 
               type="text"
               defaultValue={person.address || ''}
               onBlur={e => onPatchPerson(person.id, { address: e.target.value || null })}
+              className="w-full text-sm text-ios-label bg-transparent border-b border-dashed border-gray-300
+                focus:border-brand-500 focus:outline-none py-0.5"
+            />
+          </div>
+          <div className="mt-1">
+            <div className="flex items-center justify-between">
+              <p className="text-[10px] text-ios-tertiary mb-0.5">{t.keyPersonInstagram}</p>
+              {looksLikeUrl(person.instagram) && (
+                <a
+                  href={person.instagram}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[10px] text-brand-600 hover:underline"
+                >
+                  &#8599;
+                </a>
+              )}
+            </div>
+            <input
+              type="text"
+              defaultValue={person.instagram || ''}
+              onBlur={e => onPatchPerson(person.id, { instagram: e.target.value || null })}
+              placeholder="@handle"
+              className="w-full text-sm text-ios-label bg-transparent border-b border-dashed border-gray-300
+                focus:border-brand-500 focus:outline-none py-0.5"
+            />
+          </div>
+          <div className="mt-1">
+            <p className="text-[10px] text-ios-tertiary mb-0.5">{t.keyPersonTelegram}</p>
+            <input
+              type="text"
+              defaultValue={person.telegram || ''}
+              onBlur={e => onPatchPerson(person.id, { telegram: e.target.value || null })}
+              placeholder="@handle"
               className="w-full text-sm text-ios-label bg-transparent border-b border-dashed border-gray-300
                 focus:border-brand-500 focus:outline-none py-0.5"
             />

--- a/apps/dashboard/src/components/steps/Step1Customer.jsx
+++ b/apps/dashboard/src/components/steps/Step1Customer.jsx
@@ -25,6 +25,8 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
   const [kpName, setKpName]       = useState('');
   const [kpPhone, setKpPhone]     = useState('');
   const [kpAddress, setKpAddress] = useState('');
+  const [kpInstagram, setKpInstagram] = useState(''); // #553
+  const [kpTelegram, setKpTelegram]   = useState(''); // #553
   const [kpCreating, setKpCreating] = useState(false);
   const kpDebounceRef               = useRef(null);
 
@@ -61,6 +63,8 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
     setKpName('');
     setKpPhone('');
     setKpAddress('');
+    setKpInstagram('');
+    setKpTelegram('');
     setQuery('');
     setResults([]);
     setShowCreate(false);
@@ -85,8 +89,10 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
       setKpCreating(true);
       try {
         const reqBody = { name: kpName.trim() };
-        if (kpPhone.trim())   reqBody.phone   = kpPhone.trim();
-        if (kpAddress.trim()) reqBody.address = kpAddress.trim();
+        if (kpPhone.trim())     reqBody.phone     = kpPhone.trim();
+        if (kpAddress.trim())   reqBody.address   = kpAddress.trim();
+        if (kpInstagram.trim()) reqBody.instagram = kpInstagram.trim();
+        if (kpTelegram.trim())  reqBody.telegram  = kpTelegram.trim();
         const res = await client.post(`/customers/${chosenCustomer.id}/key-people`, reqBody);
         resolvedKpId    = res.data.id;
         resolvedPhone   = res.data.phone   || '';
@@ -368,7 +374,7 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
                 value={kpName}
                 onChange={e => {
                   setKpName(e.target.value);
-                  if (kpId) { setKpPhone(''); setKpAddress(''); }
+                  if (kpId) { setKpPhone(''); setKpAddress(''); setKpInstagram(''); setKpTelegram(''); }
                   setKpId(null);
                   setKpQuery(e.target.value);
                 }}
@@ -378,7 +384,7 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
               />
               {kpName && (
                 <button
-                  onClick={() => { setKpName(''); setKpId(null); setKpQuery(''); setKpPhone(''); setKpAddress(''); }}
+                  onClick={() => { setKpName(''); setKpId(null); setKpQuery(''); setKpPhone(''); setKpAddress(''); setKpInstagram(''); setKpTelegram(''); }}
                   className="text-ios-tertiary text-sm"
                 >&#10005;</button>
               )}
@@ -388,7 +394,7 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
                 {kpFiltered.map(p => (
                   <button
                     key={p.id}
-                    onClick={() => { setKpId(p.id); setKpName(p.name); setKpQuery(''); setKpPhone(p.phone || ''); setKpAddress(p.address || ''); }}
+                    onClick={() => { setKpId(p.id); setKpName(p.name); setKpQuery(''); setKpPhone(p.phone || ''); setKpAddress(p.address || ''); setKpInstagram(p.instagram || ''); setKpTelegram(p.telegram || ''); }}
                     className={`w-full text-left px-4 py-3 flex items-center gap-2 active:bg-ios-fill ${kpId === p.id ? 'bg-brand-50' : ''}`}
                   >
                     <div className="flex-1 min-w-0">
@@ -432,6 +438,26 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
                   value={kpAddress}
                   onChange={e => setKpAddress(e.target.value)}
                   placeholder="ul. Kwiatowa 1, Krakow"
+                  className="flex-1 text-base bg-transparent outline-none text-ios-label placeholder-ios-tertiary/50"
+                />
+              </div>
+              <div className="flex items-center px-4 py-3 gap-3">
+                <span className="text-sm text-ios-tertiary w-24 shrink-0">{t.keyPersonInstagram}</span>
+                <input
+                  type="text"
+                  value={kpInstagram}
+                  onChange={e => setKpInstagram(e.target.value)}
+                  placeholder="@handle"
+                  className="flex-1 text-base bg-transparent outline-none text-ios-label placeholder-ios-tertiary/50"
+                />
+              </div>
+              <div className="flex items-center px-4 py-3 gap-3">
+                <span className="text-sm text-ios-tertiary w-24 shrink-0">{t.keyPersonTelegram}</span>
+                <input
+                  type="text"
+                  value={kpTelegram}
+                  onChange={e => setKpTelegram(e.target.value)}
+                  placeholder="@handle"
                   className="flex-1 text-base bg-transparent outline-none text-ios-label placeholder-ios-tertiary/50"
                 />
               </div>

--- a/apps/dashboard/src/components/steps/Step1Customer.jsx
+++ b/apps/dashboard/src/components/steps/Step1Customer.jsx
@@ -394,7 +394,7 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
                 {kpFiltered.map(p => (
                   <button
                     key={p.id}
-                    onClick={() => { setKpId(p.id); setKpName(p.name); setKpQuery(''); setKpPhone(p.phone || ''); setKpAddress(p.address || ''); setKpInstagram(p.instagram || ''); setKpTelegram(p.telegram || ''); }}
+                    onClick={() => { setKpId(p.id); setKpName(p.name); setKpQuery(''); setKpPhone(p.phone || ''); setKpAddress(p.address || ''); }}
                     className={`w-full text-left px-4 py-3 flex items-center gap-2 active:bg-ios-fill ${kpId === p.id ? 'bg-brand-50' : ''}`}
                   >
                     <div className="flex-1 min-w-0">

--- a/apps/dashboard/src/translations.js
+++ b/apps/dashboard/src/translations.js
@@ -246,6 +246,8 @@ const en = {
   keyPersonNamePlaceholder: 'Name + contact',
   keyPersonPhone:           'Phone',
   keyPersonAddress:         'Address',
+  keyPersonInstagram:       'Instagram', // #553 — brand name stays latin
+  keyPersonTelegram:        'Telegram',  // #553 — brand name stays latin
   daysShort:                'd',
   monthsShort:              'mo',
   yearsShort:               'y',
@@ -1454,6 +1456,8 @@ const ru = {
   keyPersonNamePlaceholder: 'Имя + контакты',
   keyPersonPhone:           'Телефон',
   keyPersonAddress:         'Адрес',
+  keyPersonInstagram:       'Instagram', // #553 — brand name stays latin
+  keyPersonTelegram:        'Telegram',  // #553 — brand name stays latin
   daysShort:                'д',
   monthsShort:              'мес',
   yearsShort:               'г',

--- a/apps/florist/src/components/KeyPersonChips.jsx
+++ b/apps/florist/src/components/KeyPersonChips.jsx
@@ -22,6 +22,13 @@ const SLOTS = [
   { nameField: 'Key person 2', dateField: 'Key person 2 (important DATE)' },
 ];
 
+// #553 — Instagram is stored as whatever was pasted (full URL or bare
+// @handle), no strict validation. Only render it as a clickable link when it
+// already looks like a URL; otherwise show it as plain text. Mirrors the
+// dashboard KeyPersonChips.jsx helper.
+const URL_RE = /^https?:\/\//i;
+const looksLikeUrl = v => URL_RE.test(v || '');
+
 export default function KeyPersonChips({ cust, onPatch, onPatchPerson, canEdit = false }) {
   // Index of the slot currently being filled via the "+ Add" button.
   const [addingSlot, setAddingSlot] = useState(null);
@@ -117,6 +124,29 @@ function KeyPersonSlot({ slot, cust, onPatch, person, onPatchPerson, canEdit, au
             <p className="text-xs text-ios-label">{person.address}</p>
           </div>
         )}
+        {person?.instagram && (
+          <div className="mt-1">
+            <p className="text-[10px] text-ios-tertiary mb-0.5">{t.keyPersonInstagram}</p>
+            {looksLikeUrl(person.instagram) ? (
+              <a
+                href={person.instagram}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-ios-blue break-all active:underline"
+              >
+                {person.instagram}
+              </a>
+            ) : (
+              <p className="text-xs text-ios-label break-all">{person.instagram}</p>
+            )}
+          </div>
+        )}
+        {person?.telegram && (
+          <div className="mt-1">
+            <p className="text-[10px] text-ios-tertiary mb-0.5">{t.keyPersonTelegram}</p>
+            <p className="text-xs text-ios-label break-all">{person.telegram}</p>
+          </div>
+        )}
       </div>
     );
   }
@@ -179,6 +209,40 @@ function KeyPersonSlot({ slot, cust, onPatch, person, onPatchPerson, canEdit, au
               type="text"
               defaultValue={person.address || ''}
               onBlur={e => onPatchPerson(person.id, { address: e.target.value || null })}
+              className="w-full text-sm text-ios-label bg-transparent border-b border-dashed border-gray-300
+                focus:border-brand-500 focus:outline-none py-0.5"
+            />
+          </div>
+          <div className="mt-1">
+            <div className="flex items-center justify-between">
+              <p className="text-[10px] text-ios-tertiary mb-0.5">{t.keyPersonInstagram}</p>
+              {looksLikeUrl(person.instagram) && (
+                <a
+                  href={person.instagram}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[10px] text-brand-600 active:underline"
+                >
+                  &#8599;
+                </a>
+              )}
+            </div>
+            <input
+              type="text"
+              defaultValue={person.instagram || ''}
+              onBlur={e => onPatchPerson(person.id, { instagram: e.target.value || null })}
+              placeholder="@handle"
+              className="w-full text-sm text-ios-label bg-transparent border-b border-dashed border-gray-300
+                focus:border-brand-500 focus:outline-none py-0.5"
+            />
+          </div>
+          <div className="mt-1">
+            <p className="text-[10px] text-ios-tertiary mb-0.5">{t.keyPersonTelegram}</p>
+            <input
+              type="text"
+              defaultValue={person.telegram || ''}
+              onBlur={e => onPatchPerson(person.id, { telegram: e.target.value || null })}
+              placeholder="@handle"
               className="w-full text-sm text-ios-label bg-transparent border-b border-dashed border-gray-300
                 focus:border-brand-500 focus:outline-none py-0.5"
             />

--- a/apps/florist/src/components/steps/Step1Customer.jsx
+++ b/apps/florist/src/components/steps/Step1Customer.jsx
@@ -410,7 +410,7 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
                 {kpFiltered.map(p => (
                   <button
                     key={p.id}
-                    onClick={() => { setKpId(p.id); setKpName(p.name); setKpQuery(''); setKpPhone(p.phone || ''); setKpAddress(p.address || ''); setKpInstagram(p.instagram || ''); setKpTelegram(p.telegram || ''); }}
+                    onClick={() => { setKpId(p.id); setKpName(p.name); setKpQuery(''); setKpPhone(p.phone || ''); setKpAddress(p.address || ''); }}
                     className={`w-full text-left px-4 py-3 flex items-center gap-2 active:bg-ios-fill ${kpId === p.id ? 'bg-brand-50 dark:bg-brand-900/20' : ''}`}
                   >
                     <span className="flex-1 min-w-0 text-left">

--- a/apps/florist/src/components/steps/Step1Customer.jsx
+++ b/apps/florist/src/components/steps/Step1Customer.jsx
@@ -25,6 +25,8 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
   const [kpName, setKpName]       = useState('');
   const [kpPhone, setKpPhone]     = useState('');
   const [kpAddress, setKpAddress] = useState('');
+  const [kpInstagram, setKpInstagram] = useState(''); // #553
+  const [kpTelegram, setKpTelegram]   = useState(''); // #553
   const [kpCreating, setKpCreating] = useState(false);
   const kpDebounceRef               = useRef(null);
 
@@ -63,6 +65,8 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
     setKpName('');
     setKpPhone('');
     setKpAddress('');
+    setKpInstagram('');
+    setKpTelegram('');
     setQuery('');
     setResults([]);
     setShowCreate(false);
@@ -95,8 +99,10 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
       setKpCreating(true);
       try {
         const reqBody = { name: kpName.trim() };
-        if (kpPhone.trim())   reqBody.phone   = kpPhone.trim();
-        if (kpAddress.trim()) reqBody.address = kpAddress.trim();
+        if (kpPhone.trim())     reqBody.phone     = kpPhone.trim();
+        if (kpAddress.trim())   reqBody.address   = kpAddress.trim();
+        if (kpInstagram.trim()) reqBody.instagram = kpInstagram.trim();
+        if (kpTelegram.trim())  reqBody.telegram  = kpTelegram.trim();
         const res = await client.post(`/customers/${chosenCustomer.id}/key-people`, reqBody);
         resolvedKpId    = res.data.id;
         resolvedPhone   = res.data.phone   || '';
@@ -383,7 +389,7 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
                 value={kpName}
                 onChange={e => {
                   setKpName(e.target.value);
-                  if (kpId) { setKpPhone(''); setKpAddress(''); }
+                  if (kpId) { setKpPhone(''); setKpAddress(''); setKpInstagram(''); setKpTelegram(''); }
                   setKpId(null); // clear matched id when user edits
                   setKpQuery(e.target.value);
                 }}
@@ -393,7 +399,7 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
               />
               {kpName && (
                 <button
-                  onClick={() => { setKpName(''); setKpId(null); setKpQuery(''); setKpPhone(''); setKpAddress(''); }}
+                  onClick={() => { setKpName(''); setKpId(null); setKpQuery(''); setKpPhone(''); setKpAddress(''); setKpInstagram(''); setKpTelegram(''); }}
                   className="text-ios-tertiary text-sm"
                 >✕</button>
               )}
@@ -404,7 +410,7 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
                 {kpFiltered.map(p => (
                   <button
                     key={p.id}
-                    onClick={() => { setKpId(p.id); setKpName(p.name); setKpQuery(''); setKpPhone(p.phone || ''); setKpAddress(p.address || ''); }}
+                    onClick={() => { setKpId(p.id); setKpName(p.name); setKpQuery(''); setKpPhone(p.phone || ''); setKpAddress(p.address || ''); setKpInstagram(p.instagram || ''); setKpTelegram(p.telegram || ''); }}
                     className={`w-full text-left px-4 py-3 flex items-center gap-2 active:bg-ios-fill ${kpId === p.id ? 'bg-brand-50 dark:bg-brand-900/20' : ''}`}
                   >
                     <span className="flex-1 min-w-0 text-left">
@@ -448,6 +454,26 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
                   value={kpAddress}
                   onChange={e => setKpAddress(e.target.value)}
                   placeholder="ul. Kwiatowa 1, Krakow"
+                  className="flex-1 text-base bg-transparent outline-none text-ios-label placeholder-ios-tertiary/50"
+                />
+              </div>
+              <div className="flex items-center px-4 py-3 gap-3">
+                <span className="text-sm text-ios-tertiary w-24 shrink-0">{t.keyPersonInstagram}</span>
+                <input
+                  type="text"
+                  value={kpInstagram}
+                  onChange={e => setKpInstagram(e.target.value)}
+                  placeholder="@handle"
+                  className="flex-1 text-base bg-transparent outline-none text-ios-label placeholder-ios-tertiary/50"
+                />
+              </div>
+              <div className="flex items-center px-4 py-3 gap-3">
+                <span className="text-sm text-ios-tertiary w-24 shrink-0">{t.keyPersonTelegram}</span>
+                <input
+                  type="text"
+                  value={kpTelegram}
+                  onChange={e => setKpTelegram(e.target.value)}
+                  placeholder="@handle"
                   className="flex-1 text-base bg-transparent outline-none text-ios-label placeholder-ios-tertiary/50"
                 />
               </div>

--- a/apps/florist/src/translations.js
+++ b/apps/florist/src/translations.js
@@ -807,6 +807,8 @@ const en = {
   importantDate:             'Important date',
   keyPersonPhone:            'Phone',
   keyPersonAddress:          'Address',
+  keyPersonInstagram:        'Instagram', // #553 — brand name stays latin
+  keyPersonTelegram:         'Telegram',  // #553 — brand name stays latin
 
   // Timeline
   timeline:                  'Timeline',
@@ -1738,6 +1740,8 @@ const ru = {
   importantDate:             'Важная дата',
   keyPersonPhone:            'Телефон',
   keyPersonAddress:          'Адрес',
+  keyPersonInstagram:        'Instagram', // #553 — brand name stays latin
+  keyPersonTelegram:         'Telegram',  // #553 — brand name stays latin
 
   // Timeline
   timeline:                  'История',

--- a/backend/src/__tests__/customerRepo.keyPeople.integration.test.js
+++ b/backend/src/__tests__/customerRepo.keyPeople.integration.test.js
@@ -1,5 +1,6 @@
-// Integration: key_people phone + address round-trip (CR-30 C1).
-// Boots pglite, applies migrations (incl. 0018), exercises the repo against real SQL.
+// Integration: key_people phone + address round-trip (CR-30 C1), extended with
+// instagram + telegram (#553, migration 0023).
+// Boots pglite, applies migrations (incl. 0018 + 0023), exercises the repo against real SQL.
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setupPgHarness, teardownPgHarness } from './helpers/pgHarness.js';
 import { customers } from '../db/schema.js';
@@ -127,5 +128,120 @@ describe('updateKeyPerson (CR-30 C4)', () => {
     await expect(
       updateKeyPerson('00000000-0000-0000-0000-000000000000', { phone: '+48000000000' }),
     ).rejects.toMatchObject({ statusCode: 404 });
+  });
+});
+
+describe('key_people instagram + telegram (#553)', () => {
+  it('persists instagram + telegram on create and returns them from list', async () => {
+    const created = await createKeyPerson(customerId, {
+      name: 'Babcia Maria',
+      instagram: 'https://instagram.com/babcia.maria',
+      telegram: 'babcia_maria',
+    });
+
+    expect(created).toMatchObject({
+      name: 'Babcia Maria',
+      instagram: 'https://instagram.com/babcia.maria',
+      telegram: 'babcia_maria',
+    });
+
+    const list = await listKeyPeople(customerId);
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      name: 'Babcia Maria',
+      instagram: 'https://instagram.com/babcia.maria',
+      telegram: 'babcia_maria',
+    });
+  });
+
+  it('defaults instagram + telegram to null when omitted (back-compat)', async () => {
+    await createKeyPerson(customerId, { name: 'Brat Piotr' });
+    const [row] = await listKeyPeople(customerId);
+    expect(row.name).toBe('Brat Piotr');
+    expect(row.instagram).toBeNull();
+    expect(row.telegram).toBeNull();
+  });
+
+  it('treats empty-string instagram/telegram as null', async () => {
+    const created = await createKeyPerson(customerId, { name: 'X', instagram: '', telegram: '' });
+    expect(created.instagram).toBeNull();
+    expect(created.telegram).toBeNull();
+  });
+
+  it('does not require instagram/telegram alongside phone/address — all four are independent', async () => {
+    const created = await createKeyPerson(customerId, {
+      name: 'Full Profile',
+      phone: '+48500100200',
+      address: 'ul. Kwiatowa 7, Kraków',
+      instagram: '@full.profile',
+      telegram: 'fullprofile',
+    });
+    expect(created).toMatchObject({
+      phone: '+48500100200',
+      address: 'ul. Kwiatowa 7, Kraków',
+      instagram: '@full.profile',
+      telegram: 'fullprofile',
+    });
+  });
+});
+
+describe('updateKeyPerson — instagram + telegram (#553)', () => {
+  it('updates instagram + telegram and reflects the change in listKeyPeople', async () => {
+    const created = await createKeyPerson(customerId, {
+      name: 'Babcia Maria',
+      instagram: '@babcia.maria',
+      telegram: 'babcia_old',
+    });
+
+    const updated = await updateKeyPerson(created.id, {
+      instagram: 'https://instagram.com/babcia.maria.nowak',
+      telegram: 'babcia_nowak',
+    });
+
+    expect(updated).toMatchObject({
+      id:        created.id,
+      instagram: 'https://instagram.com/babcia.maria.nowak',
+      telegram:  'babcia_nowak',
+    });
+
+    const list = await listKeyPeople(customerId);
+    expect(list).toHaveLength(1);
+    expect(list[0]).toMatchObject({
+      instagram: 'https://instagram.com/babcia.maria.nowak',
+      telegram:  'babcia_nowak',
+    });
+  });
+
+  it('partial update of only telegram leaves instagram + name intact', async () => {
+    const created = await createKeyPerson(customerId, {
+      name: 'Brat Piotr',
+      instagram: '@brat.piotr',
+      telegram: 'old_handle',
+    });
+
+    const updated = await updateKeyPerson(created.id, { telegram: 'new_handle' });
+
+    expect(updated).toMatchObject({
+      name:      'Brat Piotr',
+      instagram: '@brat.piotr',
+      telegram:  'new_handle',
+    });
+
+    const [row] = await listKeyPeople(customerId);
+    expect(row.instagram).toBe('@brat.piotr');
+    expect(row.telegram).toBe('new_handle');
+  });
+
+  it('clears instagram/telegram back to null when explicitly set empty', async () => {
+    const created = await createKeyPerson(customerId, {
+      name: 'X',
+      instagram: '@x',
+      telegram: 'x_handle',
+    });
+
+    const updated = await updateKeyPerson(created.id, { instagram: '', telegram: '' });
+
+    expect(updated.instagram).toBeNull();
+    expect(updated.telegram).toBeNull();
   });
 });

--- a/backend/src/__tests__/customerRepo.keyPeople.integration.test.js
+++ b/backend/src/__tests__/customerRepo.keyPeople.integration.test.js
@@ -244,4 +244,17 @@ describe('updateKeyPerson — instagram + telegram (#553)', () => {
     expect(updated.instagram).toBeNull();
     expect(updated.telegram).toBeNull();
   });
+
+  it('clears instagram/telegram back to null when explicitly set to null (not just empty string)', async () => {
+    const created = await createKeyPerson(customerId, {
+      name: 'Y',
+      instagram: '@y',
+      telegram: 'y_handle',
+    });
+
+    const updated = await updateKeyPerson(created.id, { instagram: null, telegram: null });
+
+    expect(updated.instagram).toBeNull();
+    expect(updated.telegram).toBeNull();
+  });
 });

--- a/backend/src/db/migrations/0023_key_people_instagram_telegram.sql
+++ b/backend/src/db/migrations/0023_key_people_instagram_telegram.sql
@@ -1,0 +1,8 @@
+-- Instagram + Telegram as first-class key_people columns (#553).
+-- Owner wants dedicated inputs for a key person's social contact info,
+-- alongside phone + address (CR-30, migration 0018).
+-- Additive + nullable → safe on prod.
+
+ALTER TABLE "key_people" ADD COLUMN "instagram" text;
+--> statement-breakpoint
+ALTER TABLE "key_people" ADD COLUMN "telegram" text;

--- a/backend/src/db/schema.js
+++ b/backend/src/db/schema.js
@@ -309,6 +309,8 @@ export const keyPeople = pgTable('key_people', {
   contactDetails:     text('contact_details'),
   phone:              text('phone'),      // recipient phone — reusable address book (CR-30)
   address:            text('address'),    // recipient delivery address (CR-30)
+  instagram:          text('instagram'),  // key person's Instagram link/handle (#553)
+  telegram:           text('telegram'),   // key person's Telegram nickname (#553)
   importantDate:      date('important_date'),
   importantDateLabel: text('important_date_label'),
   createdAt:          timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),

--- a/backend/src/repos/customerRepo.js
+++ b/backend/src/repos/customerRepo.js
@@ -360,13 +360,15 @@ export async function listKeyPeople(customerId) {
     contactDetails: r.contactDetails ?? null,
     phone:          r.phone ?? null,
     address:        r.address ?? null,
+    instagram:      r.instagram ?? null,
+    telegram:       r.telegram ?? null,
     importantDate:  r.importantDate ?? null,
     importantDateLabel: r.importantDateLabel ?? null,
     createdAt:     r.createdAt,
   }));
 }
 
-export async function createKeyPerson(customerId, { name, contactDetails = null, phone = null, address = null, importantDate = null, importantDateLabel = null } = {}) {
+export async function createKeyPerson(customerId, { name, contactDetails = null, phone = null, address = null, instagram = null, telegram = null, importantDate = null, importantDateLabel = null } = {}) {
   if (!name || !name.trim()) {
     const err = new Error('name is required');
     err.statusCode = 400;
@@ -378,6 +380,8 @@ export async function createKeyPerson(customerId, { name, contactDetails = null,
     contactDetails: contactDetails || null,
     phone: phone || null,
     address: address || null,
+    instagram: instagram || null,
+    telegram: telegram || null,
     importantDate: importantDate || null,
     importantDateLabel: importantDateLabel || null,
   }).returning();
@@ -387,6 +391,8 @@ export async function createKeyPerson(customerId, { name, contactDetails = null,
     contactDetails: row.contactDetails ?? null,
     phone:          row.phone ?? null,
     address:        row.address ?? null,
+    instagram:      row.instagram ?? null,
+    telegram:       row.telegram ?? null,
     importantDate:  row.importantDate ?? null,
     importantDateLabel: row.importantDateLabel ?? null,
     createdAt:     row.createdAt,
@@ -410,6 +416,8 @@ export async function updateKeyPerson(personId, changes = {}) {
   if (changes.contactDetails !== undefined) set.contactDetails = changes.contactDetails || null;
   if (changes.phone !== undefined) set.phone = changes.phone || null;
   if (changes.address !== undefined) set.address = changes.address || null;
+  if (changes.instagram !== undefined) set.instagram = changes.instagram || null;
+  if (changes.telegram !== undefined) set.telegram = changes.telegram || null;
   if (changes.importantDate !== undefined) {
     if (changes.importantDate != null && changes.importantDate !== '') {
       if (!ISO_DATE_RE.test(changes.importantDate)) {
@@ -449,6 +457,8 @@ export async function updateKeyPerson(personId, changes = {}) {
     contactDetails: row.contactDetails ?? null,
     phone:          row.phone ?? null,
     address:        row.address ?? null,
+    instagram:      row.instagram ?? null,
+    telegram:       row.telegram ?? null,
     importantDate:  row.importantDate ?? null,
     importantDateLabel: row.importantDateLabel ?? null,
     createdAt:     row.createdAt,

--- a/backend/src/routes/customers.js
+++ b/backend/src/routes/customers.js
@@ -238,8 +238,8 @@ router.get('/:id/key-people', async (req, res, next) => {
 // POST /api/customers/:id/key-people — create a new key person for a customer
 router.post('/:id/key-people', async (req, res, next) => {
   try {
-    const { name, contactDetails, phone, address, importantDate, importantDateLabel } = req.body;
-    const person = await customerRepo.createKeyPerson(req.params.id, { name, contactDetails, phone, address, importantDate, importantDateLabel });
+    const { name, contactDetails, phone, address, instagram, telegram, importantDate, importantDateLabel } = req.body;
+    const person = await customerRepo.createKeyPerson(req.params.id, { name, contactDetails, phone, address, instagram, telegram, importantDate, importantDateLabel });
     res.status(201).json(person);
   } catch (err) {
     if (err.statusCode === 400) return res.status(400).json({ error: err.message });
@@ -250,8 +250,8 @@ router.post('/:id/key-people', async (req, res, next) => {
 // PATCH /api/customers/:id/key-people/:personId — partial update of a key person
 router.patch('/:id/key-people/:personId', async (req, res, next) => {
   try {
-    const { name, contactDetails, phone, address, importantDate, importantDateLabel } = req.body;
-    const person = await customerRepo.updateKeyPerson(req.params.personId, { name, contactDetails, phone, address, importantDate, importantDateLabel });
+    const { name, contactDetails, phone, address, instagram, telegram, importantDate, importantDateLabel } = req.body;
+    const person = await customerRepo.updateKeyPerson(req.params.personId, { name, contactDetails, phone, address, instagram, telegram, importantDate, importantDateLabel });
     res.json(person);
   } catch (err) {
     if (err.statusCode === 400 || err.statusCode === 404) return res.status(err.statusCode).json({ error: err.message });


### PR DESCRIPTION
## What

Adds two optional fields to Key Person records — **Instagram** link/handle and **Telegram** nickname — captured wherever a key person is created or edited, and displayed wherever their contact details are shown.

- New-order wizard, both apps (`Step1Customer.jsx`): the "add new recipient" form (shown while typing a brand-new key-person name) gains Instagram + Telegram inputs alongside the existing phone/address.
- CRM detail view, both apps (`CustomerDetailView.jsx` / `KeyPersonChips.jsx`): Instagram + Telegram shown and inline-editable per key person, persisted on blur via the existing key-person PATCH route. Instagram renders as a clickable new-tab link when the stored value looks like a URL (`https?://…`), otherwise as plain text (e.g. a bare `@handle`) — no strict validation, whatever the owner pastes is stored as-is. Telegram always renders as plain nickname text. Florist's `!canEdit` (non-owner) view-only branch mirrors the same display rules.

## Why

Owner request (#553, priority:high): *"when we put info about a key person, special spaces for Insta link and Telegram nickname are needed too."* Both fields are optional and never block Order or Customer creation.

## Schema note

- Migration `backend/src/db/migrations/0023_key_people_instagram_telegram.sql` — adds nullable `key_people.instagram` + `key_people.telegram` (`ALTER TABLE ... ADD COLUMN`). Additive, nullable-only — **no backfill needed**, safe on prod. Follows the exact same shape/pattern as CR-30's migration `0018_key_people_phone_address.sql` (also nullable phone/address).
- `backend/src/db/schema.js` — `keyPeople` table gains the two Drizzle column defs.
- **Lab check:** grepped `lab/` for `key_people`/`keyPeople` — no factory exists (only prose in `lab/WORKFLOW.md`); `lab/factories/customer.js` doesn't reference key people either. Both new columns are nullable `ADD COLUMN`, so **no lab factory update is required**.

## Deviations / scope notes

- `Step3Details.jsx` (delivery pre-fill step) was **deliberately not touched** in either app. Instagram/Telegram are key-person profile fields, not delivery-fulfilment fields like phone/address (which the courier actually needs on the delivery slip) — there's nothing for the Step3 pre-fill effect to consume. This also keeps the diff clear of the concurrent recipient-auto-save work landing on that same file in another branch.
- No CLAUDE.md updates — the root/dashboard/florist CLAUDE.md docs describe `KeyPersonChips.jsx`/`CustomerDetailView.jsx`/`Step1Customer.jsx` at the component/purpose level, not per-field; the CR-30 phone/address precedent (#471) didn't touch them either at that same grain.
- No BACKLOG.md item existed for #553 (tracked directly via GitHub Issues), so nothing to check off.
- Review follow-up: the autocomplete "pick an existing key person" handler also called `setKpInstagram`/`setKpTelegram`, but those inputs only render while CREATING a new person (`!kpId` gate) and the save-to-server call is likewise gated to the create path only — so picking an existing person could never display or persist those two fields via that dead assignment. Removed the two setter calls; picking an existing person now only pre-fills what's actually used (phone/address).

## Verification

- `cd backend && npx vitest run --no-file-parallelism` → **110 files / 999 tests passed**.
- `npm run lab:test:unit` → **9 files / 77 tests passed**.
- API E2E suite (`npm run harness` + `npm run test:e2e`) → **253/253 passed**, incl. section 26 (Customer CRUD via PG, 18/18). Run on an isolated port (`PORT=3102` / `HARNESS_PORT=3102`) since the default harness port 3002 was already held by a concurrent worktree session at verification time — avoided killing another session's process, consistent with the cross-session-collision precedent noted in the CR-30 PR body.
- `cd apps/dashboard && ./node_modules/.bin/vite build` → green.
- `cd apps/florist && ./node_modules/.bin/vite build` → green.
- `cd backend && npm run lint` → 0 errors; the 174 pre-existing warnings are all in files this PR didn't touch (confirmed via targeted grep of the changed files — zero new warnings introduced).
- New/extended test coverage: `backend/src/__tests__/customerRepo.keyPeople.integration.test.js` (pglite, applies migration 0023) — instagram/telegram create + list round-trip, back-compat null default, empty-string→null normalization, independence from phone/address, and full `updateKeyPerson` coverage (full update, partial update, explicit clear-to-null via both `''` and `null`).

Closes #553

🤖 Generated with [Claude Code](https://claude.com/claude-code)
