### PR TITLE
fix(orders): surface request failures in new-order Step 1 (pitfall #5)

### DIFF
--- a/apps/dashboard/src/components/steps/Step1Customer.jsx
+++ b/apps/dashboard/src/components/steps/Step1Customer.jsx
@@ -38,7 +38,10 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
       try {
         const res = await client.get('/customers', { params: { search: query } });
         setResults(res.data);
-      } catch { /* ignore */ }
+      } catch (err) {
+        console.error('Customer search failed:', err);
+        showToast(err.response?.data?.error || t.error, 'error');
+      }
       finally { setSearching(false); }
     }, 400);
     return () => clearTimeout(debounceRef.current);
@@ -51,7 +54,10 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
       try {
         const res = await client.get(`/customers/${chosenCustomer.id}/key-people`);
         setKpResults(res.data);
-      } catch { /* ignore */ }
+      } catch (err) {
+        console.error('Failed to load key people:', err);
+        showToast(err.response?.data?.error || t.error, 'error');
+      }
     }, 200);
     return () => clearTimeout(kpDebounceRef.current);
   }, [chosenCustomer?.id]);
@@ -76,7 +82,10 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
     try {
       const res = await client.post('/customers', newCustomer);
       selectCustomer(res.data);
-    } catch { /* ignore */ }
+    } catch (err) {
+      console.error('Failed to create customer:', err);
+      showToast(err.response?.data?.error || t.error, 'error');
+    }
     finally { setSaving(false); }
   }
 

--- a/apps/florist/src/components/steps/Step1Customer.jsx
+++ b/apps/florist/src/components/steps/Step1Customer.jsx
@@ -38,7 +38,10 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
       try {
         const res = await client.get(`/customers/${chosenCustomer.id}/key-people`);
         setKpResults(res.data);
-      } catch { /* ignore */ }
+      } catch (err) {
+        console.error('Failed to load key people:', err);
+        showToast(err.response?.data?.error || t.error, 'error');
+      }
     }, 200);
     return () => clearTimeout(kpDebounceRef.current);
   }, [chosenCustomer?.id]);
@@ -51,7 +54,10 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
       try {
         const res = await client.get('/customers', { params: { search: query } });
         setResults(res.data);
-      } catch { /* ignore */ }
+      } catch (err) {
+        console.error('Customer search failed:', err);
+        showToast(err.response?.data?.error || t.error, 'error');
+      }
       finally { setSearching(false); }
     }, 400);
     return () => clearTimeout(debounceRef.current);
@@ -84,7 +90,10 @@ export default function Step1Customer({ customerId, customerName, onSelect, onCh
     try {
       const res = await client.post('/customers', newCustomer);
       selectCustomer(res.data);
-    } catch { /* ignore */ }
+    } catch (err) {
+      console.error('Failed to create customer:', err);
+      showToast(err.response?.data?.error || t.error, 'error');
+    }
     finally { setSaving(false); }
   }
 


### PR DESCRIPTION
## What

`Step1Customer.jsx` had three silent `catch { /* ignore */ }` blocks in **each** app. Every failure mode rendered identically to "no results found":

| Request | Silent failure looked like |
|---|---|
| `GET /customers?search=` | Empty results list, no indication anything broke |
| `GET /customers/:id/key-people` | Recipient suggestions vanish → user retypes an existing Key Person and creates a **duplicate** |
| `POST /customers` | Spinner stops, nothing happens at all |

All three now `console.error` + show the backend error message:

```js
console.error('...', err);
showToast(err.response?.data?.error || t.error, 'error');
```

## Why

Root `CLAUDE.md` → Known Pitfalls **#5 Silent catch blocks**: *"every `catch` should either show a toast with the backend error message or log meaningfully. Never `catch(() => {})`."* Same pitfall was just fixed in `ChangeCustomerModal.jsx` (both apps) in #575 — this is the sibling occurrence in the new-order wizard, using the identical pattern.

I fixed all three rather than only the primary search. The key-people lookup is a secondary autocomplete, but its effect is keyed on `chosenCustomer?.id` (fires once per customer selection, **not** per keystroke), so a toast there is not noisy — and its silent failure causes real data pollution via duplicate Key People. The create-customer POST is the highest-impact of the three.

Both components already call `useToast()` and import `t`, so no new imports.

## Parity

Fixed identically in `apps/florist` and `apps/dashboard` per the cross-app parity rule (`Order creation: NewOrderPage.jsx + steps/` ↔ `NewOrderTab.jsx + steps/`). No backend, shared-package, or schema change — no `CHANGELOG.md` entry needed.

## Verification

All run locally in this worktree before push:

- `cd backend && npx vitest run --no-file-parallelism` → **118 files, 1078 tests passed**
- `cd apps/florist && ./node_modules/.bin/vite build` → **✓ built in 2.21s**
- `cd apps/dashboard && ./node_modules/.bin/vite build` → **✓ built in 2.31s**

Delivery app not built and `packages/shared` tests not run — the diff touches neither. Lab harness skipped (no `backend/`, `packages/shared/`, or `lab/` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)