### PR TITLE
refactor(status): replace raw status string keys with statuses.js constants

### DIFF
--- a/apps/dashboard/src/components/DayToDayTab.jsx
+++ b/apps/dashboard/src/components/DayToDayTab.jsx
@@ -10,6 +10,11 @@ import t from '../translations.js';
 import SummaryCard from './SummaryCard.jsx';
 import KanbanBoard from './KanbanBoard.jsx';
 import { DashboardSkeleton } from './Skeleton.jsx';
+// Status constants — single source of truth in backend/src/constants/statuses.js.
+// packages/shared doesn't re-export these (only duplicates a couple of status
+// arrays for other purposes), and editing packages/shared is out of scope for
+// this fix, so this imports the backend file directly via relative path.
+import { ORDER_STATUS, PAYMENT_STATUS } from '../../../../backend/src/constants/statuses.js';
 
 // "2026-03-08" → "Mar 8"
 function fmtDate(iso) {
@@ -19,12 +24,12 @@ function fmtDate(iso) {
 }
 
 const ALL_STATUSES = [
-  { key: 'New',              color: 'text-indigo-600' },
-  { key: 'Ready',            color: 'text-amber-600' },
-  { key: 'Out for Delivery', color: 'text-sky-600' },
-  { key: 'Delivered',        color: 'text-emerald-600' },
-  { key: 'Picked Up',        color: 'text-teal-600' },
-  { key: 'Cancelled',        color: 'text-rose-600' },
+  { key: ORDER_STATUS.NEW,              color: 'text-indigo-600' },
+  { key: ORDER_STATUS.READY,            color: 'text-amber-600' },
+  { key: ORDER_STATUS.OUT_FOR_DELIVERY, color: 'text-sky-600' },
+  { key: ORDER_STATUS.DELIVERED,        color: 'text-emerald-600' },
+  { key: ORDER_STATUS.PICKED_UP,        color: 'text-teal-600' },
+  { key: ORDER_STATUS.CANCELLED,        color: 'text-rose-600' },
 ];
 
 // Delivery type icon helper
@@ -210,8 +215,8 @@ export default function DayToDayTab({ onNavigate, isActive = true }) {
 
   // Compute paid/unpaid totals from recent orders (use Effective Price computed by backend)
   // Revenue still uses recentOrders (orders by Order Date); fulfillToday is for operational display
-  const paidOrders = (data.recentOrders || []).filter(o => o['Payment Status'] === 'Paid');
-  const unpaidOrders = (data.recentOrders || []).filter(o => o['Payment Status'] === 'Unpaid');
+  const paidOrders = (data.recentOrders || []).filter(o => o['Payment Status'] === PAYMENT_STATUS.PAID);
+  const unpaidOrders = (data.recentOrders || []).filter(o => o['Payment Status'] === PAYMENT_STATUS.UNPAID);
   const unpaidTotal = unpaidOrders.reduce((sum, o) => sum + (o['Effective Price'] || 0), 0);
 
   // Sort helper: chronological by time slot start (e.g. "10:00-12:00" → "10:00")
@@ -251,14 +256,14 @@ export default function DayToDayTab({ onNavigate, isActive = true }) {
           value={`${data.todayRevenue.toFixed(0)} ${t.zl}`}
           detail={`${paidOrders.length} orders`}
           color="green"
-          onClick={() => nav('orders', { payment: 'Paid' })}
+          onClick={() => nav('orders', { payment: PAYMENT_STATUS.PAID })}
         />
         <SummaryCard
           label={t.unpaid}
           value={unpaidOrders.length > 0 ? `${unpaidTotal.toFixed(0)} ${t.zl}` : '✓'}
           detail={unpaidOrders.length > 0 ? `${unpaidOrders.length} orders` : 'All paid'}
           color={unpaidOrders.length > 0 ? 'red' : 'green'}
-          onClick={() => nav('orders', { payment: 'Unpaid' })}
+          onClick={() => nav('orders', { payment: PAYMENT_STATUS.UNPAID })}
         />
       </div>
 
@@ -432,7 +437,7 @@ export default function DayToDayTab({ onNavigate, isActive = true }) {
                     from.setDate(from.getDate() - bucket.daysBack);
                   }
                   const fmt = d => d.toISOString().split('T')[0];
-                  nav('orders', { payment: 'Unpaid', dateFrom: fmt(from), dateTo: fmt(to) });
+                  nav('orders', { payment: PAYMENT_STATUS.UNPAID, dateFrom: fmt(from), dateTo: fmt(to) });
                 }}
                 className={`rounded-xl px-3 py-2 text-center transition-all ${
                   bucket.data.count > 0 ? 'cursor-pointer hover:ring-2 hover:ring-brand-300 active-scale' : ''

--- a/apps/delivery/src/pages/DeliveryListPage.jsx
+++ b/apps/delivery/src/pages/DeliveryListPage.jsx
@@ -17,6 +17,11 @@ import MapView from '../components/MapView.jsx';
 import HelpPanel from '../components/HelpPanel.jsx';
 import { useNotifications } from '../hooks/useNotifications.js';
 import { FeedbackModal } from '@flower-studio/shared';
+// Status constants — single source of truth in backend/src/constants/statuses.js.
+// packages/shared doesn't re-export these (only duplicates a couple of status
+// arrays for other purposes), and editing packages/shared is out of scope for
+// this fix, so this imports the backend file directly via relative path.
+import { DELIVERY_STATUS, DELIVERY_RESULT, PO_STATUS } from '../../../../backend/src/constants/statuses.js';
 
 function todayStr() {
   const d = new Date();
@@ -107,8 +112,8 @@ export default function DeliveryListPage() {
   // Check for assigned stock pickups
   useEffect(() => {
     Promise.all([
-      client.get('/stock-orders?status=Sent').catch(() => ({ data: [] })),
-      client.get('/stock-orders?status=Shopping').catch(() => ({ data: [] })),
+      client.get(`/stock-orders?status=${PO_STATUS.SENT}`).catch(() => ({ data: [] })),
+      client.get(`/stock-orders?status=${PO_STATUS.SHOPPING}`).catch(() => ({ data: [] })),
     ]).then(([sent, shopping]) => {
       setPickupCount(sent.data.length + shopping.data.length);
     });
@@ -131,14 +136,14 @@ export default function DeliveryListPage() {
     }
 
     const groups = {
-      'Pending':          [],
-      'Out for Delivery': [],
-      'Delivered':        [],
+      [DELIVERY_STATUS.PENDING]:          [],
+      [DELIVERY_STATUS.OUT_FOR_DELIVERY]: [],
+      [DELIVERY_STATUS.DELIVERED]:        [],
     };
     todayList.forEach(d => {
-      const status = d['Status'] || 'Pending';
+      const status = d['Status'] || DELIVERY_STATUS.PENDING;
       if (groups[status]) groups[status].push(d);
-      else groups['Pending'].push(d);
+      else groups[DELIVERY_STATUS.PENDING].push(d);
     });
     const prioritySort = (a, b) => {
       const aIsMine = a['Assigned Driver'] === driverName ? 0 : 1;
@@ -146,9 +151,9 @@ export default function DeliveryListPage() {
       if (aIsMine !== bIsMine) return aIsMine - bIsMine;
       return (a['Courier Time'] || a['Delivery Time'] || '').localeCompare(b['Courier Time'] || b['Delivery Time'] || '');
     };
-    groups['Pending'].sort(prioritySort);
-    groups['Out for Delivery'].sort(prioritySort);
-    groups['Delivered'].sort(prioritySort);
+    groups[DELIVERY_STATUS.PENDING].sort(prioritySort);
+    groups[DELIVERY_STATUS.OUT_FOR_DELIVERY].sort(prioritySort);
+    groups[DELIVERY_STATUS.DELIVERED].sort(prioritySort);
 
     // Group future deliveries by date so the driver sees Tomorrow / Day after / ...
     const byDate = {};
@@ -172,11 +177,11 @@ export default function DeliveryListPage() {
   // Standard status change — optimistic update, revert on failure
   async function updateStatus(id, newStatus) {
     const patch = { Status: newStatus };
-    if (newStatus === 'Delivered') patch['Delivery Result'] = 'Success';
+    if (newStatus === DELIVERY_STATUS.DELIVERED) patch['Delivery Result'] = DELIVERY_RESULT.SUCCESS;
     // Optimistic: apply immediately
     const prevDeliveries = deliveries;
     setDeliveries(prev => prev.map(d => d.id === id ? { ...d, ...patch } : d));
-    if (newStatus === 'Delivered') setSelectedId(null);
+    if (newStatus === DELIVERY_STATUS.DELIVERED) setSelectedId(null);
     try {
       const res = await client.patch(`/deliveries/${id}`, patch);
       setDeliveries(prev => prev.map(d => d.id === id ? { ...d, ...res.data } : d));
@@ -196,7 +201,7 @@ export default function DeliveryListPage() {
   async function handleDeliveryProblem(result) {
     const id = resultPickerId;
     setResultPickerId(null);
-    const patch = { Status: 'Delivered', 'Delivery Result': result };
+    const patch = { Status: DELIVERY_STATUS.DELIVERED, 'Delivery Result': result };
     // Optimistic
     const prevDeliveries = deliveries;
     setDeliveries(prev => prev.map(d => d.id === id ? { ...d, ...patch } : d));
@@ -222,13 +227,13 @@ export default function DeliveryListPage() {
 
   // Deliveries that need to appear on the map (not yet delivered)
   const activeDeliveries = useMemo(
-    () => deliveries.filter(d => d['Status'] !== 'Delivered'),
+    () => deliveries.filter(d => d['Status'] !== DELIVERY_STATUS.DELIVERED),
     [deliveries]
   );
 
-  const pendingCount = grouped['Pending'].length;
-  const outCount     = grouped['Out for Delivery'].length;
-  const doneCount    = grouped['Delivered'].length;
+  const pendingCount = grouped[DELIVERY_STATUS.PENDING].length;
+  const outCount     = grouped[DELIVERY_STATUS.OUT_FOR_DELIVERY].length;
+  const doneCount    = grouped[DELIVERY_STATUS.DELIVERED].length;
 
   if (showMap) {
     return (
@@ -301,14 +306,14 @@ export default function DeliveryListPage() {
         ) : (
           <>
             {/* Pending */}
-            {grouped['Pending'].length > 0 && (
+            {grouped[DELIVERY_STATUS.PENDING].length > 0 && (
               <section>
                 <p className="ios-label flex items-center gap-2">
                   <span className="w-2 h-2 rounded-full bg-ios-orange" />
                   {t.pending} ({pendingCount})
                 </p>
                 <div className="space-y-2">
-                  {grouped['Pending'].map(d => (
+                  {grouped[DELIVERY_STATUS.PENDING].map(d => (
                     <DeliveryCard
                       key={d.id}
                       delivery={d}
@@ -322,14 +327,14 @@ export default function DeliveryListPage() {
             )}
 
             {/* Out for Delivery */}
-            {grouped['Out for Delivery'].length > 0 && (
+            {grouped[DELIVERY_STATUS.OUT_FOR_DELIVERY].length > 0 && (
               <section>
                 <p className="ios-label flex items-center gap-2">
                   <span className="w-2 h-2 rounded-full bg-ios-blue" />
                   {t.outForDelivery} ({outCount})
                 </p>
                 <div className="space-y-2">
-                  {grouped['Out for Delivery'].map(d => (
+                  {grouped[DELIVERY_STATUS.OUT_FOR_DELIVERY].map(d => (
                     <DeliveryCard
                       key={d.id}
                       delivery={d}
@@ -343,14 +348,14 @@ export default function DeliveryListPage() {
             )}
 
             {/* Delivered */}
-            {grouped['Delivered'].length > 0 && (
+            {grouped[DELIVERY_STATUS.DELIVERED].length > 0 && (
               <section>
                 <p className="ios-label flex items-center gap-2">
                   <span className="w-2 h-2 rounded-full bg-ios-green" />
                   {t.delivered} ({doneCount})
                 </p>
                 <div className="space-y-2">
-                  {grouped['Delivered'].map(d => (
+                  {grouped[DELIVERY_STATUS.DELIVERED].map(d => (
                     <DeliveryCard
                       key={d.id}
                       delivery={d}


### PR DESCRIPTION
Recovered from a dangling local branch during a hygiene pass — never opened at the time. Single commit, unchanged.

## Summary
- DeliveryListPage.jsx (delivery) and DayToDayTab.jsx (dashboard) keyed grouping/colour-map objects off raw status string literals instead of the canonical constants in `backend/src/constants/statuses.js`. Converts every status literal to `DELIVERY_STATUS`/`DELIVERY_RESULT`/`PO_STATUS`/`ORDER_STATUS`/`PAYMENT_STATUS` references. No behavior change.

Closes #188

**⚠️ Needs a rebase** — 33 commits behind master, conflicts with later delivery-status work in `DeliveryListPage.jsx`. Not resolved in this pass; resolve before merging.

## Test plan
- [ ] Rebase onto master, resolve conflicts
- [ ] Re-run pre-PR matrix (frontend build for delivery + dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)