### PR TITLE
chore(ci): run the Playwright UI suite as a PR check (#612)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,18 @@
 name: Test
 
 # Runs on every pull request + every push to master.
-# Two jobs:
-#   - unit:   backend vitest suite (covers stockRepo, orderRepo, services, utils).
-#   - e2e:    boots the local-PG harness and runs scripts/e2e-test.js end-to-end.
+# Six jobs:
+#   - lint:     static guards (backend silent-catch ban, root pitfall #5).
+#   - unit:     backend vitest suite (covers stockRepo, orderRepo, services, utils).
+#   - shared:   packages/shared vitest (utils, hooks, components).
+#   - e2e:      boots the local-PG harness and runs scripts/e2e-test.js end-to-end.
+#   - ui:       Playwright drives the real React apps against that harness (#612).
+#   - lab-api:  lab factories + API integration gate against a real Postgres.
+#
+# Together these are CLAUDE.md's Pre-PR matrix. `ui` is item 4b, and it was the
+# one item nothing enforced until #612 — a UI spec could rot for weeks and no
+# PR check would notice. It exists because component tests and integration
+# tests both pass while the wiring between them is broken.
 #
 # Both jobs install deps from the root via `npm ci` (workspace layout) so
 # every workspace package is hoisted once. Backend devDeps include
@@ -152,6 +161,54 @@ jobs:
 
       - name: Run E2E suite
         run: npm run test:e2e
+
+  ui:
+    name: UI click-through (Playwright)
+    runs-on: ubuntu-latest
+    # Cold start dominates: pglite boots an in-process Postgres and replays
+    # every migration, then three Vite dev servers come up. The specs
+    # themselves run in well under a minute.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Chromium only — playwright.config.js defines a single `chromium`
+      # project. `--with-deps` pulls the system libraries the headless browser
+      # needs on a bare ubuntu runner.
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      # No harness boot step here: playwright.config.js owns its own
+      # `webServer` block (backend on :3002 + florist/delivery/dashboard Vite
+      # servers) and `reuseExistingServer: !process.env.CI` makes it always
+      # start fresh on CI. That is also why this cannot collide with the
+      # `e2e` job's harness — separate jobs, separate runners.
+      - name: Run UI suite
+        run: npm run test:ui
+
+      # The whole point of this job is that a broken spec must not be able to
+      # rot unnoticed (#612), so a failure has to be diagnosable from the PR
+      # without re-running anything locally. `trace: 'on-first-retry'` +
+      # `video: 'retain-on-failure'` are already configured; this is what
+      # carries them out of the runner.
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
 
   lab-api:
     name: Lab harness — API integration tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Operational platform for **Blossom**, a flower studio in Krakow. Each role — f
 - **Auth:** Stateless PIN via `X-Auth-PIN` header (Owner → all, Florist → orders/stock, Driver → deliveries)
 - **Real-time:** SSE via `GET /api/events` (new orders, status changes, stock alerts)
 - **Integrations:** Wix (e-commerce webhook + bidirectional product sync), Telegram (alerts), Claude AI (order intake parsing), Flowwow (email import)
-- **CI:** `.github/workflows/test.yml` runs Vitest (backend + shared) + the API E2E suite on every PR and on push to master.
+- **CI:** `.github/workflows/test.yml` runs six jobs on every PR and on push to master — static guards, backend Vitest, shared Vitest, the API E2E suite, the **Playwright UI click-through** (added #612; it was the one Pre-PR item nothing enforced), and the lab API gate. That is the Pre-PR matrix below, minus the three `vite build`s, which Vercel's preview deploys cover.
 
 ## Monorepo Layout
 ```
@@ -219,7 +219,7 @@ Before opening a PR or pushing changes that will trigger CI/Vercel builds, run t
 3. **Frontend changes** in any single app: `cd apps/<that-app> && ./node_modules/.bin/vite build`. Plus build any other app that imports a file you touched in `packages/shared/`.
 4. **Static guards** (silent-catch CI guard, etc.): the guards live in `.github/workflows/test.yml` — if you added a new `catch(...)` block to backend, scan the diff for `catch (...) {}`/`catch(() => {})` patterns yourself.
 4b. **UI click-through** (any change a person interacts with — a form, a button, an inline editor):
-   - `npm run test:ui` — Playwright drives the real React components in a real browser against the pglite harness. It boots the harness + all three Vite servers itself.
+   - `npm run test:ui` — Playwright drives the real React components in a real browser against the pglite harness. It boots the harness + all three Vite servers itself. **CI runs this as the `ui` job since #612**, so a broken spec now fails the PR instead of rotting — but run it locally anyway: the runner takes several minutes to cold-start, and a failure there costs a round-trip. On failure CI uploads `playwright-report/` + `test-results/` (traces + video) as an artifact.
    - **Write a spec for the specific behaviour you changed**, seeding only the data that behaviour needs (`tests/e2e/helpers/seed.js`) — don't widen the shared fixture. See `tests/e2e/stock-order-line-form.spec.js` as the model.
    - This layer exists because component tests and integration tests both pass while the wiring between them is broken. It has already earned its place: it caught a detached PO line keeping the previous card's name, which would have created a White peony card called "Peony Pink 60cm".
    - **Constraints that will otherwise waste an hour** (all learned the hard way, 2026-07-30):


### PR DESCRIPTION
Closes #612

`.github/workflows/test.yml` ran five jobs and none of them was `npm run test:ui`. That suite is item **4b** of CLAUDE.md's Pre-PR matrix — mandatory before a PR, with nothing verifying anyone ran it.

## Why it matters

It is the layer that has already earned its keep: it caught a detached PO line keeping the previous card's name, which would have created a White peony card called "Peony Pink 60cm". Component tests and integration tests both pass while the wiring between them is broken — that is the entire reason this layer exists.

The cost of not enforcing it showed up while running the matrix for #610: **both `explorer-ui.spec.js` specs had been failing on a clean `master`** for an unknown length of time, because `playwright.config.js` never set `VITE_OWNER_PIN` for the dashboard dev server, so it rendered its "Configuration Error" page and every dashboard spec timed out clicking. A one-line config bug (fixed in #611) that no check could see.

## The job

```yaml
ui:
  name: UI click-through (Playwright)
  timeout-minutes: 15
```

- `npx playwright install --with-deps chromium` — the config defines a single `chromium` project.
- `npm run test:ui`.
- On failure, uploads `playwright-report/` + `test-results/` (traces + video, both already configured) for 7 days. A check nobody can diagnose from the PR is barely better than no check.

**No harness boot step.** `playwright.config.js` owns its own `webServer` block (backend on :3002 + all three Vite servers) and `reuseExistingServer: !process.env.CI` makes it start fresh on CI — so it cannot collide with the `e2e` job's harness. Separate jobs, separate runners.

**Flakes.** `retries: process.env.CI ? 1 : 0` was already set, so a genuinely flaky spec retries once rather than failing the PR.

**Timeout.** 15 minutes. Cold start dominates — pglite replays every migration, then three Vite servers come up; the specs themselves run in about 22 seconds.

## Verification

`CI=1 npx playwright test` on this branch:

```
1 skipped
18 passed (22.4s)
```

The skip is `florist-order-creation.spec.js`, which targets testids that were never added to source. Adding CI does not resurrect it — that instrumentation is #609, and it is worth knowing this job goes green *without* it.

`CLAUDE.md` updated in both places that describe CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)